### PR TITLE
Add slide-svg-illustrator skill for Marp presentations

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -62,10 +62,10 @@
     {
       "name": "slides-skills",
       "source": "./",
-      "description": "Write presentation slides using Marpit-compatible Markdown. Includes slide structure, frontmatter, themes, directives, layout patterns, and authoring best practices.",
+      "description": "Complete Marp/Marpit presentation toolkit: write slides with Marpit-compatible Markdown and create slide-ready SVG illustrations optimized for HTML export. Includes slide structure, frontmatter, themes, directives, layout patterns, SVG authoring with smart sizing, and embedding best practices.",
       "version": "0.0.1",
-      "keywords": ["marpit", "marp", "slides", "presentation", "markdown", "frontmatter", "themes"],
-      "skills": ["./skills/marpit-markdown"],
+      "keywords": ["marpit", "marp", "slides", "presentation", "markdown", "svg", "illustration", "diagrams", "frontmatter", "themes"],
+      "skills": ["./skills/marpit-markdown", "./skills/slide-svg-illustrator"],
       "strict": false
     }
   ]

--- a/skills/slide-svg-illustrator/SKILL.md
+++ b/skills/slide-svg-illustrator/SKILL.md
@@ -1,0 +1,472 @@
+# Marp Slide SVG Illustrator
+
+## Intent
+
+Create clean, editable SVG illustrations that embed reliably in **Marp/Marpit Markdown** and look good in **HTML exports**. Optimize for common slide placement: **centered** or **left/right** aligned blocks, sometimes full-slide backgrounds.
+
+---
+
+## Core Defaults
+
+### Canvas Specifications
+
+- Slide baseline: **16:9, 1920×1080**
+- SVG canvas: `viewBox="0 0 1920 1080"` with explicit `width="1920"` `height="1080"`
+- Safe margins: **120px on each side** (keep key content inside)
+- Grid alignment: **8px**
+
+### Visual Style
+
+- Stroke width: **4px @ 1920×1080**, rounded caps/joins
+- Default palette:
+  - Dark: `#111827`
+  - Mid: `#6B7280`
+  - Light: `#E5E7EB`
+  - Accent: `#2563EB`
+
+### Technical Constraints
+
+- No external dependencies: no remote images, no external CSS, no external font loading
+- HTML-first: optimize for Marp HTML export (GitHub Actions workflow)
+- Self-contained: all styles and assets inline
+
+---
+
+## Output Contract
+
+Every response MUST include:
+
+1. **1–3 bullets**: intent + layout + recommended embed style
+2. **One SVG** in a single code block
+3. **One Marp embedding snippet** (choose the best option from below)
+
+---
+
+## Smart Sizing Logic
+
+**IMPORTANT**: Analyze the current slide's configuration to determine optimal SVG size automatically.
+
+### Decision Flow
+
+#### 1. Detect Slide Context
+
+Look for these indicators in the conversation:
+
+- **Theme mentioned**: `theme: default`, `theme: gaia`, `theme: uncover`
+- **Layout hints**: "centered", "two-column", "left/right split", "full-screen"
+- **Content type**: diagram, icon, background, illustration
+- **Existing slides**: If user shows their slides, match their conventions
+
+#### 2. Choose Size Based on Context
+
+| Context | Recommended Size | Embed Method |
+|---------|------------------|--------------|
+| **Centered diagram** (default) | `w:1200` (1200px) | `![w:1200](assets/...)` |
+| **Centered, compact** | `w:1000` (1000px) | `![w:1000](assets/...)` |
+| **Centered, large emphasis** | `w:1400` (1400px) | `![w:1400](assets/...)` |
+| **Two-column layout** | `width="720"` or `width="760"` | `<img ... width="720">` |
+| **Small icon/badge** | `w:200` to `w:400` | `![w:300](assets/...)` |
+| **Full-slide background** | Native 1920×1080 | `backgroundImage: url(...)` |
+| **Icon set (multiple)** | Individual icons 120×120 | Arrange in grid |
+
+#### 3. Theme-Specific Adjustments
+
+**Default theme**:
+- Clean, technical → prefer `w:1200` for main diagrams
+- Works well with two-column at `width="720"`
+
+**Gaia theme**:
+- Larger, bolder → prefer `w:1400` for impact
+- Two-column at `width="760"` for better balance
+
+**Uncover theme**:
+- Dramatic, full-screen → prefer `w:1400` or background images
+- High contrast, larger strokes (consider 5-6px)
+
+#### 4. Layout-Specific Decisions
+
+**Centered on slide**:
+```markdown
+![w:1200](assets/diagram.svg)
+```
+
+**Left text + right diagram**:
+```markdown
+<div style="display:grid; grid-template-columns: 1fr 720px; gap:48px;">
+  <div>Content...</div>
+  <div><img src="assets/diagram.svg" width="720" /></div>
+</div>
+```
+
+**Right text + left diagram**:
+```markdown
+<div style="display:grid; grid-template-columns: 720px 1fr; gap:48px;">
+  <div><img src="assets/diagram.svg" width="720" /></div>
+  <div>Content...</div>
+</div>
+```
+
+**Full-slide background**:
+```markdown
+---
+backgroundImage: url("assets/bg.svg")
+backgroundSize: cover
+---
+```
+
+### Inference Examples
+
+**User says**: "Create a process flow diagram for my slide"
+→ **Infer**: Centered, main content → use `w:1200`
+
+**User says**: "Make an SVG to go next to my bullet points on the right"
+→ **Infer**: Two-column layout → use `width="720"` with grid layout
+
+**User says**: "Create a background pattern for the title slide"
+→ **Infer**: Full-slide background → use native 1920×1080 + `backgroundImage`
+
+**User says**: "I need 6 icons for feature highlights"
+→ **Infer**: Icon set → create at 120×120 each, arrange in grid
+
+**User mentions**: "I'm using the gaia theme"
+→ **Adjust**: Increase recommended widths by ~15%, consider bolder strokes
+
+### Default When Uncertain
+
+If no context is provided, use these safe defaults:
+
+- **Size**: `w:1200` (1200px wide)
+- **Embed**: `![w:1200](assets/diagram.svg)`
+- **Canvas**: 1920×1080 with safe margins
+- **Theme**: Assume `default` theme
+
+### Multi-Version Output (Optional)
+
+When appropriate, offer both versions:
+
+1. **Standard**: `diagram.svg` (1920×1080 canvas, centered at w:1200)
+2. **Compact**: `diagram-compact.svg` (1200×675 canvas, use at w:1000)
+
+This gives users flexibility without manual scaling.
+
+---
+
+## Embedding Options
+
+### Option A (Default): External SVG File + Image Syntax
+
+Use when the SVG is saved as `assets/<name>.svg`.
+
+**Centered:**
+
+```markdown
+![w:1200](assets/diagram.svg)
+```
+
+**Left/right aligned (HTML-first, reliable):**
+
+```markdown
+<div style="display:flex; gap:40px; align-items:center;">
+  <div style="flex:1;">
+    <!-- your text -->
+    - Point A
+    - Point B
+  </div>
+  <div style="flex:0 0 auto;">
+    <img src="assets/diagram.svg" width="720" />
+  </div>
+</div>
+```
+
+Swap columns to place SVG on the left.
+
+---
+
+### Option B: Two-Column Slide Layout with Consistent Sizing
+
+Use when the slide is structurally "text + figure".
+
+```markdown
+<div style="display:grid; grid-template-columns: 1fr 760px; gap:48px; align-items:center;">
+  <div>
+    ## Title
+    - Bullet 1
+    - Bullet 2
+  </div>
+  <div style="justify-self:center;">
+    <img src="assets/figure.svg" width="760" />
+  </div>
+</div>
+```
+
+---
+
+### Option C: Full-Slide Background SVG
+
+Use when the SVG is designed as a full canvas background.
+
+```markdown
+---
+backgroundImage: url("assets/bg.svg")
+backgroundSize: cover
+---
+
+# Title
+```
+
+---
+
+## SVG Authoring Rules (HTML-First)
+
+### Required Elements
+
+Every SVG MUST include:
+
+```xml
+<svg viewBox="0 0 1920 1080" width="1920" height="1080" xmlns="http://www.w3.org/2000/svg">
+  <title>Descriptive title</title>
+  <desc>Brief description of the illustration</desc>
+
+  <g id="bg"><!-- background elements --></g>
+  <g id="main"><!-- primary content --></g>
+  <g id="labels"><!-- text labels --></g>
+  <g id="decor"><!-- decorative elements --></g>
+</svg>
+```
+
+### Grouping Convention
+
+Use meaningful IDs for layer organization:
+
+- `id="bg"` - Background shapes, fills, base layer
+- `id="main"` - Primary diagram elements, key content
+- `id="labels"` - Text labels, annotations
+- `id="decor"` - Decorative elements, accents, embellishments
+
+### Styling Strategy
+
+Choose one approach per SVG:
+
+1. **Inline attributes** (preferred for simple diagrams):
+   ```xml
+   <rect fill="#111827" stroke="#2563EB" stroke-width="4" />
+   ```
+
+2. **Internal `<style>` block** (for consistent theming):
+   ```xml
+   <style>
+     .primary { fill: #2563EB; }
+     .stroke { stroke: #111827; stroke-width: 4; }
+   </style>
+   ```
+
+### What to Avoid
+
+- `<foreignObject>` - inconsistent rendering across browsers
+- Heavy `filter` chains - especially blur effects
+- External font references - use system font stack or paths
+- Embedded raster images - unless explicitly requested
+
+### Text Strategy
+
+**Default behavior**: Keep text editable *only if asked*.
+
+**If labels are required but editability is not important:**
+- Prefer simple shapes + minimal `<text>` elements
+
+**If exact typography is required:**
+- Convert text to paths
+- Warn user that text is not editable
+
+**If using `<text>`, use system-safe font stack:**
+
+```xml
+<text font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial">
+  Label
+</text>
+```
+
+---
+
+## Create Workflow
+
+When generating new SVG illustrations:
+
+### 1. Infer Constraints
+
+Assume defaults if missing:
+
+- **Placement**: center vs left/right block
+- **Style**: outline / flat / mixed
+- **Palette**: default neutral + 1 accent color
+
+### 2. Pick Embedding Option
+
+- Most cases: **Option A** (external file)
+- Text + figure: **Option B** (grid layout)
+- Full background: **Option C** (background image)
+
+### 3. Layout Design
+
+- Use 8px grid alignment
+- Keep content inside safe margins (120px from edges)
+- Maintain consistent spacing between elements
+
+### 4. Build Layers
+
+Organize content with consistent styling:
+
+- `bg` - Background shapes, fills
+- `main` - Primary diagram elements
+- `labels` - Text annotations
+- `decor` - Decorative accents
+
+Use consistent stroke widths (4px) and border radius values.
+
+### 5. Final Checks
+
+- [ ] No clipping of content outside viewBox
+- [ ] Legible at typical slide viewing size
+- [ ] Consistent alignment and spacing
+- [ ] All paths use 8px grid alignment
+- [ ] Colors follow palette guidelines
+
+---
+
+## Normalize & Optimize Workflow (Existing SVG)
+
+When fixing or optimizing existing SVG files:
+
+### Goal
+
+Ensure consistent embedding in Marp HTML exports.
+
+### Checklist
+
+- [ ] Ensure `viewBox` exists and matches content bounds
+- [ ] Normalize to 1920×1080 canvas for slide illustrations (keep original for icons)
+- [ ] Remove editor metadata (Inkscape/Illustrator) if safe
+- [ ] Flatten styles if needed (avoid reliance on external CSS)
+- [ ] Replace problematic features with simpler primitives
+- [ ] Decide on text: editable `<text>` vs paths
+- [ ] Verify rendering in Marp preview
+
+---
+
+## Pattern Library (Quick Templates)
+
+### Process Flow (3–7 steps)
+
+- Rounded rectangles for steps
+- Arrows with proper spacing
+- Step numbers in circles
+- Consistent gap: 80px between steps
+
+### Timeline
+
+- Horizontal baseline
+- Milestones as circles or markers
+- Labels below timeline
+- Date range above
+
+### Architecture Diagram
+
+- Containers as rounded rectangles
+- Components as smaller boxes inside
+- Connectors with arrow markers
+- Layer separation: 160px
+
+### Comparison (2–3 columns)
+
+- Equal-width columns
+- Consistent iconography at top
+- Bullet points below
+- Visual separators between columns
+
+### KPI Callout
+
+- Large number (72px font or path)
+- Label below (24px)
+- Simple sparkline path if showing trend
+- Optional icon or indicator
+
+---
+
+## Common Widths Reference
+
+Recommended widths for different placements:
+
+- **Centered, full attention**: `w:1200` (1200px)
+- **Centered, compact**: `w:1000` (1000px)
+- **Side-by-side with text**: `width="720"` or `width="760"`
+- **Small icon or badge**: `w:200` to `w:400`
+- **Full-width background**: native 1920px
+
+---
+
+## Trigger Examples
+
+This skill should activate when users request:
+
+- "Make an SVG diagram for a Marp slide, centered at w:1200"
+- "Create an SVG illustration to sit on the right side next to bullets"
+- "Fix this SVG so it scales correctly in Marp HTML"
+- "Generate 6 consistent outline icons for slides"
+- "Create a process flow diagram with 5 steps"
+- "Design an architecture diagram showing 3 layers"
+
+---
+
+## Output Format
+
+Always structure responses like this:
+
+**Intent & Layout:**
+- Brief description of what the SVG shows
+- Recommended placement (centered / left / right)
+- Suggested embed method (Option A/B/C)
+
+**SVG Code:**
+```xml
+<svg viewBox="0 0 1920 1080" width="1920" height="1080" xmlns="http://www.w3.org/2000/svg">
+  <!-- complete SVG here -->
+</svg>
+```
+
+**Marp Embedding:**
+```markdown
+<!-- chosen embedding snippet -->
+```
+
+---
+
+## Quality Standards
+
+All SVG output must meet these criteria:
+
+1. **Accessibility**: Include meaningful `<title>` and `<desc>`
+2. **Maintainability**: Use clear IDs and logical grouping
+3. **Performance**: Minimize path complexity, avoid unnecessary elements
+4. **Consistency**: Follow grid alignment and palette rules
+5. **Compatibility**: Test rendering in Marp HTML output
+
+---
+
+## Advanced: Two-Version Output (Optional)
+
+For maximum flexibility, consider generating two versions:
+
+1. **Full canvas**: `diagram.svg` (1920×1080) - for background use
+2. **Compact**: `diagram-compact.svg` (1200×675) - for centered embedding
+
+This gives users options without manual scaling.
+
+---
+
+## References
+
+See `references/` for:
+- Common diagram patterns with code examples
+- Color palette variations
+- Icon design guidelines
+- Troubleshooting embedding issues

