### PR TITLE
[codex] Harden atuin history cleanup typo deletion flow

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -10,6 +10,7 @@
 - Standalone uv script guidance is also consolidated into `skills/python/`; there is no remaining `uv-scripts` skill in the repo to update.
 - Root document ownership is now fixed as `README.md` for external-facing docs and `AGENTS.md` for maintainer-facing docs; treat `justfile` as the source of truth for install recipes, with `install-all`/`install <skill>` and `clean-all`/`clean <skill>` as the supported commands.
 - `skills/python/` in this repo and `~/.codex/skills/python/` are not the same bound path; after changing the repo copy, run `just install python` again to sync the version Codex actually loads.
+- `atuin search --delete` deletes every history row matching the query under the active search semantics; do not treat preview uniqueness or local substring counts as proof of single-row safety.
 
 ## TASTE
 - `git-commit` should rely on the repo-level `AGENTS.md` for the Git baseline; `SKILL.md` should keep only the flow and judgment from diff to commit message, while less common Conventional Commits details belong in `references/`.

--- a/skills/atuin-history-cleanup/SKILL.md
+++ b/skills/atuin-history-cleanup/SKILL.md
@@ -7,7 +7,7 @@ description: Use when auditing Atuin shell history for noisy duplicates or high-
 
 ## Overview
 
-Audit first, delete second. Use the bundled script to summarize duplicate pressure and high-confidence typo-like retries, then apply only official Atuin cleanup flows.
+Audit first, delete second. Use the bundled script to summarize duplicate pressure and high-confidence typo-like retries, then apply only official Atuin cleanup flows that keep typo deletion inside Atuin's interactive inspector.
 
 Read `references/atuin-cli.md` when you need the exact delete, dedup, or prune behavior.
 
@@ -22,7 +22,8 @@ Read `references/atuin-cli.md` when you need the exact delete, dedup, or prune b
 
 - Always run `atuin info` and the audit script before any destructive step.
 - Treat duplicate cleanup as global. `atuin history dedup` is not a single-command delete tool.
-- For typo candidates, default to the interactive inspector path so you can confirm the exact row before deleting it.
+- `atuin search --delete` is query-wide and follows Atuin's active search semantics. Do not use it for typo cleanup.
+- For typo candidates, always use the interactive inspector path so you can confirm the exact row before deleting it.
 - Re-confirm every destructive command immediately before running it.
 - Do not delete rows directly from SQLite.
 - Do not edit Atuin config as part of this skill. `history_filter` and `cwd_filter` tuning is out of scope for v1.
@@ -51,7 +52,7 @@ uv run python skills/atuin-history-cleanup/scripts/atuin_history_cleanup.py audi
    Use the reported `atuin history dedup --dry-run ...` command. If the dry run matches expectations, rerun the same command without `--dry-run`.
 
 4. Review the `typos` section second.
-   Start with the suggested `atuin search -i <query>` preview command. In the TUI inspector, use `Ctrl+O`, confirm the exact entry, then `Ctrl+D` to delete that one row. Only use `atuin search --delete ...` when the audit marks the preview query as uniquely scoped to the target.
+   Start with the suggested `atuin search -i --search-mode prefix ...` preview command. The audit will also add `--cwd <cwd>` when it knows the original working directory, so review stays narrow even if your default Atuin config uses `skim` or another fuzzy mode. In the TUI inspector, use `Ctrl+O`, confirm the exact entry, then `Ctrl+D` to delete that one row. Do not rerun typo queries with `atuin search --delete`.
 
 5. Stop after the cleanup you actually verified. Do not keep expanding the scope.
 
@@ -60,6 +61,7 @@ uv run python skills/atuin-history-cleanup/scripts/atuin_history_cleanup.py audi
 - Resolves the database path from `atuin info` unless `--db-path` is provided.
 - Opens the SQLite database in read-only mode and inspects only `id`, `timestamp`, `exit`, `command`, `cwd`, `session`, and `hostname`.
 - Groups duplicates by `(command, cwd, hostname)` and reports how many rows exceed `--dupkeep`.
