### PR TITLE
[codex] simplify git-commit skill guidance

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -10,3 +10,4 @@
 - 這個 repo 的 `skills/python/` 和 `~/.codex/skills/python/` 不是同一路徑綁定；改完 repo 後要再跑 `just install python` 才會同步到 Codex 實際載入版本。
 
 ## TASTE
+- `git-commit` 應依賴 repo 級 `AGENTS.md` 的 git 基線；SKILL.md 只保留 diff 到 commit message 的流程與判斷，少見 Conventional Commits 細節放在 `references/`。

--- a/skills/git-commit/SKILL.md
+++ b/skills/git-commit/SKILL.md
@@ -1,52 +1,38 @@
 ---
 name: git-commit
-description: Use when inspecting local git changes, drafting or validating commit messages, converting ad hoc messages to Conventional Commits, choosing an appropriate commit type or scope, explaining whether a change is breaking, or creating focused commits that match the actual diff.
+description: Use when inspecting local git changes, drafting or validating Conventional Commit messages, checking type or scope choices, explaining breaking changes, or creating a focused commit from the actual diff.
 ---
 
 # Git Commit
 
-## Overview
+Inspect the actual diff before writing the message. Prefer one coherent commit per intent, then map that intent to a Conventional Commits title and only add extra sections when they carry concrete information.
 
-Inspect the actual diff before writing the message. Prefer one coherent commit per intent, then map that intent to a Conventional Commits title, optional body, and optional footers.
-
-Read `references/conventional-commits.md` when the type is ambiguous, when footers are needed, or when the change may be breaking.
+Read `references/conventional-commits.md` when the type is ambiguous, when you need trailers or breaking-change wording, or when the user asks for exact format details.
 
 ## Workflow
 
-1. Inspect the working tree first.
-   Start with `git status --short` to see staged, unstaged, and untracked paths. If the user asks for a commit, inspect `git diff --cached` first; inspect `git diff` too when unstaged changes might affect the requested commit.
+1. Inspect the exact commit contents.
+   Start with `git status --short`. If the user asks for a commit, inspect `git diff --cached` first; inspect `git diff` too when unstaged changes might affect the commit boundary.
 2. Define the commit boundary.
-   Group files by one user-visible intent. If the diff mixes unrelated work, recommend splitting it into multiple commits instead of forcing one summary over several intents.
-3. Choose the type from behavior, not file extension.
-   Use `feat` for a new capability, `fix` for a bug fix, and other common lowercase types such as `docs`, `refactor`, `test`, `perf`, `build`, `ci`, `style`, `chore`, or `revert` when they describe the dominant change more accurately.
-4. Add a scope only when it clarifies the change.
-   Keep scopes short, noun-like, and stable, such as `api`, `auth`, `parser`, or `docs`. Omit the scope when it adds little signal.
-5. Write the title in the required format.
-   Use `<type>[optional scope][!]: <description>`. Keep the description short, specific, and grounded in the diff. Prefer imperative phrasing such as `fix(parser): handle empty array input`.
-6. Add body and footers only when they add concrete value.
-   Use the body to explain why the change exists, important constraints, or notable tradeoffs. Add footers after a blank line for trailers such as `Refs: #123` or `Reviewed-by: Name`.
-7. Mark breaking changes explicitly.
-   Use `!` before the colon, a `BREAKING CHANGE:` footer, or both. When the change is breaking, describe the user impact or migration requirement clearly.
-8. Keep the message aligned with the exact commit contents.
+   Group files by one user-visible intent. If the diff mixes unrelated work, recommend splitting it into multiple commits instead of forcing one vague summary over several intents.
+3. Choose the type and scope from behavior.
+   Pick the lowercase Conventional Commits type that best matches the dominant behavior. Add a short noun-like scope only when it adds signal.
+4. Write the title in the required format.
+   Use `<type>[optional scope][!]: <description>`. Keep the description short, specific, and grounded in the diff.
+5. Add body and footers only when they add concrete value.
+   Use the body for why, constraints, or tradeoffs. Add footers only for real trailers or `BREAKING CHANGE:`.
+6. Keep the message aligned with the selected diff.
    Do not describe unstaged changes, planned follow-up work, or unrelated cleanup that is not part of the commit.
 
 ## Decision Rules
 
