### PR TITLE
[codex] add atuin history cleanup skill

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,5 +1,6 @@
 ## GOTCHA
 
 - `skill-creator` 的 `quick_validate.py` 需要 `PyYAML`; 在這個 repo 用 `uv run --with pyyaml python /home/narumi/.codex/skills/.system/skill-creator/scripts/quick_validate.py <skill-dir>` 比直接 `uv run python` 穩定。
+- 這個 sandbox 對 `~/.cache/uv` 可能是唯讀；跑 `uv run --with ...` 類的一次性工具時，先設 `UV_CACHE_DIR=/tmp/uv-cache` 比較穩。
 
 ## TASTE

--- a/skills/atuin-history-cleanup/SKILL.md
+++ b/skills/atuin-history-cleanup/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: atuin-history-cleanup
+description: Use when auditing Atuin shell history for noisy duplicates or high-confidence typo/retry pairs and when preparing safe preview-first cleanup steps without editing the SQLite database directly.
+---
+
+# Atuin History Cleanup
+
+## Overview
+
+Audit first, delete second. Use the bundled script to summarize duplicate pressure and high-confidence typo-like retries, then apply only official Atuin cleanup flows.
+
+Read `references/atuin-cli.md` when you need the exact delete, dedup, or prune behavior.
+
+## Use When
+
+- Reviewing a noisy Atuin `history.db` before removing anything.
+- Estimating how much `atuin history dedup` would remove while still keeping the newest repeated entries.
+- Looking for typo-like retries such as `gti status` followed by `git status`.
+- Rechecking an Atuin cleanup plan without mutating the database directly.
+
+## Guardrails
+
+- Always run `atuin info` and the audit script before any destructive step.
+- Treat duplicate cleanup as global. `atuin history dedup` is not a single-command delete tool.
+- For typo candidates, default to the interactive inspector path so you can confirm the exact row before deleting it.
+- Re-confirm every destructive command immediately before running it.
+- Do not delete rows directly from SQLite.
+- Do not edit Atuin config as part of this skill. `history_filter` and `cwd_filter` tuning is out of scope for v1.
+
+## Workflow
+
+1. Resolve the active database:
+
+```bash
+atuin info
+```
+
+2. Run the audit:
+
+```bash
+uv run python skills/atuin-history-cleanup/scripts/atuin_history_cleanup.py audit
+```
+
+Useful flags:
+
+```bash
+uv run python skills/atuin-history-cleanup/scripts/atuin_history_cleanup.py audit --db-path ~/.local/share/atuin/history.db --dupkeep 3 --before now --typo-window-seconds 300 --max-typos 20
+```
+
+3. Review the `duplicates` section first.
+   Use the reported `atuin history dedup --dry-run ...` command. If the dry run matches expectations, rerun the same command without `--dry-run`.
+
+4. Review the `typos` section second.
+   Start with the suggested `atuin search -i <query>` preview command. In the TUI inspector, use `Ctrl+O`, confirm the exact entry, then `Ctrl+D` to delete that one row. Only use `atuin search --delete ...` when the audit marks the preview query as uniquely scoped to the target.
+
+5. Stop after the cleanup you actually verified. Do not keep expanding the scope.
+
+## What The Audit Does
+
+- Resolves the database path from `atuin info` unless `--db-path` is provided.
+- Opens the SQLite database in read-only mode and inspects only `id`, `timestamp`, `exit`, `command`, `cwd`, `session`, and `hostname`.
+- Groups duplicates by `(command, cwd, hostname)` and reports how many rows exceed `--dupkeep`.
+- Detects typo candidates only when all of these are true:
+  - same session
+  - within the configured window
+  - arguments after the first token are identical
+  - previous command exited non-zero
+  - the first token looks rare
+  - the corrected token is much more common
+  - the token change is a single-edit or adjacent-transposition typo
+- Excludes path- or script-like first tokens from typo suggestions.
+
+## Output Expectations
+
+- `duplicates` gives one global preview/apply pair for `history dedup`.
+- `typos` gives per-row review data: id, time, cwd, original command, suggested correction, reason, and shell-safe preview commands.
+- `--format json` is preferable when another tool needs to post-process the audit.

--- a/skills/atuin-history-cleanup/agents/openai.yaml
+++ b/skills/atuin-history-cleanup/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Atuin History Cleanup"
+  short_description: "Audit and clean noisy Atuin history."
+  default_prompt: "Use $atuin-history-cleanup to find typo-like or overly duplicated Atuin history entries and propose safe cleanup steps."

