### PR TITLE
Rename python-modern-tooling skill to python

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "python-skills",
       "source": "./",
       "description": "Modern Python tooling and ORM toolkit: uv-based setup and run rules, quality gates (ruff/ty/pytest), Typer CLI patterns, logging guidance, uv packaging workflows, plus Peewee DatabaseProxy connection/transaction usage and SQLite testing.",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "keywords": [
         "python",
         "uv",
@@ -30,12 +30,11 @@
         "sqlite",
         "cli",
         "quality",
-        "project-setup",
-        "modern-tooling"
+        "project-setup"
       ],
       "skills": [
         "./skills/python-peewee",
-        "./skills/python-modern-tooling",
+        "./skills/python",
         "./skills/python-uv-project-setup",
         "./skills/python-quality-tooling",
         "./skills/python-cli-typer",

--- a/examples/slides/marketplace/slides.md
+++ b/examples/slides/marketplace/slides.md
@@ -78,7 +78,7 @@ Combines project workflow standards with ORM patterns
 
 ## 🎓 python-skills (1/2)
 
-**Python Modern Tooling** (`python-modern-tooling` umbrella)
+**Python** (`python` umbrella)
 
 - Routes requests to focused skills
 - Setup & run rules (uv)
@@ -265,7 +265,7 @@ agent-skills/
 │   ├── python-skills/
 │   └── slide-skills/
 └── skills/
-    ├── python-modern-tooling/
+    ├── python/
     ├── python-uv-project-setup/
     ├── python-quality-tooling/
     ├── python-cli-typer/
@@ -283,7 +283,6 @@ agent-skills/
 
 **Core docs**
 - **[AGENTS.md](../../../AGENTS.md)** - Developer guidelines
-- **[CONSTITUTION.md](../../../CONSTITUTION.md)** - Core principles and constraints
 - **[README.md](../../../README.md)** - Quick start and installation instructions
 
 **Implementation showcases**

--- a/skills/python/SKILL.md
+++ b/skills/python/SKILL.md
@@ -1,13 +1,13 @@
 ---
-name: python-modern-tooling
-description: Use when choosing the right modern Python tooling workflow for a project or script (uv setup, quality tools, CLI, logging, packaging) or when unsure which Python tooling skill applies.
+name: python
+description: Use when working with Python. This is the umbrella entry skill that routes to focused Python skills (uv setup, quality tools, CLI, logging, packaging).
 ---
 
-# Python Modern Tooling
+# Python
 
 ## Overview
 
-Route requests to the narrowest skill that matches the task. Core principle: keep the umbrella lean and delegate details.
+Use this skill whenever the task involves Python, then route requests to the narrowest focused skill. Core principle: keep the umbrella lean and delegate details.
 
 ## Quick Reference
 


### PR DESCRIPTION
## Summary
- rename the umbrella skill from python-modern-tooling to python
- keep it as the Python entry/routing skill
- update marketplace metadata and plugin skill path
- sync marketplace slides to the new name/path and remove stale CONSTITUTION link

## Verification
- prek run -a
- rg -n 'python-modern-tooling|Python Modern Tooling|modern-tooling|CONSTITUTION.md' -S . (no matches)