-- Prefer `feat` when the diff introduces new behavior that users or integrators can rely on.
-- Prefer `fix` when the diff corrects incorrect behavior, a regression, or an edge-case failure.
-- Prefer `refactor` when behavior should stay the same and the change mainly restructures code.
-- Prefer `docs` when the commit only changes documentation.
-- Prefer multiple commits when a single diff contains more than one independent reason to exist.
-- Prefer no body when the title fully explains the change.
-- Prefer no footer unless a trailer or breaking-change notice is actually needed.
-
-## Commit Execution
-
-- Stage only the paths intended for this commit.
-- If the repo has staged and unstaged changes, ensure the commit message matches only the staged diff.
-- If the user asks for a suggested message instead of an actual commit, return one or more candidate messages grounded in the inspected diff.
-- If the user asks whether an existing message is valid, check the structure, the type choice, and whether the wording matches the actual change.
+- Prefer `feat` for a new capability and `fix` for incorrect behavior or regressions.
+- Prefer `refactor` when behavior should stay the same, and `docs` when only documentation changes.
+- Prefer no scope, body, or footer unless each one adds concrete signal.
+- Prefer multiple commits over one vague summary when the diff contains unrelated work.
+- If the user asks for validation, check both the structure and whether the wording matches the inspected diff.
+- Follow repo git rules for staging and commit structure; this skill focuses on mapping the diff to the right message.
 
 ## Reference
 
-- `references/conventional-commits.md`: format, type guidance, breaking-change rules, footers, and examples.
+- `references/conventional-commits.md`: exact format, common types, footer rules, breaking-change wording, and examples.

--- a/skills/git-commit/references/conventional-commits.md
+++ b/skills/git-commit/references/conventional-commits.md
@@ -1,6 +1,6 @@
 # Conventional Commits Reference
 
-## Core Format
+## Format
 
 Use this structure:
 
@@ -12,8 +12,6 @@ Use this structure:
 [optional footer(s)]
 ```
 
-Rules:
-
 - Start with a lowercase type such as `feat`, `fix`, `docs`, or `refactor`.
 - Add an optional scope in parentheses when it clarifies which area changed.
 - Place `!` immediately before `:` to mark a breaking change in the title.
@@ -21,7 +19,7 @@ Rules:
 - Separate the body from the title with one blank line.
 - Separate footers from the body with one blank line.
 
-## Type Selection
+## Common Types
 
 - `feat`: add a new feature or capability
 - `fix`: patch a bug or incorrect behavior
@@ -46,17 +44,13 @@ Use a short noun-like scope only when it adds signal:
 
 Avoid broad or unstable scopes such as `misc`, `stuff`, or full file paths unless the repo already standardizes on them.
 
-## Body Guidance
+## Body And Footers
 
 Use the body for context the title cannot carry:
 
 - why the change was needed
 - what constraint or edge case shaped the implementation
 - what tradeoff or follow-up the reader should know
-
-Multi-paragraph bodies are valid when the extra detail matters.
-
-## Footer Guidance
 
 Footers follow git-trailer style. Common examples:
 
@@ -76,22 +70,10 @@ Mark a breaking change with either:
 
 Use a `BREAKING CHANGE:` footer when the impact or migration path needs more than the title can say.
 
-## SemVer Mapping
-
-- `fix` maps to a patch release
-- `feat` maps to a minor release
-- any commit with a breaking change maps to a major release
-
-Other types do not imply a version bump unless they include a breaking change.
-
 ## Examples
 
 ```text
 docs: correct spelling of changelog
-```
-
-```text
-feat(lang): add Polish language
 ```
 
 ```text


### PR DESCRIPTION
## Summary
- simplify the main git-commit workflow to keep only diff-to-message guidance
- trim the Conventional Commits reference to format-critical details
- record the new maintenance boundary in MEMORY.md

## Why
- reduce duplicated git rules between the skill and repo-level AGENTS guidance
- keep rare Conventional Commits details in the reference instead of the main skill file

## Impact
- git-commit keeps the same purpose but is shorter and easier to maintain

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run --with pyyaml python /home/narumi/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/git-commit`
- `prek run -a`