### PR TITLE
docs(writing-plans): date-prefix plan filenames

### DIFF
--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -18,11 +18,11 @@ Write plans that help an agent or engineer act, verify progress, and expose unce
 
 ## File Output
 
-When saving a plan to the repository, use `./docs/plans/` by default unless the user specifies another path. Name plan files with a lowercase kebab-case stem ending in `-plan.md`, for example `auth-migration-plan.md` or `checkout-refactor-plan.md`.
+When saving a plan to the repository, use `./docs/plans/` by default unless the user specifies another path. Name plan files as `YYYY-MM-DD_<topic>-plan.md`, where `<topic>` is a lowercase kebab-case stem, for example `2026-05-10_auth-migration-plan.md` or `2026-05-10_checkout-refactor-plan.md`.
 
 Create `./docs/plans/` if it does not exist. Do not save a plan file unless the user asks to write, create, draft into a file, or otherwise persist the plan.
 
-When archiving a completed plan, use `./docs/plans/archived/<topic>-plan.md`. Never archive, move, or rename a plan automatically. If a plan appears complete, report the completion evidence and ask the user whether to archive it.
+When archiving a completed plan, use `./docs/plans/archived/YYYY-MM-DD_<topic>-plan.md`. Never archive, move, or rename a plan automatically. If a plan appears complete, report the completion evidence and ask the user whether to archive it.
 
 ## Output Shape
 


### PR DESCRIPTION
## Summary
- Change saved plan filename guidance to use `YYYY-MM-DD_<topic>-plan.md`
- Update archived plan path guidance to match the new naming convention

## Verification
- `rg -n "YYYY-MM-DD_<topic>-plan|2026-05-10_" skills/writing-plans/SKILL.md`
- pre-commit hooks passed during commit
