### PR TITLE
[codex] refine python skills

### DIFF
--- a/skills/python-cli-typer/SKILL.md
+++ b/skills/python-cli-typer/SKILL.md
@@ -7,7 +7,14 @@ description: Use when building or structuring Python CLI commands with Typer, in
 
 ## Overview
 
-Use Typer for ergonomic CLI construction. Core principle: keep CLI entry points explicit and testable.
+Use Typer for ergonomic CLI construction. Core principle: keep command wiring thin, explicit, and testable while moving business logic into regular Python functions.
+
+## Use When
+
+- Building a Python CLI with Typer.
+- Adding commands, arguments, options, prompts, or confirmations.
+- Wiring a module entry point or console script.
+- Testing CLI behavior separately from business logic.
 
 ## Install
 
@@ -22,12 +29,18 @@ uv add typer
 | Single command | `@app.command()` |
 | Options | function args with defaults |
 | Multiple commands | multiple `@app.command()` |
+| Module run | `uv run python -m <package>.cli --help` |
+| Script run | `uv run python cli.py --help` |
+| CLI tests | `CliRunner().invoke(app, [...])` |
 
 ## Workflow
 
 - Define a `typer.Typer()` app in `cli.py`.
-- Keep command functions small; move logic into separate modules.
+- Keep command functions small; move business logic into separate modules.
+- Wire either `if __name__ == "__main__": app()` for script/module execution or a project console script in `pyproject.toml`.
 - Run CLI via `uv run python -m <module>` or `uv run python cli.py`.
+- Test command parsing and exit behavior with `typer.testing.CliRunner`.
+- Test business logic directly with normal function tests.
 
 ## Example
 
@@ -50,6 +63,12 @@ Usage:
 uv run python cli.py --help
 uv run python cli.py Alice
 uv run python cli.py Alice --count 3
+```
+
+Module entry point:
+
+```bash
+uv run python -m my_package.cli --help
 ```
 
 Multiple commands:
@@ -78,11 +97,31 @@ if __name__ == "__main__":
     app()
 ```
 
+CLI test:
+
+```python
+from typer.testing import CliRunner
+
+from my_package.cli import app
+
+runner = CliRunner()
+
+
+def test_greet() -> None:
+    result = runner.invoke(app, ["Alice", "--count", "2"])
+
+    assert result.exit_code == 0
+    assert "Hello, Alice!" in result.stdout
+```
+
 ## Common Mistakes
 
 - Putting heavy business logic inside CLI functions.
 - Forgetting to wire `if __name__ == "__main__"` for script entry.
+- Testing only the underlying functions and missing CLI parsing or exit-code behavior.
+- Adding shell parsing manually instead of using Typer arguments and options.
 
 ## Red Flags
 
 - CLI guidance that ignores Typer when Typer is the chosen framework.
+- CLI commands that cannot be run through `uv run`.

--- a/skills/python-logging/SKILL.md
+++ b/skills/python-logging/SKILL.md
@@ -7,7 +7,14 @@ description: Use when choosing or configuring Python logging, especially decidin
 
 ## Overview
 
-Choose the logging system based on project needs. Core principle: stdlib logging for libraries and ecosystem integration, loguru for fast, simple app/CLI logging.
+Choose the logging system based on project boundaries. Core principle: use stdlib logging for reusable libraries and ecosystem integration; use loguru only when an app or CLI owns the whole logging surface.
+
+## Use When
+
+- Choosing between stdlib `logging` and `loguru`.
+- Configuring log levels, handlers, formatters, or structured context.
+- Adding logging to libraries, apps, CLIs, or services.
+- Deciding how logging should interact with ops tooling.
 
 ## Quick Reference
 
@@ -16,16 +23,26 @@ Choose the logging system based on project needs. Core principle: stdlib logging
 | Library or long-lived service | stdlib `logging` |
 | Simple app or CLI | `loguru` |
 | Integrations (Sentry/OTel) | stdlib `logging` |
