### PR TITLE
[codex] add git-commit skill

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,0 +1,5 @@
+## GOTCHA
+
+- `skill-creator` 的 `quick_validate.py` 需要 `PyYAML`; 在這個 repo 用 `uv run --with pyyaml python /home/narumi/.codex/skills/.system/skill-creator/scripts/quick_validate.py <skill-dir>` 比直接 `uv run python` 穩定。
+
+## TASTE

--- a/skills/git-commit/SKILL.md
+++ b/skills/git-commit/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: git-commit
+description: Use when inspecting local git changes, drafting or validating commit messages, converting ad hoc messages to Conventional Commits, choosing an appropriate commit type or scope, explaining whether a change is breaking, or creating focused commits that match the actual diff.
+---
+
+# Git Commit
+
+## Overview
+
+Inspect the actual diff before writing the message. Prefer one coherent commit per intent, then map that intent to a Conventional Commits title, optional body, and optional footers.
+
+Read `references/conventional-commits.md` when the type is ambiguous, when footers are needed, or when the change may be breaking.
+
+## Workflow
+
+1. Inspect the working tree first.
+   Start with `git status --short` to see staged, unstaged, and untracked paths. If the user asks for a commit, inspect `git diff --cached` first; inspect `git diff` too when unstaged changes might affect the requested commit.
+2. Define the commit boundary.
+   Group files by one user-visible intent. If the diff mixes unrelated work, recommend splitting it into multiple commits instead of forcing one summary over several intents.
+3. Choose the type from behavior, not file extension.
+   Use `feat` for a new capability, `fix` for a bug fix, and other common lowercase types such as `docs`, `refactor`, `test`, `perf`, `build`, `ci`, `style`, `chore`, or `revert` when they describe the dominant change more accurately.
+4. Add a scope only when it clarifies the change.
+   Keep scopes short, noun-like, and stable, such as `api`, `auth`, `parser`, or `docs`. Omit the scope when it adds little signal.
+5. Write the title in the required format.
+   Use `<type>[optional scope][!]: <description>`. Keep the description short, specific, and grounded in the diff. Prefer imperative phrasing such as `fix(parser): handle empty array input`.
+6. Add body and footers only when they add concrete value.
+   Use the body to explain why the change exists, important constraints, or notable tradeoffs. Add footers after a blank line for trailers such as `Refs: #123` or `Reviewed-by: Name`.
+7. Mark breaking changes explicitly.
+   Use `!` before the colon, a `BREAKING CHANGE:` footer, or both. When the change is breaking, describe the user impact or migration requirement clearly.
+8. Keep the message aligned with the exact commit contents.
+   Do not describe unstaged changes, planned follow-up work, or unrelated cleanup that is not part of the commit.
+
+## Decision Rules
+
+- Prefer `feat` when the diff introduces new behavior that users or integrators can rely on.
+- Prefer `fix` when the diff corrects incorrect behavior, a regression, or an edge-case failure.
+- Prefer `refactor` when behavior should stay the same and the change mainly restructures code.
+- Prefer `docs` when the commit only changes documentation.
+- Prefer multiple commits when a single diff contains more than one independent reason to exist.
+- Prefer no body when the title fully explains the change.
+- Prefer no footer unless a trailer or breaking-change notice is actually needed.
+
+## Commit Execution
+
+- Stage only the paths intended for this commit.
+- If the repo has staged and unstaged changes, ensure the commit message matches only the staged diff.
+- If the user asks for a suggested message instead of an actual commit, return one or more candidate messages grounded in the inspected diff.
+- If the user asks whether an existing message is valid, check the structure, the type choice, and whether the wording matches the actual change.
+
+## Reference
+
+- `references/conventional-commits.md`: format, type guidance, breaking-change rules, footers, and examples.

--- a/skills/git-commit/agents/openai.yaml
+++ b/skills/git-commit/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Git Commit"
+  short_description: "Draft and validate Conventional Commit messages."
+  default_prompt: "Use $git-commit to inspect the current changes, choose a Conventional Commits message, and create a focused git commit."

