### PR TITLE
[codex] add transactional atuin typo cleanup

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -11,6 +11,8 @@
 - Root document ownership is now fixed as `README.md` for external-facing docs and `AGENTS.md` for maintainer-facing docs; treat `justfile` as the source of truth for install recipes, with `install-all`/`install <skill>` and `clean-all`/`clean <skill>` as the supported commands.
 - `skills/python/` in this repo and `~/.codex/skills/python/` are not the same bound path; after changing the repo copy, run `just install python` again to sync the version Codex actually loads.
 - `atuin search --delete` deletes every history row matching the query under the active search semantics; do not treat preview uniqueness or local substring counts as proof of single-row safety.
+- `atuin search -i` can panic inside Codex's filesystem sandbox because Atuin fails to create its log file on a read-only path; run interactive inspector deletions with escalated permissions.
+- For Atuin cleanup automation, snapshot `history.db` with SQLite's backup API instead of a raw file copy so live-database state and WAL pages stay consistent.
 
 ## TASTE
 - `git-commit` should rely on the repo-level `AGENTS.md` for the Git baseline; `SKILL.md` should keep only the flow and judgment from diff to commit message, while less common Conventional Commits details belong in `references/`.

--- a/skills/atuin-history-cleanup/SKILL.md
+++ b/skills/atuin-history-cleanup/SKILL.md
@@ -7,7 +7,7 @@ description: Use when auditing Atuin shell history for noisy duplicates or high-
 
 ## Overview
 
-Audit first, delete second. Use the bundled script to summarize duplicate pressure and high-confidence typo-like retries, then apply only official Atuin cleanup flows that keep typo deletion inside Atuin's interactive inspector.
+Audit first, delete second. Use the bundled script to summarize duplicate pressure and high-confidence typo-like retries. For typo cleanup, prefer the transactional `cleanup-typos` command so the flow snapshots `history.db`, uploads the current host history store, deletes candidates, verifies the result, and rolls back automatically if verification fails.
 
 Read `references/atuin-cli.md` when you need the exact delete, dedup, or prune behavior.
 
@@ -16,14 +16,17 @@ Read `references/atuin-cli.md` when you need the exact delete, dedup, or prune b
 - Reviewing a noisy Atuin `history.db` before removing anything.
 - Estimating how much `atuin history dedup` would remove while still keeping the newest repeated entries.
 - Looking for typo-like retries such as `gti status` followed by `git status`.
+- Running a transactional typo cleanup with backup, verification, and rollback.
 - Rechecking an Atuin cleanup plan without mutating the database directly.
 
 ## Guardrails
 
 - Always run `atuin info` and the audit script before any destructive step.
 - Treat duplicate cleanup as global. `atuin history dedup` is not a single-command delete tool.
-- `atuin search --delete` is query-wide and follows Atuin's active search semantics. Do not use it for typo cleanup.
-- For typo candidates, always use the interactive inspector path so you can confirm the exact row before deleting it.
+- `atuin search --delete` is query-wide and follows Atuin's active search semantics. Do not use it manually for typo cleanup.
+- `cleanup-typos` is the only approved automation path for typo deletion. It may use `atuin search --delete` only after a strict uniqueness gate; any ambiguous match must fall back to the interactive inspector path.
+- `cleanup-typos` must snapshot `history.db` before deletion and delay the final remote sync until verification passes.
+- Rollback is whole-database restore, not selective row restore.
 - Re-confirm every destructive command immediately before running it.
 - Do not delete rows directly from SQLite.
 - Do not edit Atuin config as part of this skill. `history_filter` and `cwd_filter` tuning is out of scope for v1.
@@ -51,8 +54,21 @@ uv run python skills/atuin-history-cleanup/scripts/atuin_history_cleanup.py audi
 3. Review the `duplicates` section first.
    Use the reported `atuin history dedup --dry-run ...` command. If the dry run matches expectations, rerun the same command without `--dry-run`.
 
-4. Review the `typos` section second.
-   Start with the suggested `atuin search -i --search-mode prefix ...` preview command. The audit will also add `--cwd <cwd>` when it knows the original working directory, so review stays narrow even if your default Atuin config uses `skim` or another fuzzy mode. In the TUI inspector, use `Ctrl+O`, confirm the exact entry, then `Ctrl+D` to delete that one row. Do not rerun typo queries with `atuin search --delete`.
+4. Review the `typos` section second and choose one path:
+   Preferred transactional path:
+
+```bash
+uv run python skills/atuin-history-cleanup/scripts/atuin_history_cleanup.py cleanup-typos
+```
+
+   Useful flags:
+
+```bash
+uv run python skills/atuin-history-cleanup/scripts/atuin_history_cleanup.py cleanup-typos --db-path ~/.local/share/atuin/history.db --before now --typo-window-seconds 300 --max-typos 20 --backup-dir ~/.local/share/atuin/cleanup-backups/manual-run
+```
+
+   Manual review path:
+   Start with the suggested `atuin search -i --search-mode prefix ...` preview command. The audit will also add `--cwd <cwd>` when it knows the original working directory, so review stays narrow even if your default Atuin config uses `skim` or another fuzzy mode. In the TUI inspector, use `Ctrl+O`, confirm the exact entry, then `Ctrl+D` to delete that one row.
 
 5. Stop after the cleanup you actually verified. Do not keep expanding the scope.
 
@@ -62,6 +78,7 @@ uv run python skills/atuin-history-cleanup/scripts/atuin_history_cleanup.py audi
 - Opens the SQLite database in read-only mode and inspects only `id`, `timestamp`, `exit`, `command`, `cwd`, `session`, and `hostname`.
 - Groups duplicates by `(command, cwd, hostname)` and reports how many rows exceed `--dupkeep`.
 - Emits typo review commands with an explicit `--search-mode prefix` override and never emits `atuin search --delete`.