+| Mixed library + app | stdlib in library; app config at boundary |
 
 ## Decision Rules
 
 Use stdlib `logging` when:
 - Building a reusable library
 - You need handler hierarchies or integration with ops tooling
+- You expect callers to configure logging
 
 Use `loguru` when:
 - You want minimal setup and readable output
 - You are building a small app or CLI
+- You control process startup and logging configuration
+
+## Workflow
+
+1. Decide whether the code is a library, service, CLI, or one-off app.
+2. Keep libraries passive: create `logging.getLogger(__name__)` and do not call `basicConfig()`.
+3. Configure handlers and levels once at the application entry point.
+4. Avoid mixing stdlib logging and loguru unless the app owns the bridge and boundary.
 
 ## Example
 
@@ -42,10 +59,13 @@ logger.info("App started")
 
 - Forcing loguru in a reusable library.
 - Mixing two logging systems without a clear boundary.
+- Calling `basicConfig()` inside imported library modules.
+- Creating handlers repeatedly in functions that run more than once.
 
 ## Red Flags
 
 - Logging recommendations with no rationale for library vs app use.
+- Global logging setup hidden in modules that are imported by tests or other applications.
 
 ## References
 

--- a/skills/python-logging/references/logging.md
+++ b/skills/python-logging/references/logging.md
@@ -1,5 +1,7 @@
 # Logging with Python stdlib
 
+Use stdlib logging for libraries, services, and applications that need standard ecosystem integration. Library modules should create loggers but leave handler and level configuration to the application entry point.
+
 ## Basic Configuration
 
 ```python
@@ -15,6 +17,20 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 logger.info("Application started")
 ```
+
+## Library Pattern
+
+```python
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def load_user(user_id: int) -> None:
+    logger.info("Loading user", extra={"user_id": user_id})
+```
+
+Do not call `logging.basicConfig()` or attach process-wide handlers inside reusable library modules.
 
 ## Loggers and Handlers
 
@@ -40,6 +56,8 @@ file_handler.setFormatter(formatter)
 logger.addHandler(console_handler)
 logger.addHandler(file_handler)
 ```
+
+Configure handlers once at process startup. If setup code can run more than once, guard against duplicate handlers or centralize setup in a single entry point.
 
 ## Structured Context
 

--- a/skills/python-logging/references/loguru.md
+++ b/skills/python-logging/references/loguru.md
@@ -1,5 +1,7 @@
 # Logging with Loguru
 
+Use loguru for small apps and CLIs where the application owns process startup and logging configuration. Avoid forcing loguru into reusable libraries that should let callers configure logging.
+
 ## Installation
 
 ```bash
@@ -32,7 +34,7 @@ logger.remove()
 logger.add(
     sys.stderr,
     format="{time:YYYY-MM-DD HH:mm:ss} | {level: <8} | {message}",
-    level="INFO"
+    level="INFO",
 )
 
 # Add file handler with rotation
@@ -40,9 +42,11 @@ logger.add(
     "logs/app.log",
     rotation="500 MB",
     retention="10 days",
-    level="DEBUG"
+    level="DEBUG",
 )
 ```
+
+Configure loguru once near the CLI or application entry point. Avoid adding sinks from functions that may be called repeatedly.
 
 ## Exception Logging
 
@@ -64,6 +68,6 @@ logger.info(
     "User action",
     user_id=123,
     action="login",
-    ip_address="192.168.1.1"
+    ip_address="192.168.1.1",
 )
 ```

--- a/skills/python-packaging-uv/SKILL.md
+++ b/skills/python-packaging-uv/SKILL.md
@@ -7,7 +7,14 @@ description: Use when building or publishing Python packages with uv, including 
 
 ## Overview
 
