### PR TITLE
docs(slides): add project overview deck

### DIFF
--- a/examples/slides/README.md
+++ b/examples/slides/README.md
@@ -1,0 +1,3 @@
+# Reusable Agent Skills
+
+[GitHub Pages](https://narumiruna.github.io/skills/slides/skills-project.html)

--- a/examples/slides/assets/skill-lifecycle.svg
+++ b/examples/slides/assets/skill-lifecycle.svg
@@ -1,0 +1,63 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1040" height="560" viewBox="0 0 1040 560" role="img" aria-labelledby="title desc">
+  <title id="title">Skill lifecycle</title>
+  <desc id="desc">A skill moves from authoring through installation, invocation, execution, feedback, and refinement.</desc>
+  <defs>
+    <filter id="shadow-sm" x="-10%" y="-10%" width="120%" height="120%">
+      <feDropShadow dx="0" dy="6" stdDeviation="8" flood-color="#1F2937" flood-opacity="0.12"/>
+    </filter>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L10,3 L0,6 Z" fill="#2563EB"/>
+    </marker>
+  </defs>
+
+  <rect x="0" y="0" width="1040" height="560" rx="24" fill="#F7FAFC"/>
+
+  <g font-family="Inter, Arial, sans-serif">
+    <text x="520" y="64" text-anchor="middle" font-size="34" font-weight="700" fill="#1F2937">From repo change to agent behavior</text>
+    <text x="520" y="98" text-anchor="middle" font-size="18" fill="#64748B">copy-based local installs make iteration safe and repeatable</text>
+
+    <g fill="none" stroke="#2563EB" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrow)">
+      <path d="M276 205 C340 150, 456 140, 512 175"/>
+      <path d="M644 208 C724 180, 804 206, 838 272"/>
+      <path d="M820 388 C756 454, 640 468, 548 438"/>
+      <path d="M390 414 C310 438, 214 402, 192 314"/>
+    </g>
+
+    <g font-size="18" fill="#1F2937">
+      <g>
+        <rect x="88" y="168" width="212" height="112" rx="16" fill="#FFFFFF" stroke="#2563EB" stroke-width="3" filter="url(#shadow-sm)"/>
+        <text x="194" y="208" text-anchor="middle" font-size="24" font-weight="700">Author</text>
+        <text x="194" y="238" text-anchor="middle" fill="#64748B">write SKILL.md</text>
+        <text x="194" y="263" text-anchor="middle" fill="#64748B">add references</text>
+      </g>
+
+      <g>
+        <rect x="414" y="144" width="212" height="112" rx="16" fill="#EFF6FF" stroke="#2563EB" stroke-width="3" filter="url(#shadow-sm)"/>
+        <text x="520" y="184" text-anchor="middle" font-size="24" font-weight="700">Install</text>
+        <text x="520" y="214" text-anchor="middle" fill="#64748B">just install-all</text>
+        <text x="520" y="239" text-anchor="middle" fill="#64748B">or npx skills add</text>
+      </g>
+
+      <g>
+        <rect x="740" y="256" width="212" height="112" rx="16" fill="#F0FDFA" stroke="#0F766E" stroke-width="3" filter="url(#shadow-sm)"/>
+        <text x="846" y="296" text-anchor="middle" font-size="24" font-weight="700">Invoke</text>
+        <text x="846" y="326" text-anchor="middle" fill="#64748B">/skills</text>
+        <text x="846" y="351" text-anchor="middle" fill="#64748B">$python, $imrad</text>
+      </g>
+
+      <g>
+        <rect x="414" y="384" width="212" height="112" rx="16" fill="#FFFBEB" stroke="#F59E0B" stroke-width="3" filter="url(#shadow-sm)"/>
+        <text x="520" y="424" text-anchor="middle" font-size="24" font-weight="700">Validate</text>
+        <text x="520" y="454" text-anchor="middle" fill="#64748B">prek run -a</text>
+        <text x="520" y="479" text-anchor="middle" fill="#64748B">render slides</text>
+      </g>
+
+      <g>
+        <rect x="88" y="304" width="212" height="112" rx="16" fill="#F8FAFC" stroke="#64748B" stroke-width="3" filter="url(#shadow-sm)"/>
+        <text x="194" y="344" text-anchor="middle" font-size="24" font-weight="700">Refine</text>
+        <text x="194" y="374" text-anchor="middle" fill="#64748B">capture gotchas</text>
+        <text x="194" y="399" text-anchor="middle" fill="#64748B">tighten routing</text>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/examples/slides/assets/system-map.svg
+++ b/examples/slides/assets/system-map.svg
@@ -1,0 +1,55 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540" role="img" aria-labelledby="title desc">
+  <title id="title">Skills repository system map</title>
+  <desc id="desc">A repository of skill directories routes into focused task skills for Codex and other agents.</desc>
+  <defs>
+    <filter id="shadow-sm" x="-10%" y="-10%" width="120%" height="120%">
+      <feDropShadow dx="0" dy="6" stdDeviation="8" flood-color="#1F2937" flood-opacity="0.12"/>
+    </filter>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L10,3 L0,6 Z" fill="#2563EB"/>
+    </marker>
+  </defs>
+
+  <rect x="0" y="0" width="960" height="540" rx="24" fill="#F7FAFC"/>
+
+  <g font-family="Inter, Arial, sans-serif">
+    <rect x="56" y="64" width="240" height="412" rx="16" fill="#FFFFFF" stroke="#2563EB" stroke-width="3" filter="url(#shadow-sm)"/>
+    <text x="176" y="112" text-anchor="middle" font-size="28" font-weight="700" fill="#1F2937">skills/</text>
+    <text x="176" y="148" text-anchor="middle" font-size="17" fill="#64748B">one directory per capability</text>
+
+    <g font-size="19" font-weight="600" fill="#1F2937">
+      <rect x="88" y="190" width="176" height="50" rx="12" fill="#EFF6FF" stroke="#2563EB" stroke-width="3"/>
+      <text x="176" y="222" text-anchor="middle">SKILL.md</text>
+      <rect x="88" y="260" width="176" height="50" rx="12" fill="#F0FDFA" stroke="#0F766E" stroke-width="3"/>
+      <text x="176" y="292" text-anchor="middle">references/</text>
+      <rect x="88" y="330" width="176" height="50" rx="12" fill="#FFFBEB" stroke="#F59E0B" stroke-width="3"/>
+      <text x="176" y="362" text-anchor="middle">scripts/</text>
+      <rect x="88" y="400" width="176" height="50" rx="12" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="3"/>
+      <text x="176" y="432" text-anchor="middle">assets/</text>
+    </g>
+
+    <line x1="314" y1="270" x2="418" y2="270" stroke="#2563EB" stroke-width="3" stroke-linecap="round" marker-end="url(#arrow)"/>
+
+    <rect x="432" y="84" width="464" height="372" rx="16" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="3" filter="url(#shadow-sm)"/>
+    <text x="664" y="132" text-anchor="middle" font-size="28" font-weight="700" fill="#1F2937">task-routed expertise</text>
+    <text x="664" y="168" text-anchor="middle" font-size="17" fill="#64748B">small, explicit instructions loaded only when useful</text>
+
+    <g font-size="20" font-weight="700" fill="#1F2937">
+      <rect x="472" y="214" width="176" height="72" rx="16" fill="#EFF6FF" stroke="#2563EB" stroke-width="3"/>
+      <text x="560" y="244" text-anchor="middle">Python</text>
+      <text x="560" y="269" text-anchor="middle" font-size="15" font-weight="400" fill="#64748B">uv, CLI, ORM</text>
+
+      <rect x="680" y="214" width="176" height="72" rx="16" fill="#F0FDFA" stroke="#0F766E" stroke-width="3"/>
+      <text x="768" y="244" text-anchor="middle">Slides</text>
+      <text x="768" y="269" text-anchor="middle" font-size="15" font-weight="400" fill="#64748B">Marp, SVG, color</text>
+
+      <rect x="472" y="318" width="176" height="72" rx="16" fill="#FFFBEB" stroke="#F59E0B" stroke-width="3"/>
+      <text x="560" y="348" text-anchor="middle">Research</text>
+      <text x="560" y="373" text-anchor="middle" font-size="15" font-weight="400" fill="#64748B">IMRaD, gourmet</text>
+
+      <rect x="680" y="318" width="176" height="72" rx="16" fill="#F8FAFC" stroke="#64748B" stroke-width="3"/>
+      <text x="768" y="348" text-anchor="middle">Workflow</text>
+      <text x="768" y="373" text-anchor="middle" font-size="15" font-weight="400" fill="#64748B">commits, hooks</text>
+    </g>
+  </g>
+</svg>