--- a/skills/slide-svg-illustrator/references/color-palettes.md
+++ b/skills/slide-svg-illustrator/references/color-palettes.md
@@ -1,0 +1,289 @@
+# Color Palettes
+
+Curated color schemes for different presentation contexts.
+
+---
+
+## Default Palette (Neutral + Blue)
+
+**Best for**: Technical documentation, professional presentations
+
+```
+Dark:    #111827  (gray-900)
+Mid:     #6B7280  (gray-500)
+Light:   #E5E7EB  (gray-200)
+Accent:  #2563EB  (blue-600)
+Success: #10B981  (green-500)
+Warning: #F59E0B  (amber-500)
+Error:   #EF4444  (red-500)
+```
+
+**Usage:**
+- Dark: Primary text, strokes, borders
+- Mid: Secondary text, inactive elements
+- Light: Backgrounds, fills
+- Accent: Highlights, active states, CTAs
+
+---
+
+## Corporate Professional
+
+**Best for**: Business presentations, formal reports
+
+```
+Primary:   #1E3A8A  (navy)
+Secondary: #0F766E  (teal)
+Neutral:   #374151  (gray-700)
+Light:     #F3F4F6  (gray-100)
+Accent:    #DC2626  (red-600)
+```
+
+**Example:**
+```xml
+<rect fill="#F3F4F6" stroke="#1E3A8A" stroke-width="4"/>
+<text fill="#374151">Label</text>
+```
+
+---
+
+## Creative & Modern
+
+**Best for**: Marketing, creative pitches, modern products
+
+```
+Primary:   #7C3AED  (purple-600)
+Secondary: #EC4899  (pink-500)
+Tertiary:  #F59E0B  (amber-500)
+Dark:      #1F2937  (gray-800)
+Light:     #FEF3C7  (amber-100)
+```
+
+**Example:**
+```xml
+<linearGradient id="gradient1" x1="0%" y1="0%" x2="100%" y2="100%">
+  <stop offset="0%" style="stop-color:#7C3AED"/>
+  <stop offset="100%" style="stop-color:#EC4899"/>
+</linearGradient>
+<rect fill="url(#gradient1)"/>
+```
+
+---
+
+## Minimal Monochrome
+
+**Best for**: Elegant, distraction-free presentations
+
+```
+Black:     #000000
+DarkGray:  #404040
+MidGray:   #808080
+LightGray: #E0E0E0
+White:     #FFFFFF
+```
+
+**Example:**
+```xml
+<rect fill="#FFFFFF" stroke="#000000" stroke-width="4"/>
+<text fill="#404040">Subtle label</text>
+```
+
+---
+
+## Data Visualization
+
+**Best for**: Charts, graphs, multi-category comparisons
+
+```
+Category1: #2563EB  (blue-600)
+Category2: #10B981  (green-500)
+Category3: #F59E0B  (amber-500)
+Category4: #EF4444  (red-500)
+Category5: #8B5CF6  (purple-500)
+Category6: #06B6D4  (cyan-500)
+Neutral:   #6B7280  (gray-500)
+```
+
+**Usage**: Each category gets a distinct color for clarity.
+
+---
+
+## Academic / Scientific
+
+**Best for**: Research presentations, educational content
+
+```
+Primary:   #1E40AF  (blue-800)
+Secondary: #059669  (green-600)
+Neutral:   #374151  (gray-700)
+Light:     #F9FAFB  (gray-50)
+Highlight: #FBBF24  (yellow-400)
+```
+
+---
+
+## Dark Mode
+
+**Best for**: Night presentations, developer content
+
+```
+Background: #0F172A  (slate-900)
+Surface:    #1E293B  (slate-800)
+Primary:    #60A5FA  (blue-400)
+Secondary:  #34D399  (green-400)
+Text:       #F1F5F9  (slate-100)
+Muted:      #64748B  (slate-500)
+```
+
+**Example:**
+```xml
+<svg viewBox="0 0 1920 1080" width="1920" height="1080">
+  <rect width="1920" height="1080" fill="#0F172A"/>
+  <rect x="240" y="320" width="400" height="200" rx="16" fill="#1E293B" stroke="#60A5FA" stroke-width="4"/>
+  <text fill="#F1F5F9">Dark mode text</text>
+</svg>
+```
+
+---
+
+## Pastel Soft
+
+**Best for**: Friendly, approachable content, design presentations
+
+```
+Pink:    #FBCFE8  (pink-200)
+Purple:  #DDD6FE  (purple-200)
+Blue:    #BFDBFE  (blue-200)
+Green:   #BBF7D0  (green-200)
+Yellow:  #FEF08A  (yellow-200)
+Dark:    #374151  (gray-700)
+```
+
+**Example:**
+```xml
+<rect fill="#BFDBFE" stroke="#374151" stroke-width="3"/>
+<text fill="#374151">Soft, friendly label</text>
+```
+
+---
+
+## High Contrast
+
+**Best for**: Accessibility, large venue presentations
+
+```
+Black:    #000000
+White:    #FFFFFF
+Yellow:   #FACC15  (yellow-400)
+Cyan:     #22D3EE  (cyan-400)
+Magenta:  #F472B6  (pink-400)
+```
+
+**Accessibility note**: Ensure text-to-background contrast ratio ≥ 7:1 for AAA compliance.
+
+---
+
+## Brand-Specific Template
+
+When working with brand colors, define them consistently:
+
+```xml
+<svg xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <style>
+      .brand-primary { fill: #CUSTOM1; }
+      .brand-secondary { fill: #CUSTOM2; }
+      .brand-accent { fill: #CUSTOM3; }
+      .brand-text { fill: #CUSTOM4; }
+    </style>
+  </defs>
+
+  <rect class="brand-primary" ... />
+  <text class="brand-text" ... />
+</svg>
+```
+
+---
+
+## Gradient Examples
+
+### Linear Gradient (Blue to Purple)
+
+```xml
+<defs>
+  <linearGradient id="grad1" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#2563EB"/>
+    <stop offset="100%" stop-color="#7C3AED"/>
+  </linearGradient>
+</defs>
+<rect fill="url(#grad1)" />
+```
+
+### Radial Gradient (Spotlight Effect)
+
+```xml
+<defs>
+  <radialGradient id="grad2" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#FFFFFF" stop-opacity="0.8"/>
+    <stop offset="100%" stop-color="#000000" stop-opacity="0.2"/>
+  </radialGradient>
+</defs>
+<rect fill="url(#grad2)" />
+```
+
+---
+
+## Semantic Color Usage
+
+### Status Indicators
+
+```
+Success: #10B981  (green-500)
+Warning: #F59E0B  (amber-500)
+Error:   #EF4444  (red-500)
+Info:    #3B82F6  (blue-500)
+```
+
+### Interactive States
+
+```
+Default:  #6B7280  (gray-500)
+Hover:    #2563EB  (blue-600)
+Active:   #1D4ED8  (blue-700)
+Disabled: #D1D5DB  (gray-300)
+```
+
+---
+
+## Color Selection Guidelines
+
+1. **Limit palette**: 3-5 colors per diagram
+2. **Sufficient contrast**: Text should be legible against background
+3. **Consistent meaning**: Same color = same meaning across all slides
+4. **Accessibility**: Test with color blindness simulators
+5. **Cultural context**: Consider cultural color associations for international audiences
+
+---
+
+## Tools for Palette Generation
+
+- **Coolors.co**: Generate harmonious palettes
+- **Adobe Color**: Extract from images
+- **Tailwind CSS**: Pre-defined, accessible colors
+- **WCAG Contrast Checker**: Verify accessibility
+
+---
+
+## Quick Swaps
+
+To change the default palette to another, replace:
+
+```
+Find:    #2563EB
+Replace: #7C3AED  (for purple)
+
+Find:    #E5E7EB
+Replace: #F3F4F6  (for lighter gray)
+
+Find:    #111827
+Replace: #1F2937  (for softer black)
+```

