### PR TITLE
[codex] add missing OpenAI skill metadata

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -2,6 +2,7 @@
 
 - `skill-creator` 的 `quick_validate.py` 需要 `PyYAML`; 在這個 repo 用 `uv run --with pyyaml python /home/narumi/.codex/skills/.system/skill-creator/scripts/quick_validate.py <skill-dir>` 比直接 `uv run python` 穩定。
 - 這個 sandbox 對 `~/.cache/uv` 可能是唯讀；跑 `uv run --with ...` 類的一次性工具時，先設 `UV_CACHE_DIR=/tmp/uv-cache` 比較穩。
+- 在這個 sandbox 首次跑 `uv run --with pyyaml` 這類 skill metadata 工具時，如果本機 cache 還沒有套件，通常還需要暫時放行網路讓 `uv` 抓 `PyYAML`。
 - Codex CLI 讀本地 skills 時對 symlink 不可靠；這個 repo 的 `just` 安裝流程改成 copy/rm，不再用 `stow`。
 - IMRaD 現在只保留 `skills/imrad/`; repo 內已無 `imrad-*` 舊 skill 名稱可更新。
 - Python 的 project setup、quality tooling、packaging 現在都整併進 `skills/python/`; repo 內已無 `python-uv-project-setup`、`python-quality-tooling`、`python-packaging-uv` 可更新。

--- a/skills/agents-writer/agents/openai.yaml
+++ b/skills/agents-writer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "AGENTS.md Writer"
+  short_description: "Create and update repository AGENTS.md guides."
+  default_prompt: "Use $agents-writer to draft or update the repository AGENTS.md contributor guide."

--- a/skills/gourmet-research/agents/openai.yaml
+++ b/skills/gourmet-research/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Gourmet Research"
+  short_description: "Produce auditable city food research outputs."
+  default_prompt: "Use $gourmet-research to build a traceable city food research pack with sources, scores, and audit files."

--- a/skills/imrad/agents/openai.yaml
+++ b/skills/imrad/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "IMRaD"
+  short_description: "Draft, transform, and review IMRaD outputs."
+  default_prompt: "Use $imrad to decide whether IMRaD fits, then draft, transform, or review this material in IMRaD form."

--- a/skills/marp-authoring/agents/openai.yaml
+++ b/skills/marp-authoring/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Marp Authoring"
+  short_description: "Write Marp/Marpit slides with minimal lookup."
+  default_prompt: "Use $marp-authoring to write or revise this Marp/Marpit deck and route to the right authoring references."

--- a/skills/mermaid-creator/agents/openai.yaml
+++ b/skills/mermaid-creator/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Mermaid Creator"
+  short_description: "Create Mermaid diagrams and export slide-ready SVGs."
+  default_prompt: "Use $mermaid-creator to create or convert this diagram in Mermaid and export SVG if needed."

--- a/skills/python-cli-typer/agents/openai.yaml
+++ b/skills/python-cli-typer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Python CLI with Typer"
+  short_description: "Build Python CLIs with Typer and testable wiring."
+  default_prompt: "Use $python-cli-typer to structure this Python CLI with Typer, keeping command wiring thin and testable."

--- a/skills/python-logging/agents/openai.yaml
+++ b/skills/python-logging/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Python Logging"
+  short_description: "Choose and configure Python logging safely."
+  default_prompt: "Use $python-logging to choose between stdlib logging and loguru, then configure the logging setup for this app or library."

--- a/skills/python-peewee/agents/openai.yaml
+++ b/skills/python-peewee/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Python Peewee"
+  short_description: "Use Peewee with DatabaseProxy and safe tests."
+  default_prompt: "Use $python-peewee to model this data with Peewee, wire DatabaseProxy correctly, and keep SQLite tests isolated."

--- a/skills/python/agents/openai.yaml
+++ b/skills/python/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Python"
+  short_description: "Handle Python and uv project workflows."
+  default_prompt: "Use $python to set up or update this Python project with uv, dependencies, quality checks, or packaging."

--- a/skills/slide-color-design/agents/openai.yaml
+++ b/skills/slide-color-design/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Slide Color Design"
+  short_description: "Design slide palettes and color systems."
+  default_prompt: "Use $slide-color-design to choose or generate a slide palette and document color roles for this deck."

--- a/skills/slide-creator/agents/openai.yaml
+++ b/skills/slide-creator/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Slide Creator"
+  short_description: "Create Marp decks, SVGs, and slide palettes."
+  default_prompt: "Use $slide-creator to build or revise this Marp/Marpit deck with consistent colors, layout, and SVG visuals."

--- a/skills/svg-illustration/agents/openai.yaml
+++ b/skills/svg-illustration/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SVG Illustration"
+  short_description: "Create slide-ready SVG diagrams and illustrations."
+  default_prompt: "Use $svg-illustration to create or refine a slide-ready SVG diagram with the right sizing, layout, and embedding rules."

--- a/skills/test-driven-development/agents/openai.yaml
+++ b/skills/test-driven-development/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Test-Driven Development"
+  short_description: "Implement non-trivial changes with TDD."
+  default_prompt: "Use $test-driven-development to drive this non-trivial change with a failing test first, then the smallest passing implementation."


### PR DESCRIPTION
## Summary
- add `agents/openai.yaml` for the 13 skills that were still missing UI metadata
- set `display_name`, `short_description`, and `default_prompt` with the repo's standard generator flow
- record the sandbox-specific `uv run --with pyyaml` network/cache gotcha in `MEMORY.md`

## Why
Several skills were missing the UI metadata file recommended by `skill-creator`, so they were inconsistent with the rest of the repository. While generating them, this sandbox also exposed a repeatable `PyYAML` fetch requirement worth preserving in project memory.

## Affected Paths
- `MEMORY.md`
- `skills/agents-writer/agents/openai.yaml`
- `skills/gourmet-research/agents/openai.yaml`
- `skills/imrad/agents/openai.yaml`
- `skills/marp-authoring/agents/openai.yaml`
- `skills/mermaid-creator/agents/openai.yaml`
- `skills/python-cli-typer/agents/openai.yaml`
- `skills/python-logging/agents/openai.yaml`
- `skills/python-peewee/agents/openai.yaml`
- `skills/python/agents/openai.yaml`
- `skills/slide-color-design/agents/openai.yaml`
- `skills/slide-creator/agents/openai.yaml`
- `skills/svg-illustration/agents/openai.yaml`
- `skills/test-driven-development/agents/openai.yaml`

## Validation
- `git diff --cached --check`
- `uv run --with pyyaml python - <<'PY' ... PY` — validated 16 total metadata files; 13 new files match expected interface fields