--- a/examples/slides/skills-project.md
+++ b/examples/slides/skills-project.md
@@ -1,0 +1,255 @@
+---
+marp: true
+theme: default
+paginate: true
+backgroundColor: #F7FAFC
+color: #1F2937
+---
+
+<style>
+section {
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  padding: 64px;
+  background: #F7FAFC;
+  color: #1F2937;
+}
+section.lead {
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+h1 {
+  color: #2563EB;
+  font-size: 56px;
+  line-height: 1.05;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+}
+h2 {
+  color: #2563EB;
+  font-size: 42px;
+  line-height: 1.12;
+  font-weight: 760;
+  letter-spacing: -0.02em;
+}
+h3 {
+  color: #0F766E;
+  font-size: 27px;
+  font-weight: 720;
+}
+p, li {
+  font-size: 27px;
+  line-height: 1.35;
+}
+strong {
+  color: #0F766E;
+}
+code {
+  color: #1F2937;
+  background: #E2E8F0;
+  border-radius: 8px;
+  padding: 0 0.18em;
+}
+pre {
+  background: #FFFFFF;
+  border: 2px solid #CBD5E1;
+  border-radius: 16px;
+  padding: 24px;
+  filter: drop-shadow(0 6px 8px rgba(31, 41, 55, 0.10));
+}
+pre code {
+  background: transparent;
+  padding: 0;
+  font-size: 22px;
+}
+table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 12px;
+  font-size: 22px;
+}
+th {
+  color: #2563EB;
+  font-weight: 760;
+}
+td, th {
+  background: #FFFFFF;
+  border: 2px solid #CBD5E1;
+  border-radius: 16px;
+  padding: 18px 20px;
+  vertical-align: top;
+}
+blockquote {
+  border-left: 8px solid #F59E0B;
+  margin-left: 0;
+  padding-left: 28px;
+  color: #1F2937;
+}
+section::after {
+  color: #64748B;
+  font-weight: 650;
+}
+</style>
+
+<!-- _class: lead -->
+<!-- _paginate: false -->
+<!-- _backgroundColor: #EFF6FF -->
+
+# Reusable Agent Skills
+
+**A compact playbook repository for making AI coding agents more predictable.**
+
+`narumiruna/skills` · Codex-first workflows · Marp example deck
+
+---
+
+## The problem: prompts do not scale by themselves
+
+- Teams repeat the same instructions across conversations.
+- Good practices get buried in ad hoc chat history.
+- Agents need **task-specific context**, not a giant universal prompt.
+- Maintainers need a reviewable way to update agent behavior.
+
+> This repository turns recurring know-how into small, installable skills.
+
+---
+
+![bg right:48% fit](assets/system-map.svg)
+
+## Project shape
+
+**Repository contract**
+
+- `skills/<skill-name>/SKILL.md` is the required entry point.
+- Optional support files stay beside the skill: `references/`, `scripts/`, `assets/`, `agents/`.
+- `README.md` explains external use and discovery.
+- `AGENTS.md` keeps maintainer workflow separate.
+
+---
+
+## What a skill gives the agent
+
+| Layer | Purpose | Example |
+|---|---|---|
+| **Routing metadata** | Decide when to load the skill | `description:` in frontmatter |
+| **Core posture** | Non-negotiable behavior | preview-first cleanup, uv-first Python |
+| **Workflow** | Repeatable task steps | inspect diff → boundary → commit title |
+| **References** | Deeper rules on demand | Marp syntax, color strategy, CLI notes |
+
+---
+
+## The collection is organized by job-to-be-done
+
+| Area | Skills |
+|---|---|
+| **Python** | `python`, `python-typer`, `python-logging`, `python-peewee` |
+| **Writing and research** | `imrad`, `gourmet-research` |
+| **Slides and visuals** | `slide-creator`, `marp-authoring`, `slide-color-design`, `svg-illustration`, `mermaid-creator` |
+| **Workflow maintenance** | `help-me`, `git-commit`, `codex-cli-hooks`, `agents-writer`, `work-log-writer` |
+
+---
+
+## Installation paths
+
+Use the hosted collection when you just want the skills:
+
+```shell
+npx skills add narumiruna/skills
+```
+
+Use local copy-based installs while editing this repository:
+
+```shell
+just install-all
+just install python
+just clean python
+```
+
+`just` by itself is intentionally non-mutating.
+
+---
+
+<!-- _class: lead -->
+<!-- _backgroundColor: #2563EB -->
+<!-- _color: #F7FAFC -->
+
+# Design principle
+
+Load the smallest useful instruction set, then follow links only when the task needs more detail.
+
+---
+
+## Why the skills stay small
+
+- **Faster routing:** descriptions name concrete trigger conditions.
+- **Lower context cost:** entry skills point to focused references.
+- **Safer changes:** behavior lives in files that can be reviewed.
+- **Better reuse:** supporting scripts and examples stay versioned with the skill.
+
+This is especially visible in the slide toolkit: colors, Marp authoring, and SVG rules are separate modules.
+
+---
+
+![bg left:55% fit](assets/skill-lifecycle.svg)
+
+## Maintainer loop
+
+1. Author or refine a skill in `skills/<name>/`.
+2. Install locally with `just install <name>` or `just install-all`.
+3. Exercise the behavior through Codex using `/skills` or `$skill-name`.
+4. Validate repository changes with `prek run -a`.
+5. Rebuild slide outputs after changing `examples/slides/`.
+
+---
+
+## Boundaries keep the repository easy to review
+
+| File | Owns | Avoid duplicating |
+|---|---|---|
+| `README.md` | install flows, external positioning, skill discovery | maintainer-only process detail |
+| `AGENTS.md` | contributor workflow and repo editing rules | product messaging |
+| `justfile` | executable install and clean recipes | undocumented side paths |
+| `examples/` | slide decks and visual examples | skill source text |
+
+---
+
+## Example: the slide skills compose cleanly
+
+1. `slide-color-design` defines the 7-role palette.
+2. `marp-authoring` writes valid Marpit Markdown.
+3. `svg-illustration` keeps diagrams consistent and validated.
+4. `slide-creator` ties the modules together for full decks.
+
+**Result:** one color system, one spacing rhythm, and SVG assets that embed reliably with `bg fit`.
+
+---
+
+<!-- _class: lead -->
+<!-- _backgroundColor: #0F766E -->
+<!-- _color: #F7FAFC -->
+
+# Takeaway
+
+Reusable skills are versioned operating procedures for agents.
+
+They make expertise explicit, reviewable, installable, and easier to improve.
+
+---
+
+## Try it
+
+```shell
+npx skills add narumiruna/skills
+```
+
+Then in Codex:
+
+```text
+/skills
+$python
+$slide-creator
+$git-commit
+```
+
+**Start with the task. Let the matching skill load the context.**


### PR DESCRIPTION
## Summary
- Add a Marp project overview deck for the reusable agent skills repository.
- Add two SVG diagrams for the repository system map and skill lifecycle.
- Add a slides README link for the GitHub Pages output.

## Affected paths
- `examples/slides/README.md`
- `examples/slides/skills-project.md`
- `examples/slides/assets/system-map.svg`
- `examples/slides/assets/skill-lifecycle.svg`

## Verification
- `svglint examples/slides/assets/system-map.svg examples/slides/assets/skill-lifecycle.svg`
- `marp examples/slides/skills-project.md -o /tmp/skills-project.html`
- `marp -I examples/slides -o /tmp/skills-slides-build`
- `prek run -a`