### PR TITLE
docs(git-commit): forbid AI attribution trailers in commits and PRs

### DIFF
--- a/skills/git-commit/SKILL.md
+++ b/skills/git-commit/SKILL.md
@@ -32,6 +32,7 @@ Read `references/conventional-commits.md` when the type is ambiguous, when you n
 - Prefer multiple commits over one vague summary when the diff contains unrelated work.
 - If the user asks for validation, check both the structure and whether the wording matches the inspected diff.
 - Follow repo git rules for staging and commit structure; this skill focuses on mapping the diff to the right message.
+- Do not add, preserve, or generate any AI attribution trailers in commits, PRs, or messages, including `Co-authored-by`, `Generated-by`, `Created-by`, `Coding-Agent`, model names, tool names, or agent attribution footers.
 
 ## Reference
 


### PR DESCRIPTION
## Summary

Add a Decision Rule to the `git-commit` skill that forbids AI attribution trailers in commits, PRs, and messages (e.g. `Co-authored-by`, `Generated-by`, `Created-by`, `Coding-Agent`, model names, tool names, agent footers). Mirrors the existing global rule in `~/.pi/agent/AGENTS.md` so the skill stays consistent when used standalone.

## Affected paths

- `skills/git-commit/SKILL.md`

## Verification

- `prek run -a` (ran via pre-commit hook on commit): all applicable hooks passed; YAML/JSON/svglint/ruff skipped (no matching files).
- `git diff origin/main -- skills/git-commit/SKILL.md`: single-line addition under Decision Rules.