### PR TITLE
[codex] add help-me skill

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,6 +1,7 @@
 ## GOTCHA
 
 - `skill-creator`'s `quick_validate.py` requires `PyYAML`; in this repo, `uv run --with pyyaml python /home/narumi/.codex/skills/.system/skill-creator/scripts/quick_validate.py <skill-dir>` is more reliable than plain `uv run python`.
+- `skill-creator`'s `init_skill.py` creates the target skill directory and `SKILL.md` before it validates `agents/openai.yaml` metadata, so a bad `--interface short_description` can leave a partially initialized skill directory behind.
 - In this sandbox, `~/.cache/uv` may be read-only; when running one-off `uv run --with ...` tools, set `UV_CACHE_DIR=/tmp/uv-cache` first for more reliable behavior.
 - In this sandbox, the first run of skill metadata tools like `uv run --with pyyaml` may still need temporary network access if the local cache does not already contain the package, so `uv` can fetch `PyYAML`.
 - Codex CLI is unreliable with symlinks when loading local skills; this repo's `just` install flow now uses copy/rm instead of `stow`.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ If Codex does not pick up a local skill change, restart Codex and try again.
 
 ### Workflow And Repository Maintenance
 
+- `help-me`: deciding whether to check `--help`, built-in `help`, or `man` before running a shell or CLI command.
 - `git-commit`: reviewing diffs, choosing commit types, and writing focused Conventional Commits.
 - `agents-writer`: creating or updating `AGENTS.md` guidance for this repository.
 - `codex-cli-hooks`: designing or debugging Codex CLI hooks and `hooks.json` behavior.

--- a/skills/help-me/SKILL.md
+++ b/skills/help-me/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: help-me
+description: Decide when to check command help before running shell or CLI commands. Use when Codex is about to execute a command and must judge whether it already understands the exact command form, flags, subcommands, or help path well enough to proceed, or should first consult `--help`, built-in `help`, `man`, or shell `help`.
+---
+
+# Help Me
+
+## Overview
+
+Decide whether you know the exact command form well enough to run it. Keep the rule simple: if you can explain it clearly, run it; if you cannot, check help first.
+
+## Decision Tree
+
+1. Ask whether you are familiar with the exact command form you are about to run, not only the base command name.
+2. Treat it as familiar only if you can explain:
+   - what it will do
+   - what target, path, or object it will touch
+   - what the important flags or subcommands change
+3. Run it directly if you can answer those questions clearly.
+4. Check help first if you cannot.
+5. Use this order:
+   - `<cmd> --help`
+   - `<cmd> <subcommand> --help`
+   - the tool's built-in `help` form
+   - `man <cmd>`
+   - `type <cmd>` or `command -v <cmd>` when the help path is unclear; if it is a shell builtin, use shell `help`
+
+Do not use a hard whitelist. Judge familiarity on the exact command you are about to run.
+
+## Examples
+
+- Run directly when familiar: `pwd`, `ls src`, `git status`
+- Check first when unfamiliar: `find ... -exec ...`, `git rebase --rebase-merges`, `docker run ... --filter ...`
+- Resolve builtins explicitly: if unsure about `cd` or `export`, run `type cd` and then `help cd`


### PR DESCRIPTION
## Summary
- add a new `help-me` skill with a minimal decision tree for when to check command help before running shell or CLI commands
- list `help-me` in the repository skill guide
- record the `init_skill.py` partial-initialization gotcha discovered while creating the skill

## Why
The repo did not have a small, generic skill for deciding when to consult `--help`, built-in `help`, or `man` before running a command. This adds that guidance in a single-file skill that stays intentionally short.

## Impact
Codex can now explicitly invoke `$help-me` for shell or CLI work when command familiarity is uncertain, without loading a larger command-reference skill.

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run --with pyyaml python /home/narumi/.codex/skills/.system/skill-creator/scripts/quick_validate.py /home/narumi/workspace/skills/skills/help-me`
