### PR TITLE
[codex] refresh root docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,49 +1,37 @@
 # Repository Guidelines
 
-## Project Structure & Module Organization
-This repository hosts reusable agent skills and plugin metadata.
+Follow global defaults; this file defines only repo-specific additions and overrides.
 
-- `.claude-plugin/marketplace.json`: plugin catalog and marketplace metadata.
-- `skills/<skill-name>/SKILL.md`: required entry file for each skill.
-- `skills/<skill-name>/references/`: optional supporting documentation.
-- `examples/slides/<project>/`: Marp slide examples and assets.
-- `.github/`: CI and automation configuration.
+## Documentation Boundaries
 
-Keep each skill focused on a single responsibility and self-contained.
+- `README.md` owns external positioning, installation flows, and skill discovery.
+- This file owns maintainer workflow. Do not duplicate README product messaging or step-by-step install instructions here.
+- When install recipes or supported paths change, update `README.md`, `AGENTS.md`, and `justfile` together.
 
-## Build, Test, and Development Commands
-Use repository commands from the root directory:
+## Repository Layout
 
-- `just sync`: symlink local skills into `~/.agents/skills` for fast local testing.
-- `just clean`: remove synced skill symlinks.
-- `prek run -a`: run the full required pre-commit suite.
-- `docker run --rm -v $PWD:/home/marp/app/ -e MARP_USER="$(id -u):$(id -g)" marpteam/marp-cli:latest -I examples/slides -o build/`: build slide HTML output.
+- Skills live in `skills/<skill-name>/SKILL.md`.
+- Optional supporting material stays inside the skill directory under `references/`, `scripts/`, `assets/`, or `agents/`.
+- Slides and visual examples live under `examples/`.
+- Tests live under `tests/`.
 
-For marketplace changes, also run `/plugin validate .` and test local install/uninstall flows.
+## Commands
 
-## Coding Style & Naming Conventions
-Write clear, standard English. Keep instructions concise and enforceable.
+- `just` is non-mutating by default and only lists available recipes.
+- Local Codex symlink flows use `just install-all`, `just install <skill>`, `just clean-all`, and `just clean <skill>`.
+- `prek run -a` is the default repository-wide verification gate before a PR.
+- Rebuild slide outputs after changing content under `examples/slides/`.
 
-- Use lowercase kebab-case for skill directories (example: `python-quality-tooling`).
-- Name the required skill entry file exactly `SKILL.md`.
-- Keep examples executable and repository-relative.
-- Avoid adding dependencies unless there is a current, concrete need.
+## Editing Rules
 
-Formatting and linting are enforced via pre-commit (`check-yaml`, `check-json`, LF normalization, trailing-whitespace cleanup, `svglint`, `ruff --fix`, `ruff-format`, `ty-check`).
+- Use lowercase kebab-case for skill directories.
+- Name the required entry file exactly `SKILL.md`.
+- Keep examples repository-relative and executable when practical.
+- Do not reintroduce root-level marketplace or plugin metadata assumptions unless the corresponding files actually exist in the repo.
 
-## Testing Guidelines
-Treat all generated outputs as untrusted until verified.
+## Pull Requests
 
-- Run `prek run -a` before opening a PR.
-- Rebuild slides when slide content changes and verify rendered output.
-- Validate marketplace changes with `/plugin validate .` and installation checks.
-
-## Commit & Pull Request Guidelines
-Follow the repository’s commit style: short, imperative, and specific (<= 72 chars), for example `fix filename`.
-
-PRs should include:
-
-- what changed and why;
-- affected paths (example: `skills/python-logging/SKILL.md`);
-- verification steps with command output summary;
-- screenshots or rendered output links for slide visual changes.
+- Summarize what changed and why.
+- List affected paths.
+- Include verification steps with command output summary.
+- Add screenshots or rendered output links for slide visual changes.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -5,5 +5,6 @@
 - IMRaD 現在只保留 `skills/imrad/`; repo 內已無 `imrad-*` 舊 skill 名稱可更新。
 - Python 的 project setup、quality tooling、packaging 現在都整併進 `skills/python/`; repo 內已無 `python-uv-project-setup`、`python-quality-tooling`、`python-packaging-uv` 可更新。
 - Standalone uv script guidance 現在也整併進 `skills/python/`; repo 內已無 `uv-scripts` 可更新。
+- Root 文件分工現在固定為 `README.md` 對外、`AGENTS.md` 對內；安裝 recipe 以 `justfile` 為準，支持的是 `install-all`/`install <skill>` 與 `clean-all`/`clean <skill>`。
 
 ## TASTE

--- a/README.md
+++ b/README.md
@@ -1,56 +1,96 @@
 # Agent Skills
 
-This repo hosts my personal agent skills.
+Reusable agent skills for coding, writing, research, and slide work. The collection is organized for Codex-first workflows, and it can also be installed as a standard skills repo with `npx skills add narumiruna/agent-skills`.
 
-## Available Plugins
+## Install
 