--- a/skills/slide-svg-illustrator/references/pattern-examples.md
+++ b/skills/slide-svg-illustrator/references/pattern-examples.md
@@ -1,0 +1,338 @@
+# Pattern Examples
+
+Complete SVG examples for common slide diagram types.
+
+---
+
+## Process Flow (5 Steps)
+
+**Use case**: Sequential process, workflow, pipeline
+
+```xml
+<svg viewBox="0 0 1920 1080" width="1920" height="1080" xmlns="http://www.w3.org/2000/svg">
+  <title>5-Step Process Flow</title>
+  <desc>Horizontal process flow with 5 sequential steps</desc>
+
+  <defs>
+    <marker id="arrowhead" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto">
+      <polygon points="0 0, 10 3, 0 6" fill="#111827" />
+    </marker>
+  </defs>
+
+  <g id="main">
+    <!-- Step 1 -->
+    <rect x="120" y="440" width="240" height="200" rx="16" fill="#E5E7EB" stroke="#111827" stroke-width="4"/>
+    <text x="240" y="520" font-family="system-ui" font-size="24" text-anchor="middle" font-weight="bold" fill="#111827">Step 1</text>
+    <text x="240" y="560" font-family="system-ui" font-size="18" text-anchor="middle" fill="#6B7280">Prepare</text>
+
+    <!-- Arrow 1 -->
+    <line x1="360" y1="540" x2="440" y2="540" stroke="#111827" stroke-width="4" marker-end="url(#arrowhead)"/>
+
+    <!-- Step 2 -->
+    <rect x="440" y="440" width="240" height="200" rx="16" fill="#E5E7EB" stroke="#111827" stroke-width="4"/>
+    <text x="560" y="520" font-family="system-ui" font-size="24" text-anchor="middle" font-weight="bold" fill="#111827">Step 2</text>
+    <text x="560" y="560" font-family="system-ui" font-size="18" text-anchor="middle" fill="#6B7280">Process</text>
+
+    <!-- Arrow 2 -->
+    <line x1="680" y1="540" x2="760" y2="540" stroke="#111827" stroke-width="4" marker-end="url(#arrowhead)"/>
+
+    <!-- Step 3 -->
+    <rect x="760" y="440" width="240" height="200" rx="16" fill="#2563EB" stroke="#111827" stroke-width="4"/>
+    <text x="880" y="520" font-family="system-ui" font-size="24" text-anchor="middle" font-weight="bold" fill="white">Step 3</text>
+    <text x="880" y="560" font-family="system-ui" font-size="18" text-anchor="middle" fill="white">Execute</text>
+
+    <!-- Arrow 3 -->
+    <line x1="1000" y1="540" x2="1080" y2="540" stroke="#111827" stroke-width="4" marker-end="url(#arrowhead)"/>
+
+    <!-- Step 4 -->
+    <rect x="1080" y="440" width="240" height="200" rx="16" fill="#E5E7EB" stroke="#111827" stroke-width="4"/>
+    <text x="1200" y="520" font-family="system-ui" font-size="24" text-anchor="middle" font-weight="bold" fill="#111827">Step 4</text>
+    <text x="1200" y="560" font-family="system-ui" font-size="18" text-anchor="middle" fill="#6B7280">Verify</text>
+
+    <!-- Arrow 4 -->
+    <line x1="1320" y1="540" x2="1400" y2="540" stroke="#111827" stroke-width="4" marker-end="url(#arrowhead)"/>
+
+    <!-- Step 5 -->
+    <rect x="1400" y="440" width="240" height="200" rx="16" fill="#E5E7EB" stroke="#111827" stroke-width="4"/>
+    <text x="1520" y="520" font-family="system-ui" font-size="24" text-anchor="middle" font-weight="bold" fill="#111827">Step 5</text>
+    <text x="1520" y="560" font-family="system-ui" font-size="18" text-anchor="middle" fill="#6B7280">Deploy</text>
+  </g>
+</svg>
+```
+
+**Embed in Marp:**
+```markdown
+![w:1400](assets/process-flow.svg)
+```
+
+---
+
+## Timeline (4 Milestones)
+
+**Use case**: Project roadmap, historical events, release schedule
+
+```xml
+<svg viewBox="0 0 1920 1080" width="1920" height="1080" xmlns="http://www.w3.org/2000/svg">
+  <title>Project Timeline</title>
+  <desc>Horizontal timeline with 4 major milestones</desc>
+
+  <g id="main">
+    <!-- Baseline -->
+    <line x1="240" y1="540" x2="1680" y2="540" stroke="#6B7280" stroke-width="4"/>
+
+    <!-- Milestone 1 -->
+    <circle cx="400" cy="540" r="24" fill="#2563EB" stroke="#111827" stroke-width="4"/>
+    <text x="400" y="480" font-family="system-ui" font-size="20" text-anchor="middle" font-weight="bold" fill="#111827">Q1 2024</text>
+    <text x="400" y="620" font-family="system-ui" font-size="18" text-anchor="middle" fill="#6B7280">Planning</text>
+
+    <!-- Milestone 2 -->
+    <circle cx="720" cy="540" r="24" fill="#2563EB" stroke="#111827" stroke-width="4"/>
+    <text x="720" y="480" font-family="system-ui" font-size="20" text-anchor="middle" font-weight="bold" fill="#111827">Q2 2024</text>
+    <text x="720" y="620" font-family="system-ui" font-size="18" text-anchor="middle" fill="#6B7280">Development</text>
+
+    <!-- Milestone 3 -->
+    <circle cx="1040" cy="540" r="24" fill="#2563EB" stroke="#111827" stroke-width="4"/>
+    <text x="1040" y="480" font-family="system-ui" font-size="20" text-anchor="middle" font-weight="bold" fill="#111827">Q3 2024</text>
+    <text x="1040" y="620" font-family="system-ui" font-size="18" text-anchor="middle" fill="#6B7280">Testing</text>
+
+    <!-- Milestone 4 -->
+    <circle cx="1360" cy="540" r="24" fill="#2563EB" stroke="#111827" stroke-width="4"/>
+    <text x="1360" y="480" font-family="system-ui" font-size="20" text-anchor="middle" font-weight="bold" fill="#111827">Q4 2024</text>
+    <text x="1360" y="620" font-family="system-ui" font-size="18" text-anchor="middle" fill="#6B7280">Launch</text>
+  </g>
+</svg>
+```
+
+**Embed in Marp:**
+```markdown
+![w:1200](assets/timeline.svg)
+```
+
+---
+
+## Architecture Diagram (3-Tier)
+
+**Use case**: System architecture, layered design, stack overview
+
+```xml
+<svg viewBox="0 0 1920 1080" width="1920" height="1080" xmlns="http://www.w3.org/2000/svg">
+  <title>3-Tier Architecture</title>
+  <desc>Three-layer architecture diagram with components</desc>
+
+  <g id="main">
+    <!-- Layer 1: Presentation -->
+    <rect x="240" y="200" width="1440" height="200" rx="16" fill="#E5E7EB" stroke="#111827" stroke-width="4"/>
+    <text x="960" y="260" font-family="system-ui" font-size="28" text-anchor="middle" font-weight="bold" fill="#111827">Presentation Layer</text>
+
+    <!-- Components -->
+    <rect x="360" y="300" width="280" height="80" rx="8" fill="white" stroke="#2563EB" stroke-width="4"/>
+    <text x="500" y="350" font-family="system-ui" font-size="20" text-anchor="middle" fill="#111827">React UI</text>
+
+    <rect x="700" y="300" width="280" height="80" rx="8" fill="white" stroke="#2563EB" stroke-width="4"/>
+    <text x="840" y="350" font-family="system-ui" font-size="20" text-anchor="middle" fill="#111827">Mobile App</text>
+
+    <rect x="1040" y="300" width="280" height="80" rx="8" fill="white" stroke="#2563EB" stroke-width="4"/>
+    <text x="1180" y="350" font-family="system-ui" font-size="20" text-anchor="middle" fill="#111827">Admin Panel</text>
+
+    <!-- Layer 2: Business Logic -->
+    <rect x="240" y="440" width="1440" height="200" rx="16" fill="#E5E7EB" stroke="#111827" stroke-width="4"/>
+    <text x="960" y="500" font-family="system-ui" font-size="28" text-anchor="middle" font-weight="bold" fill="#111827">Business Logic Layer</text>
+
+    <!-- Components -->
+    <rect x="480" y="540" width="280" height="80" rx="8" fill="white" stroke="#2563EB" stroke-width="4"/>
+    <text x="620" y="590" font-family="system-ui" font-size="20" text-anchor="middle" fill="#111827">API Gateway</text>
+
+    <rect x="820" y="540" width="280" height="80" rx="8" fill="white" stroke="#2563EB" stroke-width="4"/>
+    <text x="960" y="590" font-family="system-ui" font-size="20" text-anchor="middle" fill="#111827">Services</text>
+
+    <!-- Layer 3: Data -->
+    <rect x="240" y="680" width="1440" height="200" rx="16" fill="#E5E7EB" stroke="#111827" stroke-width="4"/>
+    <text x="960" y="740" font-family="system-ui" font-size="28" text-anchor="middle" font-weight="bold" fill="#111827">Data Layer</text>
+
+    <!-- Components -->
+    <rect x="480" y="780" width="280" height="80" rx="8" fill="white" stroke="#2563EB" stroke-width="4"/>
+    <text x="620" y="830" font-family="system-ui" font-size="20" text-anchor="middle" fill="#111827">PostgreSQL</text>
+
+    <rect x="820" y="780" width="280" height="80" rx="8" fill="white" stroke="#2563EB" stroke-width="4"/>
+    <text x="960" y="830" font-family="system-ui" font-size="20" text-anchor="middle" fill="#111827">Redis Cache</text>
+  </g>
+</svg>
+```
+
+**Embed in Marp:**
+```markdown
+![w:1400](assets/architecture.svg)
+```
+
+---
+
+## Comparison (3 Columns)
+
+**Use case**: Feature comparison, pros/cons, options evaluation
+
+```xml
+<svg viewBox="0 0 1920 1080" width="1920" height="1080" xmlns="http://www.w3.org/2000/svg">
+  <title>3-Option Comparison</title>
+  <desc>Side-by-side comparison of three options</desc>
+
+  <g id="main">
+    <!-- Column 1 -->
+    <rect x="200" y="280" width="440" height="520" rx="16" fill="#E5E7EB" stroke="#111827" stroke-width="4"/>
+    <text x="420" y="360" font-family="system-ui" font-size="32" text-anchor="middle" font-weight="bold" fill="#111827">Option A</text>
+
+    <!-- Icon placeholder -->
+    <circle cx="420" cy="460" r="40" fill="#2563EB" stroke="#111827" stroke-width="4"/>
+
+    <!-- Features -->
+    <text x="240" y="560" font-family="system-ui" font-size="20" fill="#111827">✓ Fast</text>
+    <text x="240" y="600" font-family="system-ui" font-size="20" fill="#111827">✓ Simple</text>
+    <text x="240" y="640" font-family="system-ui" font-size="20" fill="#6B7280">✗ Limited scale</text>
+
+    <!-- Column 2 -->
+    <rect x="680" y="280" width="440" height="520" rx="16" fill="#2563EB" stroke="#111827" stroke-width="4"/>
+    <text x="900" y="360" font-family="system-ui" font-size="32" text-anchor="middle" font-weight="bold" fill="white">Option B</text>
+
+    <!-- Icon placeholder -->
+    <circle cx="900" cy="460" r="40" fill="white" stroke="#111827" stroke-width="4"/>
+
+    <!-- Features -->
+    <text x="720" y="560" font-family="system-ui" font-size="20" fill="white">✓ Balanced</text>
+    <text x="720" y="600" font-family="system-ui" font-size="20" fill="white">✓ Scalable</text>
+    <text x="720" y="640" font-family="system-ui" font-size="20" fill="white">✓ Reliable</text>
+
+    <!-- Recommended badge -->
+    <rect x="820" y="720" width="160" height="40" rx="20" fill="white"/>
+    <text x="900" y="748" font-family="system-ui" font-size="18" text-anchor="middle" font-weight="bold" fill="#2563EB">Recommended</text>
+
+    <!-- Column 3 -->
+    <rect x="1160" y="280" width="440" height="520" rx="16" fill="#E5E7EB" stroke="#111827" stroke-width="4"/>
+    <text x="1380" y="360" font-family="system-ui" font-size="32" text-anchor="middle" font-weight="bold" fill="#111827">Option C</text>
+
+    <!-- Icon placeholder -->
+    <circle cx="1380" cy="460" r="40" fill="#2563EB" stroke="#111827" stroke-width="4"/>
+
+    <!-- Features -->
+    <text x="1200" y="560" font-family="system-ui" font-size="20" fill="#111827">✓ Enterprise</text>
+    <text x="1200" y="600" font-family="system-ui" font-size="20" fill="#111827">✓ Full features</text>
+    <text x="1200" y="640" font-family="system-ui" font-size="20" fill="#6B7280">✗ Complex</text>
+  </g>
+</svg>
+```
+
+**Embed in Marp:**
+```markdown
+![w:1400](assets/comparison.svg)
+```
+
+---
+
+## KPI Dashboard
+
+**Use case**: Metrics, statistics, data visualization
+
+```xml
+<svg viewBox="0 0 1920 1080" width="1920" height="1080" xmlns="http://www.w3.org/2000/svg">
+  <title>KPI Dashboard</title>
+  <desc>Key performance indicators with trend lines</desc>
+
+  <g id="main">
+    <!-- KPI 1 -->
+    <rect x="240" y="320" width="400" height="240" rx="16" fill="#E5E7EB" stroke="#111827" stroke-width="4"/>
+    <text x="440" y="420" font-family="system-ui" font-size="72" text-anchor="middle" font-weight="bold" fill="#2563EB">1.2M</text>
+    <text x="440" y="470" font-family="system-ui" font-size="24" text-anchor="middle" fill="#6B7280">Active Users</text>
+    <text x="440" y="520" font-family="system-ui" font-size="20" text-anchor="middle" fill="#10B981">↑ 15%</text>
+
+    <!-- KPI 2 -->
+    <rect x="680" y="320" width="400" height="240" rx="16" fill="#E5E7EB" stroke="#111827" stroke-width="4"/>
+    <text x="880" y="420" font-family="system-ui" font-size="72" text-anchor="middle" font-weight="bold" fill="#2563EB">$4.5M</text>
+    <text x="880" y="470" font-family="system-ui" font-size="24" text-anchor="middle" fill="#6B7280">Revenue</text>
+    <text x="880" y="520" font-family="system-ui" font-size="20" text-anchor="middle" fill="#10B981">↑ 22%</text>
+
+    <!-- KPI 3 -->
+    <rect x="1120" y="320" width="400" height="240" rx="16" fill="#E5E7EB" stroke="#111827" stroke-width="4"/>
+    <text x="1320" y="420" font-family="system-ui" font-size="72" text-anchor="middle" font-weight="bold" fill="#2563EB">98.5%</text>
+    <text x="1320" y="470" font-family="system-ui" font-size="24" text-anchor="middle" fill="#6B7280">Uptime</text>
+    <text x="1320" y="520" font-family="system-ui" font-size="20" text-anchor="middle" fill="#10B981">↑ 0.3%</text>
+
+    <!-- Simple sparkline for KPI 1 -->
+    <polyline points="280,500 320,480 360,490 400,470 440,460 480,450 520,440 560,430 600,420"
+              fill="none" stroke="#2563EB" stroke-width="3"/>
+  </g>
+</svg>
+```
+
+**Embed in Marp:**
+```markdown
+![w:1200](assets/kpi-dashboard.svg)
+```
+
+---
+
+## Icon Set (6 Icons)
+
+**Use case**: Consistent iconography for feature lists, navigation
+
+```xml
+<svg viewBox="0 0 1920 1080" width="1920" height="1080" xmlns="http://www.w3.org/2000/svg">
+  <title>Icon Set</title>
+  <desc>6 consistent outline icons</desc>
+
+  <g id="main" stroke="#111827" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <!-- Icon 1: Settings -->
+    <g transform="translate(280, 440)">
+      <circle cx="60" cy="60" r="40"/>
+      <circle cx="60" cy="60" r="20" fill="#E5E7EB"/>
+      <line x1="60" y1="0" x2="60" y2="20"/>
+      <line x1="60" y1="100" x2="60" y2="120"/>
+      <line x1="0" y1="60" x2="20" y2="60"/>
+      <line x1="100" y1="60" x2="120" y2="60"/>
+    </g>
+
+    <!-- Icon 2: Users -->
+    <g transform="translate(540, 440)">
+      <circle cx="60" cy="40" r="24"/>
+      <path d="M 20 100 Q 20 60, 60 60 Q 100 60, 100 100" fill="#E5E7EB" stroke="#111827"/>
+    </g>
+
+    <!-- Icon 3: Chart -->
+    <g transform="translate(800, 440)">
+      <rect x="20" y="80" width="20" height="40" fill="#E5E7EB"/>
+      <rect x="50" y="60" width="20" height="60" fill="#E5E7EB"/>
+      <rect x="80" y="40" width="20" height="80" fill="#E5E7EB"/>
+    </g>
+
+    <!-- Icon 4: Lock -->
+    <g transform="translate(1060, 440)">
+      <rect x="30" y="60" width="60" height="60" rx="8" fill="#E5E7EB"/>
+      <path d="M 40 60 L 40 40 A 20 20 0 0 1 80 40 L 80 60"/>
+      <circle cx="60" cy="85" r="8" fill="#111827"/>
+    </g>
+
+    <!-- Icon 5: Lightning -->
+    <g transform="translate(1320, 440)">
+      <path d="M 70 20 L 40 70 L 60 70 L 50 120 L 90 60 L 70 60 Z" fill="#2563EB"/>
+    </g>
+
+    <!-- Icon 6: Check -->
+    <g transform="translate(1580, 440)">
+      <circle cx="60" cy="60" r="40" fill="#10B981" stroke="#111827"/>
+      <polyline points="40,60 55,75 80,45" stroke="white" stroke-width="6"/>
+    </g>
+  </g>
+</svg>
+```
+
+**Embed in Marp:**
+```markdown
+![w:1200](assets/icons.svg)
+```
+
+---
+
+## Tips for Adapting Patterns
+
+1. **Spacing**: Use multiples of 8px for all gaps and margins
+2. **Colors**: Swap accent color `#2563EB` to match your theme
+3. **Text size**: Scale font sizes proportionally if changing canvas size
+4. **Stroke width**: Keep at 4px for 1920×1080, scale proportionally for other sizes
+5. **Safe area**: Keep all content 120px from edges