+- `cleanup-typos` first runs the same typo audit, then creates a snapshot, writes `pre_audit.json`, `plan.json`, and `post_verify.json`, and only commits the deletion to remote sync after verification succeeds.
 - Detects typo candidates only when all of these are true:
   - same session
   - within the configured window
@@ -77,3 +94,4 @@ uv run python skills/atuin-history-cleanup/scripts/atuin_history_cleanup.py audi
 - `duplicates` gives one global preview/apply pair for `history dedup`.
 - `typos` gives per-row review data: id, time, cwd, original command, suggested correction, reason, and shell-safe preview commands for inspector review only.
 - `--format json` is preferable when another tool needs to post-process the audit.
+- `cleanup-typos` prints a text summary and leaves its backup and verification artifacts in the chosen backup directory.

--- a/skills/atuin-history-cleanup/references/atuin-cli.md
+++ b/skills/atuin-history-cleanup/references/atuin-cli.md
@@ -7,12 +7,13 @@
 - Open the entry inspector with `Ctrl+O`.
 - After confirming the exact row, press `Ctrl+D` to delete that one history item.
 
-## Why this skill avoids `search --delete` for typos
+## Why manual typo cleanup avoids `search --delete`
 
 - `atuin search --help` defines `--delete` as deleting anything that matches the query.
 - Matching behavior depends on the selected `--search-mode` or your configured default.
 - Even under `--search-mode prefix`, `search --delete` still deletes every matching row, not one chosen id.
-- For typo cleanup, stay in the interactive inspector and delete the confirmed row with `Ctrl+D`.
+- For manual typo cleanup, stay in the interactive inspector and delete the confirmed row with `Ctrl+D`.
+- The transactional `cleanup-typos` command may use `search --delete`, but only after adding strict filter gates such as cwd, exit code, and a narrow timestamp window, and only when that filtered match set is provably unique.
 
 ## Global duplicate cleanup
 

--- a/skills/atuin-history-cleanup/scripts/atuin_history_cleanup.py
+++ b/skills/atuin-history-cleanup/scripts/atuin_history_cleanup.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
 import re
 import shlex
@@ -27,10 +28,45 @@ RARE_TOKEN_MAX_FREQUENCY = 3
 MIN_OVERLAP_PREFIX_OR_SUFFIX = 2
 TEXT_DUPLICATE_GROUP_LIMIT = 20
 TYPO_REVIEW_SEARCH_MODE = "prefix"