-Use uv build and publish commands to produce wheels/sdists and ship to PyPI. Core principle: build, verify, then publish.
+Use uv build and publish commands to produce wheels/sdists and ship to package indexes. Core principle: build from release-ready sources, verify artifacts, test installation, then publish.
+
+## Use When
+
+- Building wheels or source distributions.
+- Preparing release artifacts with uv.
+- Publishing to Test PyPI or PyPI.
+- Verifying package contents or installation behavior before release.
 
 ## Quick Reference
 
@@ -18,18 +25,24 @@ Use uv build and publish commands to produce wheels/sdists and ship to PyPI. Cor
 | Build for release (ignore local path overrides) | `uv build --no-sources` |
 | Publish to PyPI | `uv publish --token $PYPI_TOKEN` |
 | Publish to Test PyPI | `uv publish --publish-url https://test.pypi.org/legacy/ --token $TEST_PYPI_TOKEN` |
+| Inspect wheel contents | `unzip -l dist/<wheel>.whl` |
+| Test wheel install | `uv run --with dist/<wheel>.whl python -c "import <module>"` |
 
 ## Workflow
 
-1. Build artifacts in `dist/`.
-2. Test install from wheel.
-3. Publish to Test PyPI, validate, then publish to PyPI.
+1. Run the repository quality gate before release.
+2. Build artifacts in `dist/` with `uv build --no-sources`.
+3. Inspect wheel and sdist contents.
+4. Test install from the built wheel in a fresh uv-managed invocation.
+5. Publish to Test PyPI for first or risky releases, validate install/import, then publish to PyPI.
 
 ## Example
 
 ```bash
+prek run -a
 uv build --no-sources
-uv pip install dist/my_package-1.0.0-py3-none-any.whl
+unzip -l dist/my_package-1.0.0-py3-none-any.whl
+uv run --with dist/my_package-1.0.0-py3-none-any.whl python -c "import my_package"
 uv publish --publish-url https://test.pypi.org/legacy/ --token $TEST_PYPI_TOKEN
 ```
 
@@ -37,10 +50,13 @@ uv publish --publish-url https://test.pypi.org/legacy/ --token $TEST_PYPI_TOKEN
 
 - Publishing before verifying wheel contents.
 - Skipping Test PyPI for first release.
+- Building release artifacts while local `[tool.uv.sources]` overrides are active.
+- Verifying only the source tree instead of importing from the built wheel.
 
 ## Red Flags
 
 - Packaging guidance that ignores uv build/publish.
+- Publishing commands shown before quality checks and artifact verification.
 
 ## References
 

