### PR TITLE
ci: add version bump workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,56 @@
+name: bump-version
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: Version segment to bump from the latest major.minor.patch tag
+        required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+concurrency: bump-version
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          token: ${{ env.PAT_TOKEN || github.token }}
+
+      - name: Bump version tag
+        id: version
+        shell: bash
+        run: scripts/bump-version.sh "${{ inputs.bump }}"
+
+      - name: Create and push tag
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -n "${PAT_TOKEN}" ]]; then
+            git remote set-url origin "https://x-access-token:${PAT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          fi
+
+          git push origin "refs/tags/${{ steps.version.outputs.next_version }}"
+
+      - name: Write summary
+        run: |
+          {
+            echo "## Version bumped"
+            echo
+            echo "- Previous tag: \`${{ steps.version.outputs.latest_version }}\`"
+            echo "- New tag: \`${{ steps.version.outputs.next_version }}\`"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/justfile
+++ b/justfile
@@ -25,3 +25,7 @@ clean-all:
 clean skill:
     test -d skills/{{ skill }}
     if [ -e "{{ target }}/{{ skill }}" ] || [ -L "{{ target }}/{{ skill }}" ]; then rm -rf "{{ target }}/{{ skill }}"; else echo "skip clean: {{ target }}/{{ skill }} does not exist"; fi
+
+# Create the next semantic version tag from the latest major.minor.patch tag.
+bump-version bump="patch":
+    scripts/bump-version.sh {{ bump }}

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/bump-version.sh <major|minor|patch>
+
+Reads the latest git tag matching major.minor.patch, bumps the requested
+segment, and creates a new lightweight git tag named <major.minor.patch>.
+
+If no matching tag exists, starts from 0.0.0.
+USAGE
+}
+
+if [[ $# -ne 1 ]]; then
+  usage >&2
+  exit 2
+fi
+
+bump="$1"
+
+case "${bump}" in
+  major | minor | patch) ;;
+  *)
+    echo "Unsupported bump: ${bump}" >&2
+    usage >&2
+    exit 2
+    ;;
+esac
+
+git fetch --tags --force
+
+latest_version="$({
+  git tag --list '[0-9]*.[0-9]*.[0-9]*' --sort=v:refname \
+    | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+    | tail -n 1
+} || true)"
+
+if [[ -z "${latest_version}" ]]; then
+  latest_version="0.0.0"
+fi
+
+IFS=. read -r major minor patch <<< "${latest_version}"
+
+case "${bump}" in
+  major)
+    major=$((major + 1))
+    minor=0
+    patch=0
+    ;;
+  minor)
+    minor=$((minor + 1))
+    patch=0
+    ;;
+  patch)
+    patch=$((patch + 1))
+    ;;
+esac
+
+next_version="${major}.${minor}.${patch}"
+
+if git rev-parse -q --verify "refs/tags/${next_version}" >/dev/null; then
+  echo "Tag ${next_version} already exists" >&2
+  exit 1
+fi
+
+git tag "${next_version}"
+
+echo "latest_version=${latest_version}"
+echo "next_version=${next_version}"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    echo "latest_version=${latest_version}"
+    echo "next_version=${next_version}"
+  } >> "${GITHUB_OUTPUT}"
+fi


### PR DESCRIPTION
## Summary
- add a manual GitHub Actions workflow to bump semantic version tags
- move bump calculation/tag creation into scripts/bump-version.sh for local and CI reuse
- add a just bump-version entrypoint for local usage
- use PAT_TOKEN when available for checkout and tag push

## Verification
- bash -n scripts/bump-version.sh
- just --list
- prek run --files .github/workflows/bump-version.yml scripts/bump-version.sh justfile