### PR TITLE
[codex] rename python-cli-typer to python-typer

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -6,6 +6,7 @@
 - Codex CLI is unreliable with symlinks when loading local skills; this repo's `just` install flow now uses copy/rm instead of `stow`.
 - IMRaD now only lives under `skills/imrad/`; there are no remaining `imrad-*` legacy skill names in the repo to update.
 - Python project setup, quality tooling, and packaging are now consolidated into `skills/python/`; there are no remaining `python-uv-project-setup`, `python-quality-tooling`, or `python-packaging-uv` skills in the repo to update.
+- Typer CLI guidance now lives under `skills/python-typer/`; use that name consistently across repo docs and prompts.
 - Standalone uv script guidance is also consolidated into `skills/python/`; there is no remaining `uv-scripts` skill in the repo to update.
 - Root document ownership is now fixed as `README.md` for external-facing docs and `AGENTS.md` for maintainer-facing docs; treat `justfile` as the source of truth for install recipes, with `install-all`/`install <skill>` and `clean-all`/`clean <skill>` as the supported commands.
 - `skills/python/` in this repo and `~/.codex/skills/python/` are not the same bound path; after changing the repo copy, run `just install python` again to sync the version Codex actually loads.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ If Codex does not pick up a local skill change, restart Codex and try again.
 ### Python
 
 - `python`: default entry for uv project setup, dependencies, quality gates, packaging, and standalone scripts.
-- `python-cli-typer`: Typer command structure, options, and multi-command apps.
+- `python-typer`: Typer command structure, options, and multi-command apps.
 - `python-logging`: choosing and configuring stdlib logging or loguru.
 - `python-peewee`: Peewee patterns such as `DatabaseProxy`, scoped transactions, and SQLite tests.
 

--- a/examples/slides/marketplace/slides.md
+++ b/examples/slides/marketplace/slides.md
@@ -266,11 +266,8 @@ skills/
 │   └── slide-skills/
 └── skills/
     ├── python/
-    ├── python-uv-project-setup/
-    ├── python-quality-tooling/
-    ├── python-cli-typer/
+    ├── python-typer/
     ├── python-logging/
-    ├── python-packaging-uv/
     ├── python-peewee/
     └── slide-creator/
 ```

--- a/skills/python-cli-typer/agents/openai.yaml
+++ b/skills/python-cli-typer/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Python CLI with Typer"
-  short_description: "Build Python CLIs with Typer and testable wiring."
-  default_prompt: "Use $python-cli-typer to structure this Python CLI with Typer, keeping command wiring thin and testable."

--- a/skills/python-typer/SKILL.md
+++ b/skills/python-typer/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: python-cli-typer
+name: python-typer
 description: Use when building or structuring Python CLI commands with Typer, including commands, options, and multi-command apps.
 ---
 

--- a/skills/python-typer/agents/openai.yaml
+++ b/skills/python-typer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Python CLI with Typer"
+  short_description: "Build Python CLIs with Typer and testable wiring."
+  default_prompt: "Use $python-typer to structure this Python CLI with Typer, keeping command wiring thin and testable."

--- a/skills/python/SKILL.md
+++ b/skills/python/SKILL.md
@@ -18,7 +18,7 @@ Use this skill as the default entry point for Python and uv work. Own project se
 | Standalone scripts, inline metadata, one-off deps, or `--no-project` | `python` |
 | Lint, format, type-check, test, coverage, CI gates | `python` |
 | Build or publish wheel/sdist with uv | `python` |
-| Build a CLI with Typer | `python-cli-typer` |
+| Build a CLI with Typer | `python-typer` |
 | Choose/configure logging or loguru | `python-logging` |
 | Peewee ORM, DatabaseProxy, SQLite tests | `python-peewee` |
 
@@ -26,14 +26,14 @@ Use this skill as the default entry point for Python and uv work. Own project se
 
 - Stay in `python` for project-scoped work involving `pyproject.toml`, shared dependencies, `uv run`, quality tools, or package release.
 - Stay in `python` for standalone Python files when deciding among plain `uv run`, `uv run --with`, inline metadata, `--no-project`, or script-specific Python version handling.
-- Route to `python-cli-typer`, `python-logging`, or `python-peewee` only for those domain-specific concerns. Keep dependency, quality, and release expectations from this skill.
+- Route to `python-typer`, `python-logging`, or `python-peewee` only for those domain-specific concerns. Keep dependency, quality, and release expectations from this skill.
 - For mixed tasks, select project mode or standalone-script mode here first, then apply the focused skill if needed.
 
 Use these trigger rules:
 
 - Install, dependency, project initialization, missing package, running project commands, lint, type-checking, tests, coverage, CI gates, or packaging: stay in `python`.
 - Standalone script, inline script metadata, one-off dependencies, `--with`, `--no-project`, `uv init --script`, `uv add --script`, `uv lock --script`, or script Python version selection: stay in `python`.
-- CLI commands, Typer, options, arguments, shell entry points, or command tests: `python-cli-typer`.
+- CLI commands, Typer, options, arguments, shell entry points, or command tests: `python-typer`.
 - Logging, loguru, handlers, formatters, structured context, or library logging: `python-logging`.
 - Peewee, ORM models, `DatabaseProxy`, transactions, or SQLite model tests: `python-peewee`.
 
@@ -167,7 +167,7 @@ Handle in `python`: initialize the project, run `uv add --dev ruff ty pytest pyt
 
 User: "Add a Typer command and tests for it."
 
-Use `python-cli-typer` for CLI structure and keep dependency and quality rules from `python`.
+Use `python-typer` for CLI structure and keep dependency and quality rules from `python`.
 
 ## Common Mistakes
 


### PR DESCRIPTION
## Summary
- rename the Typer skill from `python-cli-typer` to `python-typer`
- update Python skill routing, README entries, and agent prompts to use the new name
- align the marketplace slide example with the current Python skill layout

## Why
The repo now uses `python-typer` as the canonical skill name for Typer-specific guidance. This removes the old name from prompts and docs so the skill can be referenced consistently.

## Affected paths
- `skills/python-typer/`
- `skills/python/SKILL.md`
- `README.md`
- `examples/slides/marketplace/slides.md`
- `MEMORY.md`

## Verification
- `prek run -a`
  - passed all configured checks
- `marp -I examples/slides -o build/slides`
  - generated `build/slides/marketplace/slides.html` successfully