--- a/skills/python-packaging-uv/references/packaging.md
+++ b/skills/python-packaging-uv/references/packaging.md
@@ -8,7 +8,7 @@
 - [Publishing](#publishing)
 - [Common Issues](#common-issues)
 
-Build and distribute Python packages using uv's built-in build tools.
+Build and distribute Python packages using uv's built-in build tools. Release flow is: run the quality gate, build from release-ready sources, inspect artifacts, test wheel installation, publish to Test PyPI when appropriate, then publish to PyPI.
 
 ## Building Packages
 
@@ -57,19 +57,25 @@ my_package-1.0.0.tar.gz
 
 Before publishing, verify:
 
-**1. Build succeeds:**
+**1. Quality gate passes:**
 ```bash
-uv build --no-sources
+prek run -a
 ```
 
-**2. Test installation from wheel:**
+**2. Build succeeds:**
 ```bash
-uv pip install dist/my_package-1.0.0-py3-none-any.whl
+uv build --no-sources
 ```
 
 **3. Verify package contents:**
 ```bash
 unzip -l dist/my_package-1.0.0-py3-none-any.whl
+tar -tzf dist/my_package-1.0.0.tar.gz
+```
+
+**4. Test installation from wheel and import from the artifact:**
+```bash
+uv run --with dist/my_package-1.0.0-py3-none-any.whl python -c "import my_package"
 ```
 
 ## Publishing
@@ -86,7 +92,7 @@ uv publish --publish-url https://test.pypi.org/legacy/ --token $TEST_PYPI_TOKEN
 
 **Test installation from Test PyPI:**
 ```bash
-uv pip install --index-url https://test.pypi.org/simple/ my-package
+uv run --with my-package --index-url https://test.pypi.org/simple/ python -c "import my_package"
 ```
 
 ## Common Issues
@@ -97,6 +103,7 @@ uv pip install --index-url https://test.pypi.org/simple/ my-package
 **Import errors after installation:**
 - Verify package name matches import name
 - Check `[project]` name and `src/` directory structure
+- Test import from the built wheel, not from the source checkout
 
 **Large package size:**
 - Add `.pyc` and `__pycache__` to `.gitignore`

--- a/skills/python-peewee/SKILL.md
+++ b/skills/python-peewee/SKILL.md
@@ -2,11 +2,39 @@
 name: python-peewee
 description: Use when working with Peewee ORM patterns, especially DatabaseProxy setup, scoped connection/transaction handling, and SQLite-based tests.
 ---
+
 # Python Peewee
 
-Use Peewee with DatabaseProxy and scoped connection/transaction patterns.
+## Overview
 
-## Set up
+Use Peewee with `DatabaseProxy`, scoped connection handling, explicit transactions, and isolated SQLite tests. Core principle: initialize the database at the boundary, then keep models and tests deterministic.
+
+## Use When
+
+- Defining Peewee models or a shared `BaseModel`.
+- Wiring `DatabaseProxy` for app and test databases.
+- Choosing `connection_context()` vs `atomic()`.
+- Writing SQLite-backed fixtures for model tests.
+
+## Quick Reference
+
+| Need | Pattern |
+| --- | --- |
+| Deferred database binding | `DatabaseProxy()` |
+| Model base class | `class BaseModel(Model)` with `Meta.database` |
+| Scoped connection | `with db.connection_context():` |
+| Transactional writes | `with db.atomic():` |
+| SQLite tests | temporary `SqliteDatabase` fixture |
+
+## Workflow
+
+1. Define one `DatabaseProxy` and one `BaseModel` for the model graph.
+2. Initialize the proxy once at the app/test boundary.
+3. Use `connection_context()` to open and close connections for scoped work.
+4. Use `atomic()` around write units that must commit or roll back together.
+5. In tests, bind the proxy to an isolated SQLite database and create/drop tables inside the fixture.
+
+## Setup
 
 ### DatabaseProxy & BaseModel
 
@@ -29,7 +57,7 @@ db = SqliteDatabase("app.db", pragmas={"foreign_keys": 1})
 db_proxy.initialize(db)
 ```
 
-## Use connections and transactions
+## Connections and Transactions
 
 ### Read (no transaction)
 
@@ -58,7 +86,7 @@ with db.connection_context():
 Use `connection_context()` for scoped connections (open/close).
 Use `atomic()` for atomic writes (BEGIN/COMMIT/ROLLBACK).
 
-## Test with SQLite
+## SQLite Test Fixture
 
 ```python
 import pytest
@@ -71,5 +99,29 @@ def test_db(tmp_path):
     with db.connection_context():
         db.create_tables([MyModel])
     yield db
-    db.close()
+    with db.connection_context():
+        db.drop_tables([MyModel])
 ```
+
+Use in function-based pytest tests:
+
+```python
+def test_create_user(test_db):
+    with test_db.atomic():
+        user = User.create(name="Ada")
+
+    assert User.get_by_id(user.id).name == "Ada"
+```
+
+## Common Mistakes
+
+- Querying models before `db_proxy.initialize(db)` has run.
+- Holding one global open connection for the whole process when scoped connections would be clearer.
+- Using `atomic()` as a substitute for opening a connection in code paths that also need explicit connection lifetime.
+- Reusing a persistent app database in tests.
+
+## Red Flags
+
+- Tests that depend on table state from previous tests.
+- Peewee models bound directly to a production database in module import code.
+- Write operations performed without a transaction boundary.

--- a/skills/python-quality-tooling/SKILL.md
+++ b/skills/python-quality-tooling/SKILL.md
@@ -7,7 +7,21 @@ description: Use when configuring or running Python quality tools (ruff, ty, pyt
 
 ## Overview
 
-Use ruff, ty, and pytest consistently through uv. Core principle: one repeatable quality gate across local and CI.
+Use ruff, ty, pytest, coverage, and prek consistently. Core principle: prefer the repository's single quality gate; otherwise run each tool through `uv run`.
+
+## Use When
+
+- Configuring or running lint, format, type checking, tests, coverage, hooks, or CI checks.
+- Deciding between `prek run -a` and individual `uv run` commands.
+- Adding quality tools as development dependencies.
+
+## Workflow
+
+1. Check the repo's existing quality gate first.
+2. If the repo uses prek, run `prek run -a` as the primary pre-merge gate.
+3. If no aggregate gate exists, run focused commands with `uv run`.
+4. Add missing quality tools with `uv add --dev`, not as runtime dependencies.
+5. Keep CI and local commands aligned.
 
 ## Quick Reference
 
@@ -19,20 +33,27 @@ Use ruff, ty, and pytest consistently through uv. Core principle: one repeatable
 | Type check | `uv run ty check` |
 | Test | `uv run pytest` |
 | Coverage | `uv run pytest --cov=src --cov-report=term-missing` |
-| Full gate (prek) | `prek run -a` |
+| Full repo gate (prek) | `prek run -a` |
 | Install git hooks (prek) | `prek install` |
 
-## Workflow
+## Command Priority
 
-- Install tools as dev deps (see `python-uv-project-setup`).
-- Run all checks before commit.
-- Keep CI aligned with local commands.
-- If the repo uses prek, prefer `prek run -a` as the single quality gate.
-- Pytest tests MUST be function-based (no class-based tests or `unittest.TestCase`).
+Use this order:
+
+1. Existing project command documented in the repo.
+2. `prek run -a` when the repo uses prek.
+3. Individual `uv run ruff ...`, `uv run ty check`, and `uv run pytest ...` commands.
+
+Pytest tests MUST be function-based (no class-based tests or `unittest.TestCase`).
 
 ## Example
 
 Pre-merge gate:
+```bash
+prek run -a
+```
+
+Fallback when no aggregate gate exists:
 ```bash
 uv run ruff check --fix
 uv run ruff format

--- a/skills/python-quality-tooling/references/quality.md
+++ b/skills/python-quality-tooling/references/quality.md
@@ -9,9 +9,11 @@
 - [Pre-merge Quality Gate](#pre-merge-quality-gate)
 - [CI Configuration Example](#ci-configuration-example)
 
-Keep quality tools in dev dependencies and run via `uv run` for consistency.
+Keep quality tools in dev dependencies. Prefer the repository's documented aggregate gate; if the repo uses prek, run `prek run -a`. Use individual `uv run` commands when no aggregate gate exists or when narrowing a failure.
 
 ## prek (pre-commit runner)
+
+Use prek as the primary gate when the repository has prek configuration or project instructions call for it. Do not mix `pre-commit` commands into a prek-standardized repo.
 
 **Install (preferred):**
 
@@ -92,26 +94,22 @@ uv run pytest -k "test_user"
 
 ## Pre-merge Quality Gate
 
-Run before committing or in CI:
+Run the project gate first when available:
 
 ```bash
-#!/bin/bash
-set -e
+prek run -a
+```
 
-echo "Running quality checks..."
+If no aggregate gate exists, run the tools directly through uv:
 
-# Format and lint
+```bash
 uv run ruff check --fix
 uv run ruff format
-
-# Type check
 uv run ty check
-
-# Run tests with coverage
 uv run pytest --cov=src --cov-report=term-missing --cov-fail-under=80
-
-echo "All checks passed!"
 ```
+
+Use function-based pytest tests. Avoid class-based `Test*` suites and `unittest.TestCase` unless the repository already requires them.
 
 ## CI Configuration Example
 

--- a/skills/python-uv-project-setup/SKILL.md
+++ b/skills/python-uv-project-setup/SKILL.md
@@ -7,12 +7,31 @@ description: Use when initializing a Python project or script, adding dependenci
 
 ## Overview
 
-Use uv for environments, dependency management, and command execution. Core principle: always install and run through uv, not pip/python directly.
+Use uv for project environments, dependency management, and command execution. Core principle: install, sync, and run through uv so local work matches the project environment.
+
+## Use When
+
+- Initializing a Python project with `pyproject.toml`.
+- Adding, removing, or syncing project dependencies.
+- Running project commands, tests, CLIs, or modules in the managed environment.
+- Fixing missing imports caused by unsynced or missing dependencies.
+
+For standalone scripts with inline metadata or one-off dependencies, use `uv-scripts` instead.
+
+## Workflow
+
+1. Identify whether the file belongs to a project or is a standalone script.
+2. For projects, inspect `pyproject.toml` and use the repo's existing uv layout.
+3. Add runtime dependencies with `uv add`; add test, lint, type, and build tools with `uv add --dev`.
+4. Run commands with `uv run` and sync with `uv sync` when dependencies changed elsewhere.
+5. If the repo has an established quality gate, run it after dependency or command changes.
 
 ## Non-Negotiable Rules
 
 - Install dependencies with `uv add` (never `pip install`).
 - Run commands with `uv run` (never direct `python` or `pytest`).
+- Use `uv add --dev` for development-only tools such as ruff, ty, pytest, pytest-cov, and build/release helpers.
+- Do not introduce a new package manager unless the existing project explicitly requires it.
 
 ## Quick Reference
 
@@ -21,13 +40,21 @@ Use uv for environments, dependency management, and command execution. Core prin
 | Initialize project | `uv init <name>` |
 | Add dependency | `uv add <package>` |
 | Add dev dependency | `uv add --dev <package>` |
+| Remove dependency | `uv remove <package>` |
 | Run Python | `uv run python <file.py>` |
+| Run module | `uv run python -m <module>` |
 | Run pytest | `uv run pytest` |
 | Sync deps | `uv sync` |
 
-## Workflow
+## Project vs. Script Boundary
 
-### Project setup (package)
+- Project work has a `pyproject.toml`, project code, or shared lockfile. Use this skill.
+- Standalone script work is a single file that should carry its own Python/dependency metadata. Use `uv-scripts`.
+- Scripts inside a project may still use project dependencies; run them with `uv run python script.py`.
+
+## Examples
+
+### Project setup
 
 ```bash
 uv init my-project
@@ -36,23 +63,17 @@ uv add loguru typer
 uv add --dev ruff pytest pytest-cov ty
 ```
 
-### Script setup (single file)
-
-For standalone scripts with their own dependencies, use the `uv-scripts` skill.
-For scripts inside a project, install with uv and run via uv:
+### Missing dependency
 
 ```bash
 uv add fastapi
-uv run python script.py
+uv run pytest
 ```
 
-## Example
+### Run project commands
 
-Issue: "Missing fastapi. Tests fail."
-
-Fix:
 ```bash
-uv add fastapi
+uv run python -m my_package
 uv run pytest
 ```
 
@@ -60,6 +81,8 @@ uv run pytest
 
 - Running `pip install` first and only switching to uv after it fails.
 - Running `python` or `pytest` directly instead of `uv run`.
+- Adding pytest, ruff, ty, or coverage tools as runtime dependencies instead of dev dependencies.
+- Treating a self-contained script as a full project when `uv-scripts` would be smaller and clearer.
 
 ## Rationalizations to Reject
 

--- a/skills/python/SKILL.md
+++ b/skills/python/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: python
-description: Use when a task involves Python and you need routing to focused Python skills (uv setup, quality tooling, CLI, logging, or packaging).
+description: Use when a task involves Python and you need routing to focused Python skills (uv setup, scripts, quality tooling, CLI, logging, packaging, or Peewee).
 ---
 
 # Python
 
 ## Overview
 
-Use this skill whenever the task involves Python, then route requests to the narrowest focused skill. Core principle: keep the umbrella lean and delegate details.
+Use this skill whenever the task involves Python, then route to the narrowest focused skill or skills. Core principle: keep this umbrella lean, make routing explicit, and let focused skills carry implementation details.
 
 ## Quick Reference
 
@@ -23,13 +23,23 @@ Use this skill whenever the task involves Python, then route requests to the nar
 
 ## Routing Rules
 
-- If the task mentions install, dependency, run, or missing package: use `python-uv-project-setup`.
-- If the task mentions standalone scripts, inline script metadata, or `uv run --with`: use `uv-scripts`.
-- If the task mentions ruff, ty, pytest, coverage, or CI: use `python-quality-tooling`.
-- If the task mentions CLI, commands, Typer: use `python-cli-typer`.
-- If the task mentions logging, loguru, handlers, formatters: use `python-logging`.
-- If the task mentions packaging, build, publish, dist: use `python-packaging-uv`.
-- If the task mentions Peewee, ORM, DatabaseProxy, or SQLite models: use `python-peewee`.
+- If the task only needs Python routing, stop here after naming the focused skill and why.
+- If the task asks for implementation or commands, continue into the focused skill immediately.
+- For multi-intent tasks, use every focused skill that owns part of the work, in this order:
+  1. Environment and dependency setup: `python-uv-project-setup` or `uv-scripts`.
+  2. Domain/framework implementation: `python-cli-typer`, `python-logging`, or `python-peewee`.
+  3. Validation: `python-quality-tooling`.
+  4. Release: `python-packaging-uv`.
+
+Use these trigger rules:
+
+- Install, dependency, project initialization, missing package, or running project commands: `python-uv-project-setup`.
+- Standalone script, inline script metadata, one-off dependencies, `--with`, or `--no-project`: `uv-scripts`.
+- Ruff, ty, pytest, coverage, CI, hooks, or pre-merge checks: `python-quality-tooling`.
+- CLI commands, Typer, options, arguments, shell entry points, or command tests: `python-cli-typer`.
+- Logging, loguru, handlers, formatters, structured context, or library logging: `python-logging`.
+- Packaging, build, wheel, sdist, dist, Test PyPI, PyPI, or release verification: `python-packaging-uv`.
+- Peewee, ORM models, `DatabaseProxy`, transactions, or SQLite model tests: `python-peewee`.
 
 ## Example
 
@@ -37,10 +47,15 @@ User: "Missing fastapi and tests fail. How should I install it?"
 
 Route to: `python-uv-project-setup` (dependency management and run rules).
 
+User: "Add a Typer command and tests for it."
+
+Route to: `python-cli-typer` for the command structure and `python-quality-tooling` for the test/quality gate.
+
 ## Common Mistakes
 
 - Providing detailed commands here instead of routing to the focused skill.
-- Mixing multiple workflows in one response.
+- Choosing only one focused skill when the task clearly has multiple independent Python concerns.
+- Routing standalone script work to project setup when inline metadata or no-project mode is the better fit.
 
 ## Red Flags
 

--- a/skills/uv-scripts/SKILL.md
+++ b/skills/uv-scripts/SKILL.md
@@ -6,7 +6,25 @@ description: Use when running or authoring standalone Python scripts with uv, es
 # UV Scripts
 
 ## Overview
-Use `uv run` to execute standalone scripts with automatic dependency management. Prefer inline metadata for self-contained scripts and `--no-project` when you are inside a project but do not need project code.
+
+Use `uv run` to execute standalone Python scripts with automatic dependency management. Core principle: prefer inline script metadata for reusable scripts, and use `--no-project` when running an ad hoc script from inside a project without needing project code.
+
+## Use When
+
+- Running or authoring a standalone Python file.
+- Adding one-off dependencies for a single invocation.
+- Embedding dependencies or Python requirements in script metadata.
+- Choosing whether a script should ignore the surrounding project.
+
+For package/project dependency management, use `python-uv-project-setup`.
+
+## Workflow
+
+1. Decide whether the file should use project dependencies, one-off dependencies, or inline metadata.
+2. Use plain `uv run script.py` when no extra dependencies are needed.
+3. Use `uv run --with ...` for disposable one-off dependencies.
+4. Use inline script metadata for reusable or shared standalone scripts.
+5. Use `--no-project` only when running inside a project and the script should ignore project code.
 
 ## Quick Reference
 
@@ -54,8 +72,9 @@ EOF
 ## Project vs. No-Project Mode
 
 - In a project (directory with `pyproject.toml`), `uv run` installs the project first.
-- If the script does not need project code, use `--no-project` to skip installation.
+- If the script does not need project code, use `--no-project` to skip project discovery and installation.
 - The `--no-project` flag must be before the script name.
+- If the script imports project modules, do not use `--no-project`.
 
 ```bash
 uv run --no-project example.py
@@ -65,7 +84,7 @@ If you use inline script metadata, project dependencies are ignored automaticall
 
 ## Running a Script With Dependencies
 
-Use `--with` to add per-invocation dependencies:
+Use `--with` for disposable, per-invocation dependencies:
 
 ```bash
 uv run --with rich example.py
@@ -73,9 +92,11 @@ uv run --with 'rich>12,<13' example.py
 uv run --with rich --with requests example.py
 ```
 
-In a project, these dependencies are added on top of project dependencies. Use `--no-project` to avoid that.
+In a project, these dependencies are added on top of project dependencies. Use `--no-project` when the script should not see the project environment.
 
-## Inline Script Metadata (Recommended)
+Use inline metadata instead of `--with` when the dependency list should live with the script or be reused by others.
+
+## Inline Script Metadata
 
 Initialize inline metadata:
 
@@ -106,6 +127,8 @@ resp = requests.get("https://peps.python.org/api/peps.json")
 data = resp.json()
 pprint([(k, v["title"]) for k, v in data.items()][:10])
 ```
+
+Use inline metadata for scripts that should be reproducible, executable by other users, or kept outside a full project.
 
 Notes:
 - The `dependencies` field must be provided even if empty.
@@ -190,3 +213,9 @@ Dependencies still work, e.g. `uv run --with PyQt5 example_pyqt.pyw`.
 - Placing `--no-project` after the script name.
 - Omitting the `# /// script` metadata block when you want self-contained scripts.
 - Assuming inline metadata uses project dependencies (it ignores them).
+
+## Red Flags
+
+- Advising `pip install` for a script dependency.
+- Adding a `pyproject.toml` only to run a one-file script.
+- Using `--no-project` for a script that imports local package code.


### PR DESCRIPTION
## What changed

- Refined the umbrella Python skill routing rules for focused Python skills.
- Expanded Python-focused skills for uv project setup, standalone scripts, quality tooling, Typer CLIs, logging, packaging, and Peewee.
- Updated related references for quality tooling, logging/loguru, and uv packaging release verification.

## Why

The Python skill set needed clearer routing, more consistent structure, and executable uv-first examples across project, script, quality, CLI, logging, packaging, and Peewee workflows.

## Validation

- `prek run -a` passed.
- Static scans checked for unwanted `pip install`, direct `python`/`pytest`, and pre-commit/prek command drift in the Python-related skill docs.