--- a/skills/slide-svg-illustrator/references/troubleshooting.md
+++ b/skills/slide-svg-illustrator/references/troubleshooting.md
@@ -1,0 +1,470 @@
+# Troubleshooting
+
+Common issues and solutions when embedding SVG in Marp slides.
+
+---
+
+## Issue: SVG Not Rendering
+
+**Symptoms:**
+- Blank space where SVG should appear
+- Broken image icon
+- SVG works locally but not in HTML export
+
+**Causes & Solutions:**
+
+### 1. Incorrect File Path
+
+**Problem:** Path doesn't match actual file location
+
+**Fix:**
+```markdown
+<!-- Wrong -->
+![w:1200](diagram.svg)
+
+<!-- Correct -->
+![w:1200](assets/diagram.svg)
+```
+
+Verify file structure:
+```
+presentation/
+├── slides.md
+└── assets/
+    └── diagram.svg
+```
+
+### 2. Missing `xmlns` Attribute
+
+**Problem:** SVG missing XML namespace declaration
+
+**Fix:**
+```xml
+<!-- Wrong -->
+<svg viewBox="0 0 1920 1080">
+
+<!-- Correct -->
+<svg viewBox="0 0 1920 1080" xmlns="http://www.w3.org/2000/svg">
+```
+
+### 3. External Dependencies
+
+**Problem:** SVG references external resources
+
+**Fix:** Embed all resources inline
+```xml
+<!-- Wrong: external image -->
+<image href="http://example.com/image.png" />
+
+<!-- Correct: data URI or remove -->
+<image href="data:image/png;base64,..." />
+```
+
+---
+
+## Issue: SVG Clipped or Cropped
+
+**Symptoms:**
+- Parts of SVG cut off at edges
+- Content extends beyond visible area
+
+**Causes & Solutions:**
+
+### 1. Content Outside ViewBox
+
+**Problem:** Elements positioned outside viewBox bounds
+
+**Fix:** Ensure all content within 120-1800 range (horizontal) and 120-960 range (vertical)
+
+```xml
+<!-- Check bounds -->
+<rect x="120" y="120" width="1680" height="840" fill="none" stroke="red"/>
+```
+
+### 2. Missing ViewBox
+
+**Problem:** ViewBox not defined or incorrect
+
+**Fix:**
+```xml
+<!-- Wrong -->
+<svg width="1920" height="1080">
+
+<!-- Correct -->
+<svg viewBox="0 0 1920 1080" width="1920" height="1080">
+```
+
+### 3. Transform Issues
+
+**Problem:** Elements transformed outside visible area
+
+**Fix:** Review all `transform` attributes
+```xml
+<!-- Check: does this push content out? -->
+<g transform="translate(2000, 0)">
+```
+
+---
+
+## Issue: Text Not Displaying
+
+**Symptoms:**
+- Missing labels or annotations
+- Font rendering issues
+
+**Causes & Solutions:**
+
+### 1. External Font References
+
+**Problem:** Font not available in export environment
+
+**Fix:** Use system font stack
+```xml
+<!-- Wrong -->
+<text font-family="CustomFont">
+
+<!-- Correct -->
+<text font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial">
+```
+
+### 2. Missing Font Size
+
+**Problem:** Font size not specified, defaults to tiny
+
+**Fix:**
+```xml
+<!-- Add explicit font-size -->
+<text font-size="24" fill="#111827">Label</text>
+```
+
+### 3. Text Color Matches Background
+
+**Problem:** Text invisible due to same color as background
+
+**Fix:** Verify contrast
+```xml
+<rect fill="#FFFFFF"/>
+<text fill="#000000">Visible text</text>
+```
+
+---
+
+## Issue: SVG Too Small or Too Large
+
+**Symptoms:**
+- SVG appears tiny on slide
+- SVG overflows slide bounds
+
+**Causes & Solutions:**
+
+### 1. Wrong Width Specification
+
+**Problem:** Width not appropriate for layout
+
+**Fix:** Adjust based on placement
+
+**Centered:**
+```markdown
+![w:1200](assets/diagram.svg)
+```
+
+**Side-by-side:**
+```markdown
+<img src="assets/diagram.svg" width="720" />
+```
+
+### 2. Missing Width/Height Attributes
+
+**Problem:** Browser can't determine size
+
+**Fix:**
+```xml
+<!-- Wrong -->
+<svg viewBox="0 0 1920 1080">
+
+<!-- Correct -->
+<svg viewBox="0 0 1920 1080" width="1920" height="1080">
+```
+
+---
+
+## Issue: Inconsistent Rendering Across Browsers
+
+**Symptoms:**
+- SVG looks different in Chrome vs Firefox
+- Elements misaligned in HTML export
+
+**Causes & Solutions:**
+
+### 1. Missing Explicit Sizes
+
+**Problem:** Relying on browser defaults
+
+**Fix:** Specify all dimensions explicitly
+```xml
+<rect x="100" y="100" width="200" height="100" />
+<!-- Not: <rect /> with CSS -->
+```
+
+### 2. Using `foreignObject`
+
+**Problem:** `foreignObject` has inconsistent support
+
+**Fix:** Avoid entirely, use native SVG elements
+```xml
+<!-- Avoid -->
+<foreignObject>
+  <div>HTML content</div>
+</foreignObject>
+
+<!-- Use instead -->
+<text>SVG text</text>
+```
+
+---
+
+## Issue: Blurry or Pixelated SVG
+
+**Symptoms:**
+- SVG appears low quality
+- Jagged edges
+
+**Causes & Solutions:**
+
+### 1. Rasterized Elements
+
+**Problem:** SVG contains embedded raster images
+
+**Fix:** Use vector shapes only
+```xml
+<!-- Avoid -->
+<image href="bitmap.png" />
+
+<!-- Prefer -->
+<path d="M..." />
+```
+
+### 2. Browser Scaling Issues
+
+**Problem:** SVG scaled improperly by browser
+
+**Fix:** Ensure viewBox and dimensions match
+```xml
+<svg viewBox="0 0 1920 1080" width="1920" height="1080">
+```
+
+---
+
+## Issue: Colors Not Matching Expectation
+
+**Symptoms:**
+- Colors appear different in export
+- Gradients not rendering
+
+**Causes & Solutions:**
+
+### 1. Missing Color Definitions
+
+**Problem:** Colors not explicitly defined
+
+**Fix:**
+```xml
+<!-- Wrong: relies on defaults -->
+<rect />
+
+<!-- Correct: explicit colors -->
+<rect fill="#E5E7EB" stroke="#111827" />
+```
+
+### 2. Invalid Gradient References
+
+**Problem:** Gradient ID doesn't match
+
+**Fix:**
+```xml
+<defs>
+  <linearGradient id="grad1">...</linearGradient>
+</defs>
+<rect fill="url(#grad1)" />
+<!-- Ensure ID matches -->
+```
+
+---
+
+## Issue: Performance Problems
+
+**Symptoms:**
+- Slide deck loads slowly
+- Browser lags when navigating
+
+**Causes & Solutions:**
+
+### 1. Overly Complex Paths
+
+**Problem:** Too many path points
+
+**Fix:** Simplify paths using tools or manual reduction
+```xml
+<!-- Complex -->
+<path d="M0,0 L1,1 L2,1.5 L3,2 ..." />
+
+<!-- Simplified -->
+<path d="M0,0 L10,10" />
+```
+
+### 2. Too Many Elements
+
+**Problem:** Thousands of individual elements
+
+**Fix:** Group and simplify
+```xml
+<!-- Instead of 100 circles -->
+<circle ... />
+<circle ... />
+
+<!-- Use patterns or combine -->
+<pattern id="dots">...</pattern>
+```
+
+---
+
+## Issue: Alignment Issues
+
+**Symptoms:**
+- Elements not aligned as expected
+- Spacing inconsistent
+
+**Causes & Solutions:**
+
+### 1. Not Using Grid
+
+**Problem:** Arbitrary positioning
+
+**Fix:** Align to 8px grid
+```xml
+<!-- Wrong -->
+<rect x="123" y="456" />
+
+<!-- Correct -->
+<rect x="120" y="456" />
+```
+
+### 2. Inconsistent Spacing
+
+**Problem:** Different gaps between elements
+
+**Fix:** Use consistent spacing units (40px, 80px, 160px)
+
+---
+
+## Issue: Arrows Not Appearing
+
+**Symptoms:**
+- Arrow markers missing from lines
+- Arrowheads not visible
+
+**Causes & Solutions:**
+
+### 1. Missing Marker Definition
+
+**Problem:** Marker not defined in `<defs>`
+
+**Fix:**
+```xml
+<defs>
+  <marker id="arrowhead" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto">
+    <polygon points="0 0, 10 3, 0 6" fill="#111827" />
+  </marker>
+</defs>
+<line x1="100" y1="100" x2="200" y2="100" marker-end="url(#arrowhead)" />
+```
+
+### 2. Incorrect Marker Reference
+
+**Problem:** ID mismatch
+
+**Fix:** Ensure `marker-end="url(#arrowhead)"` matches `id="arrowhead"`
+
+---
+
+## Issue: GitHub Actions Build Fails
+
+**Symptoms:**
+- Marp CLI fails to process SVG
+- Build errors related to assets
+
+**Causes & Solutions:**
+
+### 1. File Not Committed
+
+**Problem:** SVG file not in repository
+
+**Fix:**
+```bash
+git add assets/diagram.svg
+git commit -m "Add SVG diagram"
+git push
+```
+
+### 2. Incorrect Path in CI
+
+**Problem:** Path works locally but not in CI
+
+**Fix:** Use relative paths from markdown file
+```markdown
+![w:1200](./assets/diagram.svg)
+```
+
+---
+
+## Debugging Workflow
+
+1. **Open SVG directly in browser**
+   - Check if SVG renders correctly standalone
+   - Verify viewBox and dimensions
+
+2. **Inspect in Marp preview (VS Code)**
+   - Use Marp extension to preview
+   - Check console for errors
+
+3. **Test in HTML export**
+   ```bash
+   marp slides.md -o output.html
+   ```
+   - Open output.html in browser
+   - Check network tab for failed loads
+
+4. **Validate SVG syntax**
+   - Use online validators
+   - Check XML well-formedness
+
+5. **Simplify progressively**
+   - Remove complex features one by one
+   - Identify problematic element
+
+---
+
+## Quick Fixes Checklist
+
+When SVG isn't working, try:
+
+- [ ] Verify file path is correct
+- [ ] Add `xmlns="http://www.w3.org/2000/svg"`
+- [ ] Ensure viewBox and width/height are set
+- [ ] Remove external dependencies (fonts, images)
+- [ ] Check all content within safe margins (120px from edges)
+- [ ] Use system font stack for text
+- [ ] Validate XML syntax
+- [ ] Test SVG file standalone in browser
+- [ ] Check browser console for errors
+- [ ] Simplify complex filters or effects
+
+---
+
+## Still Having Issues?
+
+1. **Validate SVG**: Use https://validator.w3.org/
+2. **Check Marp docs**: https://marpit.marp.app/
+3. **Simplify**: Start with basic shapes, add complexity gradually
+4. **Test standalone**: Open SVG directly in browser
+5. **Compare working example**: Use pattern examples from this skill