--- a/skills/atuin-history-cleanup/references/atuin-cli.md
+++ b/skills/atuin-history-cleanup/references/atuin-cli.md
@@ -1,0 +1,24 @@
+# Atuin CLI Notes
+
+## Single-entry delete in the TUI
+
+- Run `atuin search -i <query>` to open the interactive search view.
+- Open the entry inspector with `Ctrl+O`.
+- After confirming the exact row, press `Ctrl+D` to delete that one history item.
+
+## Batch delete after preview
+
+- Start with `atuin search -i <query>` so you can preview what the query matches.
+- If the preview is clearly scoped, rerun it as `atuin search --delete <query>`.
+- Keep the preview and apply commands adjacent so deletion stays review-first.
+
+## Global duplicate cleanup
+
+- Preview with `atuin history dedup --dry-run --before "<before>" --dupkeep <n>`.
+- If the dry run matches expectations, rerun the same command without `--dry-run`.
+- `history dedup` is global across the selected history window, not a single-command delete.
+
+## Retroactive filter cleanup
+
+- Use `atuin history prune` only when you already have `history_filter` or `cwd_filter` rules and need to retroactively remove matching entries.
+- Do not use `history prune` as a general typo or duplicate cleanup substitute.

--- a/skills/atuin-history-cleanup/scripts/atuin_history_cleanup.py
+++ b/skills/atuin-history-cleanup/scripts/atuin_history_cleanup.py
@@ -1,0 +1,735 @@
+#!/usr/bin/env python3
+"""Audit Atuin history for duplicates and typo-like retries."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shlex
+import shutil
+import sqlite3
+import subprocess
+import sys
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote as url_quote
+
+HISTORY_SELECT = """
+SELECT id, timestamp, exit, command, cwd, session, hostname
+FROM history
+"""
+
+RARE_TOKEN_MAX_FREQUENCY = 3
+MIN_OVERLAP_PREFIX_OR_SUFFIX = 2
+TEXT_DUPLICATE_GROUP_LIMIT = 20
+
+
+class AuditError(RuntimeError):
+    """User-facing audit failure."""
+
+
+@dataclass(frozen=True, slots=True)
+class HistoryEntry:
+    """Subset of Atuin history fields used by this audit."""
+
+    id: str
+    timestamp: datetime | None
+    exit_code: int | None
+    command: str
+    cwd: str
+    session: str | None
+    hostname: str | None
+
+
+def shell_quote(value: str) -> str:
+    """Return a shell-safe token."""
+    return shlex.quote(value)
+
+
+def build_shell_command(parts: list[str]) -> str:
+    """Render a list of argv parts as a shell-ready command string."""
+    return " ".join(shell_quote(part) for part in parts)
+
+
+def build_cd_command(cwd: str) -> str | None:
+    """Return a shell-safe cd helper when the cwd looks usable."""
+    if not cwd or cwd == "unknown":
+        return None
+    return f"cd {shell_quote(cwd)}"
+
+
+def parse_cli_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Audit Atuin history for duplicates and typo-like retries."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    audit = subparsers.add_parser(
+        "audit",
+        help="Inspect Atuin history without mutating the database.",
+    )
+    audit.add_argument("--db-path", help="Explicit path to Atuin history.db")
+    audit.add_argument(
+        "--dupkeep",
+        type=int,
+        default=3,
+        help="How many copies dedup should keep per (command, cwd, hostname) group.",
+    )
+    audit.add_argument(
+        "--before",
+        default="now",
+        help="Audit only rows at or before this timestamp. Accepts 'now', ISO-8601, or Unix epoch.",
+    )
+    audit.add_argument(
+        "--typo-window-seconds",
+        type=int,
+        default=300,
+        help="Maximum gap between a failed typo and the corrected retry.",
+    )
+    audit.add_argument(
+        "--max-typos",
+        type=int,
+        default=20,
+        help="Maximum typo candidates to return.",
+    )
+    audit.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format.",
+    )
+    return parser.parse_args(argv)
+
+
+def normalize_epoch_seconds(raw_value: float) -> float:
+    """Normalize seconds, milliseconds, microseconds, or nanoseconds to seconds."""
+    absolute = abs(raw_value)
+    if absolute >= 1_000_000_000_000_000_000:
+        return raw_value / 1_000_000_000
+    if absolute >= 1_000_000_000_000_000:
+        return raw_value / 1_000_000
+    if absolute >= 1_000_000_000_000:
+        return raw_value / 1_000
+    return raw_value
+
+
+def parse_timestamp(value: Any) -> datetime | None:
+    """Parse Atuin timestamps stored as ints, floats, or ISO strings."""
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return datetime.fromtimestamp(normalize_epoch_seconds(float(value)), tz=UTC)
+
+    raw = value.decode() if isinstance(value, bytes) else str(value)
+    raw = raw.strip()
+    if not raw:
+        return None
+
+    if re.fullmatch(r"-?\d+(?:\.\d+)?", raw):
+        return datetime.fromtimestamp(normalize_epoch_seconds(float(raw)), tz=UTC)
+
+    normalized = raw.replace("Z", "+00:00")
+    normalized = re.sub(r"\s+UTC$", "+00:00", normalized)
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def parse_before(value: str) -> datetime:
+    """Parse the audit cutoff timestamp."""
+    if value == "now":
+        return datetime.now(tz=UTC)
+
+    parsed = parse_timestamp(value)
+    if parsed is None:
+        raise AuditError(
+            f"Unsupported --before value: {value!r}. Use 'now', ISO-8601, or Unix epoch."
+        )
+    return parsed
+
+
+def parse_history_db_path(atuin_info_output: str) -> Path:
+    """Best-effort parse of history.db from `atuin info`."""
+    candidates: list[str] = []
+
+    for line in atuin_info_output.splitlines():
+        stripped = line.strip()
+        if not stripped or ":" not in stripped:
+            continue
+        label, value = stripped.split(":", 1)
+        normalized_label = re.sub(r"\s+", " ", label.lower())
+        cleaned_value = value.strip().strip("'\"")
+        if not cleaned_value:
+            continue
+        if "history" in normalized_label and (
+            "db" in normalized_label
+            or "database" in normalized_label
+            or "path" in normalized_label
+        ):
+            candidates.append(cleaned_value)
+        elif cleaned_value.endswith(".db") and "history" in normalized_label:
+            candidates.append(cleaned_value)
+
+    for candidate in candidates:
+        path = Path(candidate).expanduser()
+        if path.suffix == ".db":
+            return path
+
+    fallback_match = re.search(
+        r"(?P<path>(?:~|/)[^\s'\"`]*history\.db)", atuin_info_output
+    )
+    if fallback_match:
+        return Path(fallback_match.group("path")).expanduser()
+
+    raise AuditError("Could not find history.db in `atuin info` output.")
+
+
+def resolve_db_path(explicit_path: str | None) -> Path:
+    """Resolve the SQLite database path from CLI args or `atuin info`."""
+    if explicit_path:
+        path = Path(explicit_path).expanduser()
+    else:
+        if shutil.which("atuin") is None:
+            raise AuditError(
+                "Atuin is not installed or not on PATH. Pass --db-path to audit a specific database."
+            )
+        result = subprocess.run(
+            ["atuin", "info"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            stderr = result.stderr.strip() or "unknown error"
+            raise AuditError(f"`atuin info` failed: {stderr}")
+        path = parse_history_db_path(result.stdout)
+
+    if not path.exists():
+        raise AuditError(f"History database does not exist: {path}")
+    if not path.is_file():
+        raise AuditError(f"History database is not a file: {path}")
+    return path.resolve()
+
+
+def parse_exit_code(value: Any) -> int | None:
+    """Normalize exit code values from SQLite."""
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def load_history_entries(
+    db_path: Path, before_cutoff: datetime
+) -> tuple[list[HistoryEntry], dict[str, int]]:
+    """Load history rows from SQLite in read-only mode."""
+    sqlite_uri = f"file:{url_quote(str(db_path))}?mode=ro"
+    total_rows = 0
+    skipped_unparsed_timestamp = 0
+    excluded_after_before = 0
+    entries: list[HistoryEntry] = []
+
+    try:
+        connection = sqlite3.connect(sqlite_uri, uri=True)
+        connection.row_factory = sqlite3.Row
+    except sqlite3.Error as exc:
+        raise AuditError(f"Failed to open SQLite database: {exc}") from exc
+
+    try:
+        try:
+            rows = connection.execute(HISTORY_SELECT)
+        except sqlite3.Error as exc:
+            raise AuditError(f"Failed to read Atuin history table: {exc}") from exc
+
+        for row in rows:
+            total_rows += 1
+            timestamp = parse_timestamp(row["timestamp"])
+            if timestamp is None:
+                skipped_unparsed_timestamp += 1
+                continue
+            if timestamp > before_cutoff:
+                excluded_after_before += 1
+                continue
+
+            command = str(row["command"] or "").strip()
+            if not command:
+                continue
+
+            entries.append(
+                HistoryEntry(
+                    id=str(row["id"]),
+                    timestamp=timestamp,
+                    exit_code=parse_exit_code(row["exit"]),
+                    command=command,
+                    cwd=str(row["cwd"] or ""),
+                    session=str(row["session"]) if row["session"] else None,
+                    hostname=str(row["hostname"]) if row["hostname"] else None,
+                )
+            )
+    finally:
+        connection.close()
+
+    stats = {
+        "rows_total": total_rows,
+        "rows_analyzed": len(entries),
+        "rows_skipped_unparsed_timestamp": skipped_unparsed_timestamp,
+        "rows_excluded_after_before": excluded_after_before,
+    }
+    return entries, stats
+
+
+def split_command_tokens(command: str) -> list[str] | None:
+    """Split a shell command into tokens."""
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return None
+    return tokens or None
+
+
+def looks_like_path_or_script(token: str) -> bool:
+    """Exclude path-like and script-like command names."""
+    if "/" in token or "\\" in token or "." in token:
+        return True
+    if token.startswith(("~", "./", "../")):
+        return True
+    return bool(re.match(r"^[A-Za-z]:[/\\]", token))
+
+
+def is_adjacent_transposition(left: str, right: str) -> bool:
+    """Return true when the two strings differ only by one adjacent swap."""
+    if len(left) != len(right) or left == right:
+        return False
+    diffs = [
+        index
+        for index, (a_char, b_char) in enumerate(zip(left, right))
+        if a_char != b_char
+    ]
+    if len(diffs) != 2:
+        return False
+    first, second = diffs
+    if second != first + 1:
+        return False
+    return (
+        left[first] == right[second]
+        and left[second] == right[first]
+        and left[:first] == right[:first]
+        and left[second + 1 :] == right[second + 1 :]
+    )
+
+
+def is_one_edit_apart(left: str, right: str) -> bool:
+    """Return true when the strings are one insertion, deletion, or substitution apart."""
+    if left == right:
+        return False
+    left_length = len(left)
+    right_length = len(right)
+    if abs(left_length - right_length) > 1:
+        return False
+
+    if left_length == right_length:
+        differences = sum(1 for a_char, b_char in zip(left, right) if a_char != b_char)
+        return differences == 1
+
+    if left_length > right_length:
+        left, right = right, left
+        left_length, right_length = right_length, left_length
+
+    index_left = 0
+    index_right = 0
+    edits = 0
+    while index_left < left_length and index_right < right_length:
+        if left[index_left] == right[index_right]:
+            index_left += 1
+            index_right += 1
+            continue
+        edits += 1
+        if edits > 1:
+            return False
+        index_right += 1
+    return True
+
+
+def common_prefix_length(left: str, right: str) -> int:
+    """Count shared characters from the start."""
+    count = 0
+    for left_char, right_char in zip(left, right):
+        if left_char != right_char:
+            break
+        count += 1
+    return count
+
+
+def common_suffix_length(left: str, right: str) -> int:
+    """Count shared characters from the end."""
+    count = 0
+    for left_char, right_char in zip(reversed(left), reversed(right)):
+        if left_char != right_char:
+            break
+        count += 1
+    return count
+
+
+def is_high_confidence_typo_token(typo_token: str, corrected_token: str) -> bool:
+    """Return true only for conservative typo-like token changes."""
+    if typo_token == corrected_token:
+        return False
+    if is_adjacent_transposition(typo_token, corrected_token):
+        return True
+    if not is_one_edit_apart(typo_token, corrected_token):
+        return False
+    if max(len(typo_token), len(corrected_token)) < 4:
+        return False
+    return (
+        common_prefix_length(typo_token, corrected_token)
+        >= MIN_OVERLAP_PREFIX_OR_SUFFIX
+        or common_suffix_length(typo_token, corrected_token)
+        >= MIN_OVERLAP_PREFIX_OR_SUFFIX
+    )
+
+
+def build_dedup_command(before_value: str, dupkeep: int, dry_run: bool) -> str:
+    """Build the suggested Atuin dedup command."""
+    parts = ["atuin", "history", "dedup"]
+    if dry_run:
+        parts.append("--dry-run")
+    parts.extend(["--before", before_value, "--dupkeep", str(dupkeep)])
+    return build_shell_command(parts)
+
+
+def analyze_duplicates(
+    entries: list[HistoryEntry], before_value: str, dupkeep: int
+) -> dict[str, Any]:
+    """Group duplicates by (command, cwd, hostname)."""
+    grouped: dict[tuple[str, str, str | None], list[HistoryEntry]] = defaultdict(list)
+    for entry in entries:
+        grouped[(entry.command, entry.cwd, entry.hostname)].append(entry)
+
+    groups: list[dict[str, Any]] = []
+    for (command, cwd, hostname), group_entries in grouped.items():
+        count = len(group_entries)
+        if count <= dupkeep:
+            continue
+        latest_timestamp = max(
+            entry.timestamp for entry in group_entries if entry.timestamp is not None
+        )
+        groups.append(
+            {
+                "command": command,
+                "cwd": cwd,
+                "hostname": hostname,
+                "count": count,
+                "deletable_count": count - dupkeep,
+                "latest_timestamp": latest_timestamp.isoformat(),
+            }
+        )
+
+    groups.sort(
+        key=lambda item: (
+            item["deletable_count"],
+            item["count"],
+            item["latest_timestamp"],
+            item["command"],
+        ),
+        reverse=True,
+    )
+
+    return {
+        "dupkeep": dupkeep,
+        "group_count": len(groups),
+        "deletable_count": sum(group["deletable_count"] for group in groups),
+        "preview_command": build_dedup_command(before_value, dupkeep, dry_run=True),
+        "apply_command": build_dedup_command(before_value, dupkeep, dry_run=False),
+        "groups": groups,
+    }
+
+
+def count_preview_matches(entries: list[HistoryEntry], query: str) -> int:
+    """Approximate how many local rows the preview query would hit."""
+    return sum(1 for entry in entries if query in entry.command)
+
+
+def analyze_typos(
+    entries: list[HistoryEntry],
+    typo_window_seconds: int,
+    max_typos: int,
+) -> dict[str, Any]:
+    """Find conservative typo-like retry pairs."""
+    tokenized_commands: dict[str, list[str]] = {}
+    first_token_frequency: Counter[str] = Counter()
+
+    for entry in entries:
+        tokens = split_command_tokens(entry.command)
+        if not tokens:
+            continue
+        tokenized_commands[entry.id] = tokens
+        first_token_frequency[tokens[0]] += 1
+
+    by_session: dict[str, list[HistoryEntry]] = defaultdict(list)
+    for entry in entries:
+        if entry.session:
+            by_session[entry.session].append(entry)
+
+    candidates: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+
+    for session_entries in by_session.values():
+        session_entries.sort(
+            key=lambda entry: (
+                entry.timestamp or datetime.min.replace(tzinfo=UTC),
+                entry.id,
+            )
+        )
+        for previous, current in zip(session_entries, session_entries[1:]):
+            if previous.id in seen_ids:
+                continue
+            if previous.timestamp is None or current.timestamp is None:
+                continue
+
+            delta_seconds = int(
+                (current.timestamp - previous.timestamp).total_seconds()
+            )
+            if delta_seconds < 0 or delta_seconds > typo_window_seconds:
+                continue
+            if previous.exit_code in (None, 0):
+                continue
+
+            previous_tokens = tokenized_commands.get(previous.id)
+            current_tokens = tokenized_commands.get(current.id)
+            if not previous_tokens or not current_tokens:
+                continue
+            if len(previous_tokens) != len(current_tokens):
+                continue
+            if previous_tokens[1:] != current_tokens[1:]:
+                continue
+
+            typo_token = previous_tokens[0]
+            corrected_token = current_tokens[0]
+            if looks_like_path_or_script(typo_token) or looks_like_path_or_script(
+                corrected_token
+            ):
+                continue
+
+            typo_frequency = first_token_frequency[typo_token]
+            corrected_frequency = first_token_frequency[corrected_token]
+            if typo_frequency == 0 or typo_frequency > RARE_TOKEN_MAX_FREQUENCY:
+                continue
+            if corrected_frequency < typo_frequency * 5:
+                continue
+            if not is_high_confidence_typo_token(typo_token, corrected_token):
+                continue
+
+            query = previous.command
+            preview_match_count = count_preview_matches(entries, query)
+            unique_preview = preview_match_count == 1
+            reason = "; ".join(
+                [
+                    f"same session within {delta_seconds}s",
+                    f"previous exit {previous.exit_code}",
+                    "arguments unchanged after the command name",
+                    f"token frequency {corrected_token}={corrected_frequency} vs {typo_token}={typo_frequency}",
+                ]
+            )
+
+            candidates.append(
+                {
+                    "id": previous.id,
+                    "timestamp": previous.timestamp.isoformat(),
+                    "cwd": previous.cwd,
+                    "cwd_shell_quoted": shell_quote(previous.cwd),
+                    "cd_command": build_cd_command(previous.cwd),
+                    "original_command": previous.command,
+                    "suggested_command": current.command,
+                    "reason": reason,
+                    "preview_query": query,
+                    "preview_query_shell_quoted": shell_quote(query),
+                    "preview_match_count": preview_match_count,
+                    "preview_command": build_shell_command(
+                        ["atuin", "search", "-i", query]
+                    ),
+                    "delete_command": (
+                        build_shell_command(["atuin", "search", "--delete", query])
+                        if unique_preview
+                        else None
+                    ),
+                    "unique_preview": unique_preview,
+                    "time_delta_seconds": delta_seconds,
+                    "previous_exit_code": previous.exit_code,
+                    "session": previous.session,
+                    "hostname": previous.hostname,
+                    "typo_token": typo_token,
+                    "corrected_token": corrected_token,
+                    "typo_token_frequency": typo_frequency,
+                    "corrected_token_frequency": corrected_frequency,
+                }
+            )
+            seen_ids.add(previous.id)
+
+    candidates.sort(
+        key=lambda item: (item["timestamp"], item["id"]),
+        reverse=True,
+    )
+
+    return {
+        "window_seconds": typo_window_seconds,
+        "candidate_count": len(candidates),
+        "returned_count": min(len(candidates), max_typos),
+        "candidates": candidates[:max_typos],
+    }
+
+
+def audit_history(
+    db_path: str | Path | None,
+    *,
+    dupkeep: int,
+    before: str,
+    typo_window_seconds: int,
+    max_typos: int,
+) -> dict[str, Any]:
+    """Run the audit and return a structured report."""
+    if dupkeep < 1:
+        raise AuditError("--dupkeep must be at least 1.")
+    if typo_window_seconds < 1:
+        raise AuditError("--typo-window-seconds must be at least 1.")
+    if max_typos < 1:
+        raise AuditError("--max-typos must be at least 1.")
+
+    before_cutoff = parse_before(before)
+    resolved_db_path = resolve_db_path(str(db_path) if db_path is not None else None)
+    entries, stats = load_history_entries(resolved_db_path, before_cutoff)
+
+    report = {
+        "db_path": str(resolved_db_path),
+        "scope": {
+            "before": before,
+            "before_iso": before_cutoff.isoformat(),
+            "dupkeep": dupkeep,
+            "typo_window_seconds": typo_window_seconds,
+            "max_typos": max_typos,
+        },
+        "stats": stats,
+        "duplicates": analyze_duplicates(entries, before, dupkeep),
+        "typos": analyze_typos(entries, typo_window_seconds, max_typos),
+    }
+    return report
+
+
+def format_duplicates_section(duplicates: dict[str, Any]) -> list[str]:
+    """Render the duplicate summary for text output."""
+    lines = [
+        "Duplicates",
+        f"- Groups over dupkeep={duplicates['dupkeep']}: {duplicates['group_count']}",
+        f"- Potential removals: {duplicates['deletable_count']}",
+        f"- Preview: {duplicates['preview_command']}",
+        f"- Apply: {duplicates['apply_command']}",
+    ]
+
+    groups: list[dict[str, Any]] = duplicates["groups"]
+    if not groups:
+        lines.append("- No duplicate groups exceed the current threshold.")
+        return lines
+
+    visible_groups = groups[:TEXT_DUPLICATE_GROUP_LIMIT]
+    lines.append(f"- Matching groups (top {len(visible_groups)} by removable count):")
+    for group in visible_groups:
+        lines.append(
+            "  "
+            + f"{group['count']} copies ({group['deletable_count']} removable) | "
+            + f"host={group['hostname'] or '-'} | cwd={group['cwd'] or '-'} | "
+            + f"command={group['command']}"
+        )
+    if len(groups) > len(visible_groups):
+        omitted = len(groups) - len(visible_groups)
+        lines.append(f"  ... {omitted} more groups omitted from text output")
+    return lines
+
+
+def format_typos_section(typos: dict[str, Any]) -> list[str]:
+    """Render the typo summary for text output."""
+    lines = [
+        "Typos",
+        f"- Candidates shown: {typos['returned_count']} of {typos['candidate_count']}",
+        f"- Window: {typos['window_seconds']}s",
+    ]
+
+    candidates: list[dict[str, Any]] = typos["candidates"]
+    if not candidates:
+        lines.append("- No high-confidence typo candidates found.")
+        return lines
+
+    for index, candidate in enumerate(candidates, start=1):
+        lines.extend(
+            [
+                f"{index}. id={candidate['id']} @ {candidate['timestamp']}",
+                f"   cwd: {candidate['cwd']}",
+                f"   original: {candidate['original_command']}",
+                f"   suggested: {candidate['suggested_command']}",
+                f"   reason: {candidate['reason']}",
+                f"   preview: {candidate['preview_command']}",
+                "   inspector: run preview, press Ctrl+O, confirm the entry, then press Ctrl+D",
+            ]
+        )
+        if candidate["cd_command"]:
+            lines.insert(-2, f"   restore cwd: {candidate['cd_command']}")
+        if candidate["delete_command"]:
+            lines.append(
+                f"   apply: {candidate['delete_command']}  # only after the preview shows exactly one target"
+            )
+    return lines
+
+
+def render_text_report(report: dict[str, Any]) -> str:
+    """Render the audit as plain text."""
+    stats = report["stats"]
+    lines = [
+        "Atuin history audit",
+        f"DB: {report['db_path']}",
+        f"Rows analyzed: {stats['rows_analyzed']} of {stats['rows_total']} total",
+        f"Skipped unparsed timestamps: {stats['rows_skipped_unparsed_timestamp']}",
+        f"Excluded after cutoff: {stats['rows_excluded_after_before']}",
+        "",
+    ]
+    lines.extend(format_duplicates_section(report["duplicates"]))
+    lines.append("")
+    lines.extend(format_typos_section(report["typos"]))
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint."""
+    args = parse_cli_args(argv)
+    if args.command != "audit":
+        raise AuditError(f"Unsupported command: {args.command}")
+
+    try:
+        report = audit_history(
+            args.db_path,
+            dupkeep=args.dupkeep,
+            before=args.before,
+            typo_window_seconds=args.typo_window_seconds,
+            max_typos=args.max_typos,
+        )
+    except AuditError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    if args.format == "json":
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(render_text_report(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_atuin_history_cleanup.py
+++ b/tests/test_atuin_history_cleanup.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "skills"
+    / "atuin-history-cleanup"
+    / "scripts"
+    / "atuin_history_cleanup.py"
+)
+
+SPEC = importlib.util.spec_from_file_location(
+    "atuin_history_cleanup_script", SCRIPT_PATH
+)
+assert SPEC is not None
+assert SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def iso_at(offset_seconds: int) -> str:
+    base = datetime(2026, 4, 1, 8, 0, 0, tzinfo=UTC)
+    return (base + timedelta(seconds=offset_seconds)).isoformat()
+
+
+def row(
+    row_id: str,
+    offset_seconds: int,
+    exit_code: int,
+    command: str,
+    cwd: str = "/repo",
+    session: str = "session-1",
+    hostname: str = "host-1",
+) -> tuple[str, str, int, str, str, str, str]:
+    return (
+        row_id,
+        iso_at(offset_seconds),
+        exit_code,
+        command,
+        cwd,
+        session,
+        hostname,
+    )
+
+
+def write_history_db(
+    tmp_path: Path,
+    rows: list[tuple[str, str, int, str, str, str, str]],
+) -> Path:
+    db_path = tmp_path / "history.db"
+    connection = sqlite3.connect(db_path)
+    try:
+        connection.execute(
+            """
+            CREATE TABLE history (
+                id TEXT PRIMARY KEY,
+                timestamp TEXT NOT NULL,
+                exit INTEGER,
+                command TEXT NOT NULL,
+                cwd TEXT NOT NULL,
+                session TEXT,
+                hostname TEXT
+            )
+            """
+        )
+        connection.executemany(
+            """
+            INSERT INTO history (id, timestamp, exit, command, cwd, session, hostname)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            rows,
+        )
+        connection.commit()
+    finally:
+        connection.close()
+    return db_path
+
+
+def run_audit(db_path: Path, **overrides: object) -> dict[str, Any]:
+    kwargs: dict[str, object] = {
+        "dupkeep": 3,
+        "before": "now",
+        "typo_window_seconds": 300,
+        "max_typos": 20,
+    }
+    kwargs.update(overrides)
+    return MODULE.audit_history(db_path, **kwargs)
+
+
+def test_duplicate_groups_report_global_dedup_preview(tmp_path: Path) -> None:
+    db_path = write_history_db(
+        tmp_path,
+        [
+            row("dup-1", 0, 0, "git status"),
+            row("dup-2", 30, 0, "git status"),
+            row("dup-3", 60, 0, "git status"),
+            row("dup-4", 90, 0, "git status"),
+            row("dup-5", 120, 0, "git status"),
+            row("other-1", 150, 0, "git pull"),
+        ],
+    )
+
+    report = run_audit(db_path)
+
+    duplicates = report["duplicates"]
+    assert duplicates["group_count"] == 1
+    assert duplicates["deletable_count"] == 2
+    assert duplicates["groups"][0]["command"] == "git status"
+    assert (
+        duplicates["preview_command"]
+        == "atuin history dedup --dry-run --before now --dupkeep 3"
+    )
+    assert duplicates["apply_command"] == "atuin history dedup --before now --dupkeep 3"
+
+
+def test_typo_retry_candidate_is_detected(tmp_path: Path) -> None:
+    db_path = write_history_db(
+        tmp_path,
+        [
+            row("git-1", 0, 0, "git branch", session="freq-1"),
+            row("git-2", 30, 0, "git status", session="freq-2"),
+            row("git-3", 60, 0, "git add .", session="freq-3"),
+            row("git-4", 90, 0, "git diff", session="freq-4"),
+            row("git-5", 120, 0, "git log --oneline", session="freq-5"),
+            row("git-6", 150, 0, "git fetch", session="freq-6"),
+            row("typo-1", 300, 127, "gti status", session="repair"),
+            row("typo-2", 320, 0, "git status", session="repair"),
+        ],
+    )
+
+    report = run_audit(db_path)
+
+    typos = report["typos"]
+    assert typos["candidate_count"] == 1
+    candidate = typos["candidates"][0]
+    assert candidate["original_command"] == "gti status"
+    assert candidate["suggested_command"] == "git status"
+    assert candidate["time_delta_seconds"] == 20
+    assert candidate["delete_command"] == "atuin search --delete 'gti status'"
+    assert "previous exit 127" in candidate["reason"]
+
+
+def test_non_typo_tool_switch_is_not_reported(tmp_path: Path) -> None:
+    db_path = write_history_db(
+        tmp_path,
+        [
+            row("eza-1", 0, 0, "eza .", session="freq-1"),
+            row("eza-2", 30, 0, "eza -la", session="freq-2"),
+            row("eza-3", 60, 0, "eza src", session="freq-3"),
+            row("eza-4", 90, 0, "eza docs", session="freq-4"),
+            row("eza-5", 120, 0, "eza tests", session="freq-5"),
+            row("eza-6", 150, 0, "eza .git", session="freq-6"),
+            row("switch-1", 300, 1, "exa .", session="repair"),
+            row("switch-2", 315, 0, "eza .", session="repair"),
+        ],
+    )
+
+    report = run_audit(db_path)
+
+    assert report["typos"]["candidate_count"] == 0
+    assert report["typos"]["candidates"] == []
+
+
+def test_path_like_tokens_are_excluded(tmp_path: Path) -> None:
+    db_path = write_history_db(
+        tmp_path,
+        [
+            row("script-1", 0, 0, "./build.sh release", session="freq-1"),
+            row("script-2", 30, 0, "./build.sh test", session="freq-2"),
+            row("script-3", 60, 0, "./build.sh lint", session="freq-3"),
+            row("script-4", 90, 0, "./build.sh docs", session="freq-4"),
+            row("script-5", 120, 0, "./build.sh clean", session="freq-5"),
+            row("script-6", 150, 0, "./build.sh package", session="freq-6"),
+            row("repair-1", 300, 1, "./buid.sh release", session="repair"),
+            row("repair-2", 320, 0, "./build.sh release", session="repair"),
+        ],
+    )
+
+    report = run_audit(db_path)
+
+    assert report["typos"]["candidate_count"] == 0
+    assert report["typos"]["candidates"] == []
+
+
+def test_shell_quoting_is_preserved_for_cwd_and_query(tmp_path: Path) -> None:
+    weird_cwd = "/tmp/My Project/(draft)[$HOME]"
+    db_path = write_history_db(
+        tmp_path,
+        [
+            row("git-1", 0, 0, "git branch", cwd=weird_cwd, session="freq-1"),
+            row("git-2", 30, 0, "git status", cwd=weird_cwd, session="freq-2"),
+            row("git-3", 60, 0, "git add .", cwd=weird_cwd, session="freq-3"),
+            row("git-4", 90, 0, "git diff", cwd=weird_cwd, session="freq-4"),
+            row("git-5", 120, 0, "git log --oneline", cwd=weird_cwd, session="freq-5"),
+            row("git-6", 150, 0, "git fetch", cwd=weird_cwd, session="freq-6"),
+            row(
+                "quote-1",
+                300,
+                1,
+                "gti commit --amend --no-edit",
+                cwd=weird_cwd,
+                session="repair",
+            ),
+            row(
+                "quote-2",
+                315,
+                0,
+                "git commit --amend --no-edit",
+                cwd=weird_cwd,
+                session="repair",
+            ),
+        ],
+    )
+
+    report = run_audit(db_path)
+    candidate = report["typos"]["candidates"][0]
+
+    assert candidate["cwd_shell_quoted"] == "'/tmp/My Project/(draft)[$HOME]'"
+    assert candidate["cd_command"] == "cd '/tmp/My Project/(draft)[$HOME]'"
+    assert (
+        candidate["preview_command"] == "atuin search -i 'gti commit --amend --no-edit'"
+    )
+    assert (
+        candidate["delete_command"]
+        == "atuin search --delete 'gti commit --amend --no-edit'"
+    )


### PR DESCRIPTION
## What changed

- added a new `atuin-history-cleanup` skill with a preview-first workflow for duplicate and typo-like Atuin history cleanup
- added `references/atuin-cli.md` for the supported Atuin delete, dedup, and prune flows
- added `scripts/atuin_history_cleanup.py` to audit Atuin history in read-only mode and emit duplicate and typo cleanup guidance
- added fixture-based smoke tests covering dedup reporting, typo detection, false-positive avoidance, path/script exclusion, and shell quoting
- recorded the `UV_CACHE_DIR=/tmp/uv-cache` sandbox gotcha in `MEMORY.md`

## Why

This repo did not yet have a reusable skill for safely auditing noisy Atuin history. The new skill keeps destructive actions behind explicit preview and confirmation, avoids direct SQLite mutation, and standardizes the workflow around official Atuin commands.

## Impact

- Codex can now guide users through Atuin history cleanup with a bounded, repeatable workflow
- duplicate cleanup is framed as a global `atuin history dedup` operation instead of an unsafe per-row shortcut
- typo cleanup remains conservative and review-first, with TUI inspector guidance as the default delete path

## Validation

- `uv run --with pyyaml python /home/narumi/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/atuin-history-cleanup`
- `ruff check skills/atuin-history-cleanup/scripts/atuin_history_cleanup.py tests/test_atuin_history_cleanup.py`
- `ruff format --check skills/atuin-history-cleanup/scripts/atuin_history_cleanup.py tests/test_atuin_history_cleanup.py`
- `ty check skills/atuin-history-cleanup/scripts/atuin_history_cleanup.py tests/test_atuin_history_cleanup.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run --with pytest python -m pytest tests/test_atuin_history_cleanup.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run python skills/atuin-history-cleanup/scripts/atuin_history_cleanup.py audit --max-typos 2`