+- Emits typo review commands with an explicit `--search-mode prefix` override and never emits `atuin search --delete`.
 - Detects typo candidates only when all of these are true:
   - same session
   - within the configured window
@@ -73,5 +75,5 @@ uv run python skills/atuin-history-cleanup/scripts/atuin_history_cleanup.py audi
 ## Output Expectations
 
 - `duplicates` gives one global preview/apply pair for `history dedup`.
-- `typos` gives per-row review data: id, time, cwd, original command, suggested correction, reason, and shell-safe preview commands.
+- `typos` gives per-row review data: id, time, cwd, original command, suggested correction, reason, and shell-safe preview commands for inspector review only.
 - `--format json` is preferable when another tool needs to post-process the audit.

--- a/skills/atuin-history-cleanup/references/atuin-cli.md
+++ b/skills/atuin-history-cleanup/references/atuin-cli.md
@@ -2,15 +2,17 @@
 
 ## Single-entry delete in the TUI
 
-- Run `atuin search -i <query>` to open the interactive search view.
+- Run `atuin search -i --search-mode prefix <query>` to open the interactive search view.
+- Add `--cwd <cwd>` when you know the original working directory and want a narrower review.
 - Open the entry inspector with `Ctrl+O`.
 - After confirming the exact row, press `Ctrl+D` to delete that one history item.
 
-## Batch delete after preview
+## Why this skill avoids `search --delete` for typos
 
-- Start with `atuin search -i <query>` so you can preview what the query matches.
-- If the preview is clearly scoped, rerun it as `atuin search --delete <query>`.
-- Keep the preview and apply commands adjacent so deletion stays review-first.
+- `atuin search --help` defines `--delete` as deleting anything that matches the query.
+- Matching behavior depends on the selected `--search-mode` or your configured default.
+- Even under `--search-mode prefix`, `search --delete` still deletes every matching row, not one chosen id.
+- For typo cleanup, stay in the interactive inspector and delete the confirmed row with `Ctrl+D`.
 
 ## Global duplicate cleanup
 

--- a/skills/atuin-history-cleanup/scripts/atuin_history_cleanup.py
+++ b/skills/atuin-history-cleanup/scripts/atuin_history_cleanup.py
@@ -26,6 +26,7 @@ FROM history
 RARE_TOKEN_MAX_FREQUENCY = 3
 MIN_OVERLAP_PREFIX_OR_SUFFIX = 2
 TEXT_DUPLICATE_GROUP_LIMIT = 20
+TYPO_REVIEW_SEARCH_MODE = "prefix"
 
 
 class AuditError(RuntimeError):
@@ -60,6 +61,15 @@ def build_cd_command(cwd: str) -> str | None:
     if not cwd or cwd == "unknown":
         return None
     return f"cd {shell_quote(cwd)}"
+
+
+def build_typo_preview_command(command: str, cwd: str) -> str:
+    """Build a narrow interactive review command for a typo candidate."""
+    parts = ["atuin", "search", "-i", "--search-mode", TYPO_REVIEW_SEARCH_MODE]
+    if cwd and cwd != "unknown":
+        parts.extend(["--cwd", cwd])
+    parts.append(command)
+    return build_shell_command(parts)
 
 
 def parse_cli_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -455,11 +465,6 @@ def analyze_duplicates(
     }
 
 