-- `python-skills` - Python toolkit centered on a single `python` entry for uv project and standalone script work, quality gates, and packaging, with focused skills for Typer, logging, and Peewee
-- `slide-skills` - Umbrella + focused skills for Marp/Marpit slides (color, authoring, SVG) with fast routing
-- `writing-skills` - IMRaD toolkit centered on a single `imrad` skill that auto-routes between applicability detection, drafting, recomposition, and review
-- `gourmet-research` - Evidence-based gourmet research workflow for city dining recommendations
+### 1. Install with `npx`
 
-## Installation
+Use this when you want the collection without linking a local checkout.
 
-### Codex (local skills)
-
-Codex does not support marketplaces. Use one of the following:
-
-Option A: Copy skills directly into `~/.codex/skills/`:
 ```shell
-cp -R ./skills/* ~/.codex/skills/
+npx skills add narumiruna/agent-skills
 ```
 
-Option B: Use `stow` to create symlinks (recommended for development).
-Install `stow`:
+### 2. Local Codex development with `just` and `stow`
+
+Install `stow` first:
+
 ```shell
-# Linux (Debian/Ubuntu)
+# Debian/Ubuntu
 sudo apt update
 sudo apt install -y stow
 
-# macOS (using Homebrew)
+# macOS
 brew install stow
 ```
 
-Sync skills into `~/.codex/skills/` using the Makefile:
+Then install symlinks into `~/.codex/skills`:
 
 ```shell
-just
+just install-all
 
-# or
-just sync
+# or install one skill
+just install python
 ```
 
-Remove the synced skills when finished:
+Remove symlinks when finished:
 
 ```shell
-just clean
+just clean-all
+
+# or clean one skill
+just clean python
 ```
 
-## Learn More
+`just` by itself only lists the available recipes.
 
-This marketplace demonstrates:
-- Multi-skill plugins (python-skills, slide-skills with multiple skills)
-- Using `strict: false` for inline plugin definitions
-- Organizing skills in `skills/` directory
-- Marketplace validation and testing
-- Entry skills for faster routing in multi-skill bundles
+### 3. Manual copy for Codex
+
+Use this when you want a simple local copy without `stow`.
+
+```shell
+mkdir -p ~/.codex/skills
+cp -R ./skills/* ~/.codex/skills/
+```
+
+## How To Use In Codex
+
+- Run `/skills` to inspect the installed collection.
+- Type `$python`, `$imrad`, or another skill name to invoke one explicitly.
+- Or describe the task normally and let Codex choose a matching skill.
+
+If Codex does not pick up a local skill change, restart Codex and try again.
+
+## Skill Guide
+
+### Python
+
+- `python`: default entry for uv project setup, dependencies, quality gates, packaging, and standalone scripts.
+- `python-cli-typer`: Typer command structure, options, and multi-command apps.
+- `python-logging`: choosing and configuring stdlib logging or loguru.
+- `python-peewee`: Peewee patterns such as `DatabaseProxy`, scoped transactions, and SQLite tests.
+
+### Writing And Research
+
+- `imrad`: deciding whether IMRaD fits, drafting new IMRaD outputs, and reviewing existing drafts.
+- `gourmet-research`: evidence-based city dining research with structured scoring and audit files.
+
+### Slides And Visuals
+
+- `slide-creator`: end-to-end Marp/Marpit slide creation, including color systems and SVG visuals.
+- `marp-authoring`: focused Marp/Marpit authoring rules, directives, and layouts.
+- `slide-color-design`: slide palette selection and color-system workflows.
+- `svg-illustration`: SVG diagram and illustration guidance for slide decks.
+- `mermaid-creator`: Mermaid diagrams for docs, architecture, sequence flows, ER diagrams, and Gantt charts.
+
+### Workflow And Repository Maintenance
+
+- `git-commit`: reviewing diffs, choosing commit types, and writing focused Conventional Commits.
+- `agents-writer`: creating or updating `AGENTS.md` guidance for this repository.
+- `codex-cli-hooks`: designing or debugging Codex CLI hooks and `hooks.json` behavior.
+- `test-driven-development`: applying a red-green-refactor workflow to non-trivial code changes.
+
+### Utilities
+
+- `atuin-history-cleanup`: preview-first cleanup planning for noisy Atuin shell history.


### PR DESCRIPTION
## Summary

Refresh the root documentation so it matches the current repository layout and supported workflows.

## What changed

- rewrote the root README as a skills-collection overview instead of an old marketplace/plugin showcase
- replaced stale install instructions with the current `npx`, `just`, and manual Codex flows
- added a grouped skill guide and a short Codex usage section
- narrowed the root `AGENTS.md` file to maintainer-facing repo rules and removed outdated marketplace assumptions
- added a `MEMORY.md` gotcha to keep future root docs aligned with `justfile`

## Why

The root docs had drifted from the actual repository state. They still referenced removed plugin bundles, nonexistent commands such as `just sync`, and old marketplace-oriented structure.

## Impact

- new users get an accurate install and discovery path
- maintainers now have a clearer boundary between README responsibilities and AGENTS rules
- future doc edits have an explicit reminder to keep root install recipes aligned with `justfile`

## Validation

- `prek run -a`
