### PR TITLE
[codex] add stop hook

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/bin/env bash \"$(git rev-parse --show-toplevel)/.codex/hooks/stop-prek-run-a.sh\"",
+            "statusMessage": "Running prek run -a",
+            "timeout": 1800
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/hooks/stop-prek-run-a.sh
+++ b/.codex/hooks/stop-prek-run-a.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+input="$(cat)"
+stop_hook_active=false
+if printf '%s' "$input" | rg -q '"stop_hook_active"[[:space:]]*:[[:space:]]*true'; then
+  stop_hook_active=true
+fi
+
+repo_root="$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)"
+cache_root="${XDG_CACHE_HOME:-/tmp/codex-prek-cache}"
+export XDG_CACHE_HOME="$cache_root"
+export PREK_CACHE_DIR="${PREK_CACHE_DIR:-$cache_root/prek}"
+export PREK_LOG_FILE="${PREK_LOG_FILE:-$cache_root/prek.log}"
+mkdir -p "$PREK_CACHE_DIR"
+mkdir -p "$(dirname "$PREK_LOG_FILE")"
+
+if ! output="$(cd "$repo_root" && prek run -a 2>&1)"; then
+  if [ -n "$output" ]; then
+    printf '%s\n' "$output" >&2
+  fi
+
+  if [ "$stop_hook_active" = true ]; then
+    printf '%s\n' '{"continue":false,"systemMessage":"`prek run -a` failed after the Stop continuation pass."}'
+    exit 0
+  fi
+
+  printf '%s\n' '{"decision":"block","reason":"`prek run -a` failed. Inspect the pre-commit output, fix the issues, then stop again."}'
+  exit 0
+fi
+
+printf '%s\n' '{"continue":false,"systemMessage":"`prek run -a` passed."}'

--- a/.gitignore
+++ b/.gitignore
@@ -212,4 +212,3 @@ __marimo__/
 notes/
 docs/
 vendor/
-.codex


### PR DESCRIPTION
## What changed
- added a Codex Stop hook configuration under `.codex/hooks.json`
- added `.codex/hooks/stop-prek-run-a.sh` to run `prek run -a` on Stop with writable cache paths
- removed `.codex` from `.gitignore` so the hook configuration can be committed

## Why
- this makes Stop run the repository pre-commit suite automatically
- the hook surfaces failing `prek run -a` output and blocks Stop until the issues are fixed

## Impact
- Codex users in this repo get automatic pre-commit validation at Stop time
- the hook avoids common sandbox cache issues by redirecting cache and log paths under `/tmp`

## Validation
- `prek run -a`