--- a/skills/git-commit/references/conventional-commits.md
+++ b/skills/git-commit/references/conventional-commits.md
@@ -1,0 +1,110 @@
+# Conventional Commits Reference
+
+## Core Format
+
+Use this structure:
+
+```text
+<type>[optional scope][!]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+Rules:
+
+- Start with a lowercase type such as `feat`, `fix`, `docs`, or `refactor`.
+- Add an optional scope in parentheses when it clarifies which area changed.
+- Place `!` immediately before `:` to mark a breaking change in the title.
+- Put the description immediately after `: `.
+- Separate the body from the title with one blank line.
+- Separate footers from the body with one blank line.
+
+## Type Selection
+
+- `feat`: add a new feature or capability
+- `fix`: patch a bug or incorrect behavior
+- `docs`: change documentation only
+- `refactor`: restructure code without intended behavior change
+- `perf`: improve performance
+- `test`: add or update tests
+- `build`: change build tooling or packaging
+- `ci`: change CI configuration or automation
+- `style`: change formatting without behavior impact
+- `chore`: maintenance work that does not fit the above
+- `revert`: revert an earlier change
+
+If one change honestly fits several types, prefer splitting it into multiple commits.
+
+## Scope Guidance
+
+Use a short noun-like scope only when it adds signal:
+
+- `feat(api): add webhook retry configuration`
+- `fix(parser): reject trailing commas in strict mode`
+
+Avoid broad or unstable scopes such as `misc`, `stuff`, or full file paths unless the repo already standardizes on them.
+
+## Body Guidance
+
+Use the body for context the title cannot carry:
+
+- why the change was needed
+- what constraint or edge case shaped the implementation
+- what tradeoff or follow-up the reader should know
+
+Multi-paragraph bodies are valid when the extra detail matters.
+
+## Footer Guidance
+
+Footers follow git-trailer style. Common examples:
+
+- `Refs: #123`
+- `Reviewed-by: Z`
+- `Co-authored-by: Name <email@example.com>`
+
+`BREAKING CHANGE:` is a special footer token and must be uppercase.
+
+## Breaking Changes
+
+Mark a breaking change with either:
+
+- `!` in the title, such as `feat(api)!: remove v1 session endpoint`
+- a footer, such as `BREAKING CHANGE: session tokens now expire after 15 minutes`
+- or both
+
+Use a `BREAKING CHANGE:` footer when the impact or migration path needs more than the title can say.
+
+## SemVer Mapping
+
+- `fix` maps to a patch release
+- `feat` maps to a minor release
+- any commit with a breaking change maps to a major release
+
+Other types do not imply a version bump unless they include a breaking change.
+
+## Examples
+
+```text
+docs: correct spelling of changelog
+```
+
+```text
+feat(lang): add Polish language
+```
+
+```text
+fix: prevent racing of requests
+
+Introduce a request id and track the latest request so stale responses
+can be ignored safely.
+
+Refs: #123
+```
+
+```text
+feat!: drop support for Node 6
+
+BREAKING CHANGE: use JavaScript features not available in Node 6.
+```


### PR DESCRIPTION
## What changed
- add a new `git-commit` skill for drafting and validating Conventional Commits messages against the actual diff
- add `references/conventional-commits.md` so the skill can load detailed format, footer, and breaking-change guidance only when needed
- add `agents/openai.yaml` metadata for the new skill
- add a repo `MEMORY.md` note documenting the working `quick_validate.py` invocation in this workspace

## Why
This repository did not have a focused skill for commit-message drafting and validation. The new skill gives Codex a repeatable workflow for inspecting git changes, choosing the right Conventional Commit type and scope, and handling bodies, footers, and breaking changes without overloading the main skill file.

## Impact
- contributors can invoke `$git-commit` for commit-message help grounded in the current diff
- future skill work in this repo can reuse the recorded validation gotcha instead of rediscovering the `PyYAML` requirement

## Validation
- `uv run --with pyyaml python /home/narumi/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/git-commit`
- `prek run -a`