-def count_preview_matches(entries: list[HistoryEntry], query: str) -> int:
-    """Approximate how many local rows the preview query would hit."""
-    return sum(1 for entry in entries if query in entry.command)
-
-
 def analyze_typos(
     entries: list[HistoryEntry],
     typo_window_seconds: int,
@@ -531,8 +536,6 @@ def analyze_typos(
                 continue
 
             query = previous.command
-            preview_match_count = count_preview_matches(entries, query)
-            unique_preview = preview_match_count == 1
             reason = "; ".join(
                 [
                     f"same session within {delta_seconds}s",
@@ -554,16 +557,12 @@ def analyze_typos(
                     "reason": reason,
                     "preview_query": query,
                     "preview_query_shell_quoted": shell_quote(query),
-                    "preview_match_count": preview_match_count,
-                    "preview_command": build_shell_command(
-                        ["atuin", "search", "-i", query]
+                    # Always override the search mode for review. Users often
+                    # configure skim/fuzzy search, and Atuin's `--delete`
+                    # removes every matching row rather than a chosen id.
+                    "preview_command": build_typo_preview_command(
+                        previous.command, previous.cwd
                     ),
-                    "delete_command": (
-                        build_shell_command(["atuin", "search", "--delete", query])
-                        if unique_preview
-                        else None
-                    ),
-                    "unique_preview": unique_preview,
                     "time_delta_seconds": delta_seconds,
                     "previous_exit_code": previous.exit_code,
                     "session": previous.session,
@@ -682,10 +681,6 @@ def format_typos_section(typos: dict[str, Any]) -> list[str]:
         )
         if candidate["cd_command"]:
             lines.insert(-2, f"   restore cwd: {candidate['cd_command']}")
-        if candidate["delete_command"]:
-            lines.append(
-                f"   apply: {candidate['delete_command']}  # only after the preview shows exactly one target"
-            )
     return lines
 
 

--- a/skills/atuin-history-cleanup/tests/test_atuin_history_cleanup.py
+++ b/skills/atuin-history-cleanup/tests/test_atuin_history_cleanup.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "atuin_history_cleanup.py"
+)
+SPEC = importlib.util.spec_from_file_location("atuin_history_cleanup", MODULE_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def make_entry(
+    entry_id: str,
+    *,
+    offset_seconds: int,
+    exit_code: int | None,
+    command: str,
+    cwd: str,
+    session: str,
+    hostname: str = "host",
+) -> object:
+    return MODULE.HistoryEntry(
+        id=entry_id,
+        timestamp=datetime(2026, 1, 1, tzinfo=UTC) + timedelta(seconds=offset_seconds),
+        exit_code=exit_code,
+        command=command,
+        cwd=cwd,
+        session=session,
+        hostname=hostname,
+    )
+
+
+def test_typo_preview_uses_prefix_mode_and_cwd() -> None:
+    entries = [
+        make_entry(
+            "1",
+            offset_seconds=0,
+            exit_code=127,
+            command="mkdit test-ctx7",
+            cwd="/tmp/project dir",
+            session="session-1",
+        ),
+        make_entry(
+            "2",
+            offset_seconds=2,
+            exit_code=0,
+            command="mkdir test-ctx7",
+            cwd="/tmp/project dir",
+            session="session-1",
+        ),
+        make_entry(
+            "3",
+            offset_seconds=10,
+            exit_code=0,
+            command="mkdir alpha",
+            cwd="/tmp/project dir",
+            session="session-2",
+        ),
+        make_entry(
+            "4",
+            offset_seconds=11,
+            exit_code=0,
+            command="mkdir beta",
+            cwd="/tmp/project dir",
+            session="session-3",
+        ),
+        make_entry(
+            "5",
+            offset_seconds=12,
+            exit_code=0,
+            command="mkdir gamma",
+            cwd="/tmp/project dir",
+            session="session-4",
+        ),
+        make_entry(
+            "6",
+            offset_seconds=13,
+            exit_code=0,
+            command="mkdir delta",
+            cwd="/tmp/project dir",
+            session="session-5",
+        ),
+    ]
+
+    report = MODULE.analyze_typos(entries, typo_window_seconds=300, max_typos=10)
+
+    candidate = report["candidates"][0]
+    assert (
+        candidate["preview_command"]
+        == "atuin search -i --search-mode prefix --cwd '/tmp/project dir' 'mkdit test-ctx7'"
+    )
+    assert candidate["preview_query"] == "mkdit test-ctx7"
+    assert "delete_command" not in candidate
+    assert "unique_preview" not in candidate
+    assert "preview_match_count" not in candidate
+
+
+def test_typo_preview_skips_unknown_cwd_and_text_output_has_no_apply() -> None:
+    entries = [
+        make_entry(
+            "1",
+            offset_seconds=0,
+            exit_code=127,
+            command="gbst",
+            cwd="unknown",
+            session="session-1",
+        ),
+        make_entry(
+            "2",
+            offset_seconds=1,
+            exit_code=0,
+            command="gst",
+            cwd="unknown",
+            session="session-1",
+        ),
+        make_entry(
+            "3",
+            offset_seconds=10,
+            exit_code=0,
+            command="gst status",
+            cwd="unknown",
+            session="session-2",
+        ),
+        make_entry(
+            "4",
+            offset_seconds=11,
+            exit_code=0,
+            command="gst diff",
+            cwd="unknown",
+            session="session-3",
+        ),
+        make_entry(
+            "5",
+            offset_seconds=12,
+            exit_code=0,
+            command="gst log",
+            cwd="unknown",
+            session="session-4",
+        ),
+        make_entry(
+            "6",
+            offset_seconds=13,
+            exit_code=0,
+            command="gst push",
+            cwd="unknown",
+            session="session-5",
+        ),
+    ]
+
+    report = MODULE.analyze_typos(entries, typo_window_seconds=300, max_typos=10)
+
+    candidate = report["candidates"][0]
+    assert candidate["preview_command"] == "atuin search -i --search-mode prefix gbst"
+    assert "--cwd" not in candidate["preview_command"]
+
+    text = "\n".join(MODULE.format_typos_section(report))
+    assert "apply:" not in text
+
+
+def test_duplicates_section_keeps_dedup_apply_command() -> None:
+    entries = [
+        make_entry(
+            str(index),
+            offset_seconds=index,
+            exit_code=0,
+            command="gst",
+            cwd="/tmp/repo",
+            session=f"session-{index}",
+        )
+        for index in range(4)
+    ]
+
+    duplicates = MODULE.analyze_duplicates(entries, before_value="now", dupkeep=3)
+    lines = MODULE.format_duplicates_section(duplicates)
+
+    assert "- Preview: atuin history dedup --dry-run --before now --dupkeep 3" in lines
+    assert "- Apply: atuin history dedup --before now --dupkeep 3" in lines


### PR DESCRIPTION
## What changed
- updated `atuin-history-cleanup` guidance to forbid `atuin search --delete` for typo cleanup
- narrowed typo review commands to `atuin search -i --search-mode prefix`, adding `--cwd` when available
- removed typo-side `delete_command` / uniqueness heuristics from the audit script
- added regression tests for preview command generation and for the absence of typo `apply:` suggestions
- recorded the Atuin `search --delete` gotcha in `MEMORY.md`

## Why
`atuin search --help` defines `--delete` as deleting anything matching the query, and the actual match set depends on the active search mode. With a fuzzy default such as `skim`, a typo query can match many unrelated rows, so the old guidance was unsafe.

## Impact
The skill now treats typo cleanup as inspector-only: review in Atuin first, then delete the confirmed row from the interactive inspector. Duplicate cleanup via `atuin history dedup` is unchanged.

## Root cause
The previous skill and audit output inferred safety from local preview heuristics and suggested `atuin search --delete` when a query looked uniquely scoped. That assumption did not match Atuin's real CLI semantics.

## Validation
- `git diff --check`
- `uv run python -m py_compile skills/atuin-history-cleanup/scripts/atuin_history_cleanup.py skills/atuin-history-cleanup/tests/test_atuin_history_cleanup.py`
- manual execution of the new regression tests through `uv run python` import-and-call flow
- `uv run python skills/atuin-history-cleanup/scripts/atuin_history_cleanup.py audit --max-typos 2 --format json`

## Notes
- direct `pytest` invocation via `uv run --with pytest pytest ...` could not run in this environment because DNS/network access to fetch `pytest` was unavailable