### PR DESCRIPTION
## Summary

- Add new **slide-svg-illustrator** skill to the slides-skills plugin
- Optimized for creating SVG illustrations for Marp/Marpit HTML exports
- Smart sizing logic automatically determines optimal SVG dimensions based on slide context

## Key Features

### Smart Sizing Logic
- Automatically detects slide theme (default/gaia/uncover)
- Infers layout context (centered/two-column/full-screen)
- Recommends optimal embedding method and size

### Comprehensive References

**Pattern Examples:**
- Process flows (3-7 steps)
- Timelines with milestones
- Architecture diagrams (3-tier)
- Comparison layouts (2-3 columns)
- KPI dashboards
- Icon sets

**Color Palettes:**
- 8 curated color schemes
- Context-specific recommendations
- Accessibility guidelines

**Troubleshooting:**
- Common SVG embedding issues
- Browser rendering fixes
- GitHub Actions integration tips

### Technical Standards

- Canvas: 1920×1080 with 120px safe margins
- Grid: 8px alignment
- Stroke: 4px (default), rounded caps/joins
- HTML-first: optimized for Marp HTML export
- No external dependencies

## Changes

- Created `skills/slide-svg-illustrator/SKILL.md` with smart sizing logic
- Added 3 reference documents (patterns, palettes, troubleshooting)
- Updated `slides-skills` plugin description and keywords
- Total: 5 files, 1,572 insertions

## Testing

To test locally:
```bash
/plugin marketplace add .
/plugin install slides-skills@narumi
```

Then try:
- "Create a process flow diagram for my slide"
- "Make an SVG to go next to bullet points on the right"
- "Create 6 icons for feature highlights"

🤖 Generated with [Claude Code](https://claude.com/claude-code)