+DEFAULT_CLEANUP_DUPKEEP = 3
 
 
 class AuditError(RuntimeError):
     """User-facing audit failure."""
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+def load_transactional_module() -> Any:
+    """Load the sibling transactional helper module from disk."""
+    module_path = SCRIPT_DIR / "atuin_history_cleanup_transactional.py"
+    spec = importlib.util.spec_from_file_location(
+        "atuin_history_cleanup_transactional_runtime",
+        module_path,
+    )
+    if spec is None or spec.loader is None:
+        raise AuditError(f"Failed to load transactional helpers from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+transactional = load_transactional_module()
+
+transactional.CleanupError = AuditError
+build_cleanup_plan = transactional.build_cleanup_plan
+execute_cleanup_plan = transactional.execute_cleanup_plan
+get_current_host_uuid = transactional.get_current_host_uuid
+get_remote_sync_status = transactional.get_remote_sync_status
+read_history_ids = transactional.read_history_ids
+render_cleanup_report = transactional.render_cleanup_report
+resolve_backup_dir = transactional.resolve_backup_dir
+rollback_cleanup = transactional.rollback_cleanup
+run_cli_command = transactional.run_cli_command
+sqlite_backup = transactional.sqlite_backup
+verify_cleanup_result = transactional.verify_cleanup_result
+write_json_report = transactional.write_json_report
 
 
 @dataclass(frozen=True, slots=True)
@@ -72,6 +108,28 @@ def build_typo_preview_command(command: str, cwd: str) -> str:
     return build_shell_command(parts)
 
 
+def add_shared_history_scope_args(parser: argparse.ArgumentParser) -> None:
+    """Add db and typo-scope arguments shared by audit and cleanup."""
+    parser.add_argument("--db-path", help="Explicit path to Atuin history.db")
+    parser.add_argument(
+        "--before",
+        default="now",
+        help="Audit only rows at or before this timestamp. Accepts 'now', ISO-8601, or Unix epoch.",
+    )
+    parser.add_argument(
+        "--typo-window-seconds",
+        type=int,
+        default=300,
+        help="Maximum gap between a failed typo and the corrected retry.",
+    )
+    parser.add_argument(
+        "--max-typos",
+        type=int,
+        default=20,
+        help="Maximum typo candidates to return.",
+    )
+
+
 def parse_cli_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(
@@ -83,7 +141,7 @@ def parse_cli_args(argv: list[str] | None = None) -> argparse.Namespace:
         "audit",
         help="Inspect Atuin history without mutating the database.",
     )
-    audit.add_argument("--db-path", help="Explicit path to Atuin history.db")
+    add_shared_history_scope_args(audit)
     audit.add_argument(
         "--dupkeep",
         type=int,
@@ -91,27 +149,20 @@ def parse_cli_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="How many copies dedup should keep per (command, cwd, hostname) group.",
     )
     audit.add_argument(
-        "--before",
-        default="now",
-        help="Audit only rows at or before this timestamp. Accepts 'now', ISO-8601, or Unix epoch.",
-    )
-    audit.add_argument(
-        "--typo-window-seconds",
-        type=int,
-        default=300,
-        help="Maximum gap between a failed typo and the corrected retry.",
-    )
-    audit.add_argument(
-        "--max-typos",
-        type=int,
-        default=20,
-        help="Maximum typo candidates to return.",
-    )
-    audit.add_argument(
         "--format",
         choices=("text", "json"),
         default="text",
         help="Output format.",
+    )
+
+    cleanup = subparsers.add_parser(
+        "cleanup-typos",
+        help="Transactionally delete high-confidence typo entries with backup and rollback.",
+    )
+    add_shared_history_scope_args(cleanup)
+    cleanup.add_argument(
+        "--backup-dir",
+        help="Directory for history.db snapshots and cleanup reports.",
     )
     return parser.parse_args(argv)
 
@@ -701,28 +752,138 @@ def render_text_report(report: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def cleanup_typos(
+    db_path: str | Path | None,
+    *,
+    before: str,
+    typo_window_seconds: int,
+    max_typos: int,
+    backup_dir: str | None,
+) -> dict[str, Any]:
+    """Run the transactional typo cleanup flow."""
+    pre_audit = audit_history(
+        db_path,
+        dupkeep=DEFAULT_CLEANUP_DUPKEEP,
+        before=before,
+        typo_window_seconds=typo_window_seconds,
+        max_typos=max_typos,
+    )
+    candidates = pre_audit["typos"]["candidates"]
+    candidate_count = pre_audit["typos"]["candidate_count"]
+    if candidate_count == 0:
+        return {
+            "status": "noop",
+            "db_path": pre_audit["db_path"],
+            "candidate_count": 0,
+        }
+    if pre_audit["typos"]["returned_count"] != candidate_count:
+        raise AuditError(
+            f"Found {candidate_count} typo candidates but --max-typos only allowed "
+            f"{pre_audit['typos']['returned_count']}. Increase --max-typos or narrow --before."
+        )
+
+    resolved_db_path = Path(pre_audit["db_path"])
+    remote = get_remote_sync_status()
+    current_host = get_current_host_uuid()
+    backup_root = resolve_backup_dir(resolved_db_path, backup_dir)
+    snapshot_path = backup_root / "history.db.before"
+    rollback_warnings: list[str] = []
+    mutation_started = False
+
+    try:
+        run_cli_command(
+            ["atuin", "store", "push", "--tag", "history", "--host", current_host]
+        )
+        sqlite_backup(resolved_db_path, snapshot_path)
+        write_json_report(backup_root / "pre_audit.json", pre_audit)
+
+        before_cutoff = parse_before(before)
+        entries, _ = load_history_entries(resolved_db_path, before_cutoff)
+        plan = build_cleanup_plan(candidates, entries)
+        write_json_report(
+            backup_root / "plan.json",
+            {
+                "db_path": str(resolved_db_path),
+                "backup_dir": str(backup_root),
+                "candidate_count": len(plan),
+                "plan": plan,
+            },
+        )
+
+        mutation_started = True
+        execution = execute_cleanup_plan(plan)
+        post_audit = audit_history(
+            resolved_db_path,
+            dupkeep=DEFAULT_CLEANUP_DUPKEEP,
+            before=before,
+            typo_window_seconds=typo_window_seconds,
+            max_typos=max_typos,
+        )
+        verification = verify_cleanup_result(
+            snapshot_path,
+            resolved_db_path,
+            target_ids=[candidate["id"] for candidate in plan],
+            post_audit=post_audit,
+        )
+        post_verify = {"post_audit": post_audit, "verification": verification}
+        write_json_report(backup_root / "post_verify.json", post_verify)
+
+        run_cli_command(["atuin", "sync"])
+
+        return {
+            "status": "success",
+            "db_path": str(resolved_db_path),
+            "backup_dir": str(backup_root),
+            "candidate_count": len(plan),
+            "fast_count": execution["fast_count"],
+            "interactive_count": execution["interactive_count"],
+            "remote": remote,
+            "current_host": current_host,
+            "verification": verification,
+        }
+    except AuditError as exc:
+        if mutation_started and snapshot_path.exists():
+            rollback_warnings = rollback_cleanup(snapshot_path, resolved_db_path)
+
+        detail = str(exc)
+        if rollback_warnings:
+            detail += " Rollback warnings: " + "; ".join(rollback_warnings)
+        detail += f" Backup dir: {backup_root}"
+        raise AuditError(detail) from exc
+
+
 def main(argv: list[str] | None = None) -> int:
     """CLI entrypoint."""
     args = parse_cli_args(argv)
-    if args.command != "audit":
-        raise AuditError(f"Unsupported command: {args.command}")
-
     try:
-        report = audit_history(
-            args.db_path,
-            dupkeep=args.dupkeep,
-            before=args.before,
-            typo_window_seconds=args.typo_window_seconds,
-            max_typos=args.max_typos,
-        )
+        if args.command == "audit":
+            report = audit_history(
+                args.db_path,
+                dupkeep=args.dupkeep,
+                before=args.before,
+                typo_window_seconds=args.typo_window_seconds,
+                max_typos=args.max_typos,
+            )
+        elif args.command == "cleanup-typos":
+            report = cleanup_typos(
+                args.db_path,
+                before=args.before,
+                typo_window_seconds=args.typo_window_seconds,
+                max_typos=args.max_typos,
+                backup_dir=args.backup_dir,
+            )
+        else:
+            raise AuditError(f"Unsupported command: {args.command}")
     except AuditError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
 
-    if args.format == "json":
+    if args.command == "audit" and args.format == "json":
         print(json.dumps(report, indent=2, sort_keys=True))
-    else:
+    elif args.command == "audit":
         print(render_text_report(report))
+    else:
+        print(render_cleanup_report(report))
     return 0
 
 

--- a/skills/atuin-history-cleanup/scripts/atuin_history_cleanup_transactional.py
+++ b/skills/atuin-history-cleanup/scripts/atuin_history_cleanup_transactional.py
@@ -1,0 +1,472 @@
+"""Transactional helpers for Atuin typo cleanup."""
+
+from __future__ import annotations
+
+import json
+import os
+import pty
+import re
+import select
+import shlex
+import sqlite3
+import subprocess
+import time
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote as url_quote
+
+HISTORY_ID_SELECT = """
+SELECT id
+FROM history
+"""
+
+TYPO_REVIEW_SEARCH_MODE = "prefix"
+TYPO_DELETE_FILTER_MODE = "global"
+TYPO_DELETE_TIME_WINDOW = timedelta(seconds=1)
+DEFAULT_CLEANUP_BACKUP_DIRNAME = "cleanup-backups"
+PTY_STEP_SETTLE_SECONDS = 0.25
+PTY_COMMAND_TIMEOUT_SECONDS = 10.0
+
+
+class CleanupError(RuntimeError):
+    """User-facing transactional cleanup failure."""
+
+
+def shell_quote(value: str) -> str:
+    """Return a shell-safe token."""
+    return shlex.quote(value)
+
+
+def build_shell_command(parts: list[str]) -> str:
+    """Render a list of argv parts as a shell-ready command string."""
+    return " ".join(shell_quote(part) for part in parts)
+
+
+def read_history_ids(db_path: Path) -> set[str]:
+    """Read the raw row ids from Atuin history."""
+    sqlite_uri = f"file:{url_quote(str(db_path))}?mode=ro"
+    try:
+        connection = sqlite3.connect(sqlite_uri, uri=True)
+    except sqlite3.Error as exc:
+        raise CleanupError(f"Failed to open SQLite database: {exc}") from exc
+
+    try:
+        try:
+            rows = connection.execute(HISTORY_ID_SELECT)
+        except sqlite3.Error as exc:
+            raise CleanupError(f"Failed to read Atuin history ids: {exc}") from exc
+        return {str(row[0]) for row in rows}
+    finally:
+        connection.close()
+
+
+def sqlite_backup(source: Path, destination: Path) -> None:
+    """Create a consistent SQLite snapshot using the backup API."""
+    destination.parent.mkdir(parents=True, exist_ok=True)
+
+    source_uri = f"file:{url_quote(str(source))}?mode=ro"
+    try:
+        source_connection = sqlite3.connect(source_uri, uri=True)
+        destination_connection = sqlite3.connect(destination)
+    except sqlite3.Error as exc:
+        raise CleanupError(f"Failed to open SQLite backup connections: {exc}") from exc
+
+    try:
+        source_connection.backup(destination_connection)
+    except sqlite3.Error as exc:
+        raise CleanupError(f"Failed to back up SQLite database: {exc}") from exc
+    finally:
+        destination_connection.close()
+        source_connection.close()
+
+
+def write_json_report(path: Path, payload: dict[str, Any]) -> None:
+    """Write a JSON report to disk."""
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def resolve_backup_dir(db_path: Path, explicit_dir: str | None) -> Path:
+    """Resolve the cleanup backup directory."""
+    if explicit_dir:
+        backup_dir = Path(explicit_dir).expanduser()
+    else:
+        timestamp = datetime.now(tz=UTC).strftime("%Y%m%dT%H%M%SZ")
+        backup_dir = db_path.parent / DEFAULT_CLEANUP_BACKUP_DIRNAME / timestamp
+
+    backup_dir = backup_dir.resolve()
+    if backup_dir.exists():
+        raise CleanupError(f"Backup directory already exists: {backup_dir}")
+    backup_dir.mkdir(parents=True, exist_ok=False)
+    return backup_dir
+
+
+def run_cli_command(
+    parts: list[str],
+    *,
+    check: bool = True,
+    capture_output: bool = True,
+    text: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    """Run a command and surface a concise user-facing error on failure."""
+    result = subprocess.run(
+        parts,
+        check=False,
+        capture_output=capture_output,
+        text=text,
+    )
+    if check and result.returncode != 0:
+        stderr = result.stderr.strip() or result.stdout.strip() or "unknown error"
+        raise CleanupError(f"`{build_shell_command(parts)}` failed: {stderr}")
+    return result
+
+
+def parse_remote_sync_status(raw_output: str) -> dict[str, str]:
+    """Extract the configured remote status fields from `atuin status`."""
+    section: str | None = None
+    remote: dict[str, str] = {}
+
+    for line in raw_output.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("[") and stripped.endswith("]"):
+            section = stripped.strip("[]").lower()
+            continue
+        if section != "remote" or ":" not in stripped:
+            continue
+        key, value = stripped.split(":", 1)
+        remote[key.strip().lower()] = value.strip()
+
+    address = remote.get("address")
+    username = remote.get("username")
+    if not address or not username:
+        raise CleanupError(
+            "Atuin remote sync is not configured or the current user is not logged in."
+        )
+    return {"address": address, "username": username}
+
+
+def get_remote_sync_status() -> dict[str, str]:
+    """Read and validate the current Atuin remote sync configuration."""
+    result = run_cli_command(["atuin", "status"])
+    return parse_remote_sync_status(result.stdout)
+
+
+def parse_current_host_uuid(raw_output: str) -> str:
+    """Extract the current host UUID from `atuin store status`."""
+    match = re.search(
+        r"^host:\s+([0-9a-f-]+)\s+<-\s+CURRENT HOST$",
+        raw_output,
+        re.MULTILINE,
+    )
+    if match is None:
+        raise CleanupError("Could not determine the current host UUID from `atuin store status`.")
+    return match.group(1)
+
+
+def get_current_host_uuid() -> str:
+    """Return the current Atuin host UUID."""
+    result = run_cli_command(["atuin", "store", "status"])
+    return parse_current_host_uuid(result.stdout)
+
+
+def parse_candidate_timestamp(value: Any) -> datetime:
+    """Parse ISO timestamps from the audit output."""
+    raw = str(value).strip().replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError as exc:
+        raise CleanupError(f"Invalid candidate timestamp: {value!r}") from exc
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def candidate_delete_window(candidate: dict[str, Any]) -> tuple[datetime, datetime]:
+    """Return the narrow timestamp window used for typo deletion."""
+    timestamp = parse_candidate_timestamp(candidate["timestamp"])
+    return (
+        timestamp - TYPO_DELETE_TIME_WINDOW,
+        timestamp + TYPO_DELETE_TIME_WINDOW,
+    )
+
+
+def entry_matches_cleanup_candidate(
+    entry: Any,
+    candidate: dict[str, Any],
+    *,
+    after_cutoff: datetime,
+    before_cutoff: datetime,
+) -> bool:
+    """Apply the cleanup search filters in Python before choosing a delete path."""
+    if entry.timestamp is None:
+        return False
+    if entry.timestamp < after_cutoff or entry.timestamp > before_cutoff:
+        return False
+    if not entry.command.startswith(candidate["original_command"]):
+        return False
+
+    cwd = candidate["cwd"]
+    if cwd and cwd != "unknown" and entry.cwd != cwd:
+        return False
+
+    exit_code = candidate["previous_exit_code"]
+    if exit_code is not None and entry.exit_code != exit_code:
+        return False
+
+    return True
+
+
+def build_cleanup_search_parts(
+    candidate: dict[str, Any],
+    *,
+    interactive: bool,
+    delete: bool,
+) -> list[str]:
+    """Build a deterministic Atuin search command for typo cleanup."""
+    after_cutoff, before_cutoff = candidate_delete_window(candidate)
+    parts = ["atuin", "search"]
+    if interactive:
+        parts.append("-i")
+    if delete:
+        parts.append("--delete")
+
+    parts.extend(
+        [
+            "--filter-mode",
+            TYPO_DELETE_FILTER_MODE,
+            "--search-mode",
+            TYPO_REVIEW_SEARCH_MODE,
+            "--after",
+            after_cutoff.isoformat(),
+            "--before",
+            before_cutoff.isoformat(),
+        ]
+    )
+
+    if candidate["cwd"] and candidate["cwd"] != "unknown":
+        parts.extend(["--cwd", candidate["cwd"]])
+    if candidate["previous_exit_code"] is not None:
+        parts.extend(["--exit", str(candidate["previous_exit_code"])])
+
+    parts.append(candidate["original_command"])
+    return parts
+
+
+def build_cleanup_plan(
+    candidates: list[dict[str, Any]],
+    entries: list[Any],
+) -> list[dict[str, Any]]:
+    """Route each candidate through a strict fast path or the TUI fallback."""
+    plan: list[dict[str, Any]] = []
+
+    for candidate in candidates:
+        after_cutoff, before_cutoff = candidate_delete_window(candidate)
+        matching_entries = sorted(
+            [
+                entry
+                for entry in entries
+                if entry_matches_cleanup_candidate(
+                    entry,
+                    candidate,
+                    after_cutoff=after_cutoff,
+                    before_cutoff=before_cutoff,
+                )
+            ],
+            key=lambda entry: (
+                entry.timestamp or datetime.min.replace(tzinfo=UTC),
+                entry.id,
+            ),
+        )
+        matching_ids = [entry.id for entry in matching_entries]
+        if candidate["id"] not in matching_ids:
+            raise CleanupError(
+                f"Could not re-locate typo candidate {candidate['id']} before deletion."
+            )
+
+        target_index = matching_ids.index(candidate["id"])
+        move_up = len(matching_ids) - target_index - 1
+        route = "fast" if len(matching_ids) == 1 else "interactive"
+        command_parts = build_cleanup_search_parts(
+            candidate,
+            interactive=route == "interactive",
+            delete=route == "fast",
+        )
+
+        plan.append(
+            {
+                "id": candidate["id"],
+                "timestamp": candidate["timestamp"],
+                "cwd": candidate["cwd"],
+                "original_command": candidate["original_command"],
+                "route": route,
+                "match_count": len(matching_ids),
+                "match_ids": matching_ids,
+                "move_up": move_up,
+                "after_iso": after_cutoff.isoformat(),
+                "before_iso": before_cutoff.isoformat(),
+                "command": build_shell_command(command_parts),
+                "command_parts": command_parts,
+            }
+        )
+
+    return plan
+
+
+def read_pty_output(master_fd: int, timeout_seconds: float) -> bytes:
+    """Drain whatever the child TTY has emitted for a short burst."""
+    chunks: list[bytes] = []
+    deadline = time.monotonic() + timeout_seconds
+
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+
+        ready, _, _ = select.select([master_fd], [], [], remaining)
+        if not ready:
+            break
+
+        try:
+            chunk = os.read(master_fd, 4096)
+        except OSError:
+            break
+        if not chunk:
+            break
+        chunks.append(chunk)
+        deadline = time.monotonic() + 0.05
+
+    return b"".join(chunks)
+
+
+def run_interactive_cleanup_delete(command_parts: list[str], *, move_up: int) -> None:
+    """Drive Atuin's inspector deletion flow through a PTY."""
+    master_fd, slave_fd = pty.openpty()
+    process = subprocess.Popen(
+        command_parts,
+        stdin=slave_fd,
+        stdout=slave_fd,
+        stderr=slave_fd,
+        close_fds=True,
+    )
+    os.close(slave_fd)
+
+    output = bytearray()
+    try:
+        output.extend(read_pty_output(master_fd, PTY_STEP_SETTLE_SECONDS))
+        for _ in range(move_up):
+            os.write(master_fd, b"\x1b[A")
+            output.extend(read_pty_output(master_fd, PTY_STEP_SETTLE_SECONDS))
+
+        os.write(master_fd, b"\x0f")
+        output.extend(read_pty_output(master_fd, PTY_STEP_SETTLE_SECONDS))
+        os.write(master_fd, b"\x04")
+        output.extend(read_pty_output(master_fd, PTY_STEP_SETTLE_SECONDS))
+        os.write(master_fd, b"\x1b")
+        output.extend(read_pty_output(master_fd, PTY_STEP_SETTLE_SECONDS))
+
+        try:
+            process.wait(timeout=PTY_COMMAND_TIMEOUT_SECONDS)
+        except subprocess.TimeoutExpired as exc:
+            process.kill()
+            raise CleanupError(
+                f"`{build_shell_command(command_parts)}` timed out while driving the TUI inspector."
+            ) from exc
+    finally:
+        os.close(master_fd)
+
+    if process.returncode != 0:
+        decoded = output.decode(errors="replace").strip()
+        detail = decoded or f"exit code {process.returncode}"
+        raise CleanupError(f"`{build_shell_command(command_parts)}` failed: {detail}")
+
+
+def execute_cleanup_plan(plan: list[dict[str, Any]]) -> dict[str, int]:
+    """Execute the planned typo cleanup commands."""
+    fast_count = 0
+    interactive_count = 0
+
+    for item in plan:
+        if item["route"] == "fast":
+            run_cli_command(item["command_parts"])
+            fast_count += 1
+            continue
+
+        run_interactive_cleanup_delete(item["command_parts"], move_up=item["move_up"])
+        interactive_count += 1
+
+    return {"fast_count": fast_count, "interactive_count": interactive_count}
+
+
+def verify_cleanup_result(
+    snapshot_db_path: Path,
+    live_db_path: Path,
+    *,
+    target_ids: list[str],
+    post_audit: dict[str, Any],
+) -> dict[str, Any]:
+    """Confirm that only the intended ids disappeared and no typo candidates remain."""
+    if post_audit["typos"]["candidate_count"] != 0:
+        raise CleanupError(
+            "Post-delete audit still found high-confidence typo candidates. Rolling back."
+        )
+
+    snapshot_ids = read_history_ids(snapshot_db_path)
+    live_ids = read_history_ids(live_db_path)
+    removed_ids = sorted(snapshot_ids - live_ids)
+    added_ids = sorted(live_ids - snapshot_ids)
+
+    target_id_set = set(target_ids)
+    unexpected_removed_ids = sorted(set(removed_ids) - target_id_set)
+    missing_removed_ids = sorted(target_id_set - set(removed_ids))
+    if added_ids or unexpected_removed_ids or missing_removed_ids:
+        raise CleanupError(
+            "Post-delete verification failed: "
+            + f"added_ids={added_ids}, "
+            + f"unexpected_removed_ids={unexpected_removed_ids}, "
+            + f"missing_removed_ids={missing_removed_ids}."
+        )
+
+    return {
+        "removed_ids": removed_ids,
+        "added_ids": added_ids,
+        "target_ids": sorted(target_id_set),
+    }
+
+
+def rollback_cleanup(snapshot_db_path: Path, live_db_path: Path) -> list[str]:
+    """Restore the saved database snapshot and best-effort re-align sync state."""
+    warnings: list[str] = []
+    sqlite_backup(snapshot_db_path, live_db_path)
+    try:
+        run_cli_command(["atuin", "sync", "-f"])
+    except CleanupError as exc:
+        warnings.append(str(exc))
+    return warnings
+
+
+def render_cleanup_report(result: dict[str, Any]) -> str:
+    """Render a text summary for cleanup-typos."""
+    if result["status"] == "noop":
+        return "\n".join(
+            [
+                "Atuin typo cleanup",
+                f"DB: {result['db_path']}",
+                "No high-confidence typo candidates found.",
+            ]
+        )
+
+    lines = [
+        "Atuin typo cleanup",
+        f"DB: {result['db_path']}",
+        f"Backup dir: {result['backup_dir']}",
+        f"Candidates deleted: {result['candidate_count']}",
+        f"Fast path deletions: {result['fast_count']}",
+        f"Interactive fallback deletions: {result['interactive_count']}",
+        f"Remote: {result['remote']['username']} @ {result['remote']['address']}",
+        f"Current host: {result['current_host']}",
+        f"Removed ids: {len(result['verification']['removed_ids'])}",
+        "Status: success",
+    ]
+    return "\n".join(lines)

--- a/skills/atuin-history-cleanup/tests/test_atuin_history_cleanup.py
+++ b/skills/atuin-history-cleanup/tests/test_atuin_history_cleanup.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
 import importlib.util
+import sqlite3
 import sys
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+import subprocess
+
+import pytest
 
 MODULE_PATH = (
     Path(__file__).resolve().parents[1] / "scripts" / "atuin_history_cleanup.py"
@@ -19,7 +23,7 @@ SPEC.loader.exec_module(MODULE)
 def make_entry(
     entry_id: str,
     *,
-    offset_seconds: int,
+    offset_seconds: float,
     exit_code: int | None,
     command: str,
     cwd: str,
@@ -35,6 +39,31 @@ def make_entry(
         session=session,
         hostname=hostname,
     )
+
+
+def make_candidate(
+    entry: object, *, suggested_command: str = "git status"
+) -> dict[str, object]:
+    return {
+        "id": entry.id,
+        "timestamp": entry.timestamp.isoformat(),
+        "cwd": entry.cwd,
+        "original_command": entry.command,
+        "previous_exit_code": entry.exit_code,
+        "suggested_command": suggested_command,
+    }
+
+
+def create_history_db(path: Path, ids: list[str]) -> None:
+    connection = sqlite3.connect(path)
+    try:
+        connection.execute("CREATE TABLE history (id TEXT PRIMARY KEY)")
+        connection.executemany(
+            "INSERT INTO history (id) VALUES (?)", [(entry_id,) for entry_id in ids]
+        )
+        connection.commit()
+    finally:
+        connection.close()
 
 
 def test_typo_preview_uses_prefix_mode_and_cwd() -> None:
@@ -182,3 +211,331 @@ def test_duplicates_section_keeps_dedup_apply_command() -> None:
 
     assert "- Preview: atuin history dedup --dry-run --before now --dupkeep 3" in lines
     assert "- Apply: atuin history dedup --before now --dupkeep 3" in lines
+
+
+def test_parse_cli_args_supports_cleanup_typos() -> None:
+    args = MODULE.parse_cli_args(
+        [
+            "cleanup-typos",
+            "--before",
+            "now",
+            "--max-typos",
+            "5",
+            "--backup-dir",
+            "/tmp/backup",
+        ]
+    )
+
+    assert args.command == "cleanup-typos"
+    assert args.before == "now"
+    assert args.max_typos == 5
+    assert args.backup_dir == "/tmp/backup"
+
+
+def test_cleanup_plan_uses_fast_path_for_unique_match() -> None:
+    typo_entry = make_entry(
+        "1",
+        offset_seconds=0,
+        exit_code=127,
+        command="mkdit test-ctx7",
+        cwd="/tmp/project",
+        session="session-1",
+    )
+    corrected_entry = make_entry(
+        "2",
+        offset_seconds=2,
+        exit_code=0,
+        command="mkdir test-ctx7",
+        cwd="/tmp/project",
+        session="session-1",
+    )
+
+    plan = MODULE.build_cleanup_plan(
+        [make_candidate(typo_entry, suggested_command=corrected_entry.command)],
+        [typo_entry, corrected_entry],
+    )
+
+    item = plan[0]
+    assert item["route"] == "fast"
+    assert item["match_ids"] == ["1"]
+    assert item["move_up"] == 0
+    assert item["command_parts"][:6] == [
+        "atuin",
+        "search",
+        "--delete",
+        "--filter-mode",
+        "global",
+        "--search-mode",
+    ]
+    assert "--cwd" in item["command_parts"]
+    assert "--exit" in item["command_parts"]
+
+
+def test_cleanup_plan_falls_back_to_interactive_for_prefix_collision() -> None:
+    typo_entry = make_entry(
+        "1",
+        offset_seconds=0,
+        exit_code=-1,
+        command="fishb",
+        cwd="unknown",
+        session="session-1",
+    )
+    colliding_entry = make_entry(
+        "2",
+        offset_seconds=0.5,
+        exit_code=-1,
+        command="fishbg",
+        cwd="unknown",
+        session="session-2",
+    )
+    corrected_entry = make_entry(
+        "3",
+        offset_seconds=1,
+        exit_code=0,
+        command="fish",
+        cwd="unknown",
+        session="session-1",
+    )
+
+    plan = MODULE.build_cleanup_plan(
+        [make_candidate(typo_entry, suggested_command=corrected_entry.command)],
+        [typo_entry, colliding_entry, corrected_entry],
+    )
+
+    item = plan[0]
+    assert item["route"] == "interactive"
+    assert item["match_ids"] == ["1", "2"]
+    assert item["move_up"] == 1
+    assert item["command_parts"][2:7] == [
+        "-i",
+        "--filter-mode",
+        "global",
+        "--search-mode",
+        "prefix",
+    ]
+
+
+def test_verify_cleanup_result_rejects_unexpected_removed_ids(tmp_path: Path) -> None:
+    snapshot_db = tmp_path / "history-before.db"
+    live_db = tmp_path / "history-live.db"
+    create_history_db(snapshot_db, ["1", "2", "3"])
+    create_history_db(live_db, ["3"])
+
+    with pytest.raises(MODULE.AuditError) as excinfo:
+        MODULE.verify_cleanup_result(
+            snapshot_db,
+            live_db,
+            target_ids=["1"],
+            post_audit={"typos": {"candidate_count": 0}},
+        )
+
+    assert "unexpected_removed_ids=['2']" in str(excinfo.value)
+
+
+def test_cleanup_typos_runs_transactional_flow(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    history_db = tmp_path / "history.db"
+    create_history_db(history_db, ["1", "2"])
+    backup_dir = tmp_path / "backup"
+
+    pre_audit = {
+        "db_path": str(history_db),
+        "typos": {
+            "candidate_count": 2,
+            "returned_count": 2,
+            "candidates": [
+                {
+                    "id": "1",
+                    "timestamp": "2026-01-01T00:00:00+00:00",
+                    "cwd": "unknown",
+                    "original_command": "cdoex",
+                    "previous_exit_code": 127,
+                },
+                {
+                    "id": "2",
+                    "timestamp": "2026-01-01T00:00:01+00:00",
+                    "cwd": "unknown",
+                    "original_command": "gbst",
+                    "previous_exit_code": 127,
+                },
+            ],
+        },
+    }
+    post_audit = {
+        "db_path": str(history_db),
+        "typos": {"candidate_count": 0, "returned_count": 0, "candidates": []},
+    }
+    audit_reports = [pre_audit, post_audit]
+
+    monkeypatch.setattr(
+        MODULE, "audit_history", lambda *args, **kwargs: audit_reports.pop(0)
+    )
+    monkeypatch.setattr(
+        MODULE,
+        "get_remote_sync_status",
+        lambda: {"address": "https://api.atuin.sh", "username": "narumi"},
+    )
+    monkeypatch.setattr(MODULE, "get_current_host_uuid", lambda: "host-uuid")
+    monkeypatch.setattr(
+        MODULE, "load_history_entries", lambda *args, **kwargs: ([], {})
+    )
+    monkeypatch.setattr(
+        MODULE,
+        "build_cleanup_plan",
+        lambda candidates, entries: [
+            {
+                "id": "1",
+                "route": "fast",
+                "command_parts": ["atuin", "search", "--delete", "cdoex"],
+            },
+            {
+                "id": "2",
+                "route": "interactive",
+                "command_parts": ["atuin", "search", "-i", "gbst"],
+            },
+        ],
+    )
+    monkeypatch.setattr(
+        MODULE,
+        "execute_cleanup_plan",
+        lambda plan: {"fast_count": 1, "interactive_count": 1},
+    )
+    monkeypatch.setattr(
+        MODULE,
+        "verify_cleanup_result",
+        lambda *args, **kwargs: {
+            "removed_ids": ["1", "2"],
+            "added_ids": [],
+            "target_ids": ["1", "2"],
+        },
+    )
+
+    commands: list[list[str]] = []
+
+    def fake_run(
+        parts: list[str], **kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        commands.append(parts)
+        return subprocess.CompletedProcess(parts, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(MODULE, "run_cli_command", fake_run)
+
+    result = MODULE.cleanup_typos(
+        None,
+        before="now",
+        typo_window_seconds=300,
+        max_typos=20,
+        backup_dir=str(backup_dir),
+    )
+
+    assert result["status"] == "success"
+    assert result["fast_count"] == 1
+    assert result["interactive_count"] == 1
+    assert commands == [
+        ["atuin", "store", "push", "--tag", "history", "--host", "host-uuid"],
+        ["atuin", "sync"],
+    ]
+    assert (backup_dir / "history.db.before").exists()
+    assert (backup_dir / "pre_audit.json").exists()
+    assert (backup_dir / "plan.json").exists()
+    assert (backup_dir / "post_verify.json").exists()
+
+
+def test_cleanup_typos_rolls_back_after_verification_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    history_db = tmp_path / "history.db"
+    create_history_db(history_db, ["1"])
+    backup_dir = tmp_path / "backup"
+
+    pre_audit = {
+        "db_path": str(history_db),
+        "typos": {
+            "candidate_count": 1,
+            "returned_count": 1,
+            "candidates": [
+                {
+                    "id": "1",
+                    "timestamp": "2026-01-01T00:00:00+00:00",
+                    "cwd": "unknown",
+                    "original_command": "cdoex",
+                    "previous_exit_code": 127,
+                },
+            ],
+        },
+    }
+    post_audit = {
+        "db_path": str(history_db),
+        "typos": {
+            "candidate_count": 1,
+            "returned_count": 1,
+            "candidates": pre_audit["typos"]["candidates"],
+        },
+    }
+    audit_reports = [pre_audit, post_audit]
+
+    monkeypatch.setattr(
+        MODULE, "audit_history", lambda *args, **kwargs: audit_reports.pop(0)
+    )
+    monkeypatch.setattr(
+        MODULE,
+        "get_remote_sync_status",
+        lambda: {"address": "https://api.atuin.sh", "username": "narumi"},
+    )
+    monkeypatch.setattr(MODULE, "get_current_host_uuid", lambda: "host-uuid")
+    monkeypatch.setattr(
+        MODULE, "load_history_entries", lambda *args, **kwargs: ([], {})
+    )
+    monkeypatch.setattr(
+        MODULE,
+        "build_cleanup_plan",
+        lambda candidates, entries: [
+            {
+                "id": "1",
+                "route": "fast",
+                "command_parts": ["atuin", "search", "--delete", "cdoex"],
+            },
+        ],
+    )
+    monkeypatch.setattr(
+        MODULE,
+        "execute_cleanup_plan",
+        lambda plan: {"fast_count": 1, "interactive_count": 0},
+    )
+    monkeypatch.setattr(
+        MODULE,
+        "verify_cleanup_result",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            MODULE.AuditError("verification failed")
+        ),
+    )
+    monkeypatch.setattr(
+        MODULE,
+        "run_cli_command",
+        lambda parts, **kwargs: subprocess.CompletedProcess(
+            parts, 0, stdout="", stderr=""
+        ),
+    )
+
+    rollback_calls: list[tuple[Path, Path]] = []
+
+    def fake_rollback(snapshot: Path, live: Path) -> list[str]:
+        rollback_calls.append((snapshot, live))
+        return []
+
+    monkeypatch.setattr(MODULE, "rollback_cleanup", fake_rollback)
+
+    with pytest.raises(MODULE.AuditError) as excinfo:
+        MODULE.cleanup_typos(
+            None,
+            before="now",
+            typo_window_seconds=300,
+            max_typos=20,
+            backup_dir=str(backup_dir),
+        )
+
+    assert "verification failed" in str(excinfo.value)
+    assert f"Backup dir: {backup_dir}" in str(excinfo.value)
+    assert rollback_calls == [(backup_dir / "history.db.before", history_db)]


### PR DESCRIPTION
## Summary
- add a `cleanup-typos` subcommand to `atuin_history_cleanup.py`
- add transactional helpers for snapshotting `history.db`, building a cleanup plan, executing deletions, verifying results, and rolling back on failure
- update the skill docs and Atuin CLI reference to explain the approved transactional typo-cleanup path and its guardrails
- expand tests to cover CLI parsing, fast-path vs interactive planning, verification, success flow, and rollback
- record the Atuin sandbox/log-path and SQLite backup gotchas in `MEMORY.md`

## Why
- `atuin search --delete` is query-wide, so typo cleanup needs a strict uniqueness gate before any automated delete
- raw file copies of a live SQLite database are not reliable when WAL state is involved
- the skill needed a safer automation path that can prove the deletion result and restore the database if verification fails

## Impact
- users can run typo cleanup with a database snapshot and persisted audit artifacts
- ambiguous matches still fall back to the interactive inspector instead of forcing automation
- remote sync is delayed until verification succeeds

## Validation
- `prek run -a`
- `uv run --with pytest python -m pytest skills/atuin-history-cleanup/tests/test_atuin_history_cleanup.py` (9 passed)
