### PR TITLE
feat(memory-md): add repository memory skill

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -13,3 +13,4 @@
 
 ## TASTE
 - `git-commit` should rely on the repo-level `AGENTS.md` for the Git baseline; `SKILL.md` should keep only the flow and judgment from diff to commit message, while less common Conventional Commits details belong in `references/`.
+- `memory-md` should stay a thin repo-memory decision and editing guide; keep `SKILL.md` focused on when to read/update `MEMORY.md` and the required `GOTCHA` / `TASTE` shape.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -13,4 +13,4 @@
 
 ## TASTE
 - `git-commit` should rely on the repo-level `AGENTS.md` for the Git baseline; `SKILL.md` should keep only the flow and judgment from diff to commit message, while less common Conventional Commits details belong in `references/`.
-- `memory-md` should stay a thin repo-memory decision and editing guide; keep `SKILL.md` focused on when to read/update `MEMORY.md` and the required `GOTCHA` / `TASTE` shape.
+- `memory-md` should trigger at the start of repository conversations, record repeatable mistakes as `GOTCHA`, correct wrong or stale memory entries in place, and store durable user preferences under `TASTE`.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ If Codex does not pick up a local skill change, restart Codex and try again.
 
 - `help-me`: deciding whether to check `--help`, built-in `help`, or `man` before running a shell or CLI command.
 - `git-commit`: reviewing diffs, choosing commit types, and writing focused Conventional Commits.
+- `memory-md`: deciding when to read or update repository `MEMORY.md` files and keeping `GOTCHA` / `TASTE` entries concise.
 - `work-log-writer`: explicitly invoked only; writing concise work logs from repository evidence.
 - `writing-agents-md`: creating or updating `AGENTS.md` guidance for this repository.
 - `codex-cli-hooks`: designing or debugging Codex CLI hooks and `hooks.json` behavior.

--- a/examples/slides/skills-project.md
+++ b/examples/slides/skills-project.md
@@ -146,7 +146,7 @@ section::after {
 | **Python** | `python`, `python-typer`, `python-logging`, `python-peewee` |
 | **Writing and research** | `imrad`, `gourmet-research` |
 | **Slides and visuals** | `slide-creator`, `marp-authoring`, `slide-color-design`, `svg-illustration`, `mermaid-creator` |
-| **Workflow maintenance** | `help-me`, `git-commit`, `codex-cli-hooks`, `writing-agents-md`, `work-log-writer` |
+| **Workflow maintenance** | `help-me`, `git-commit`, `memory-md`, `codex-cli-hooks`, `writing-agents-md`, `work-log-writer` |
 
 ---
 

--- a/skills/memory-md/SKILL.md
+++ b/skills/memory-md/SKILL.md
@@ -19,6 +19,7 @@ Use `MEMORY.md` as a concise repository-local memory file. It is not automatical
 - Add or revise an entry after a mistake, discovery, or user preference when it will help avoid repeating the same issue.
 - If an existing `MEMORY.md` entry is wrong, stale, or contradicted by current evidence, correct that entry instead of adding a conflicting note.
 - Keep entries short, reusable, and grounded in the current repo.
+- Never store secrets or sensitive data in `MEMORY.md`. This includes credentials, tokens, API keys, cookies, private URLs or endpoints, proprietary/internal-only details that should not be committed, and sensitive personal data. When a gotcha or preference involves such material, record only the minimal sanitized lesson, not the secret or identifying detail itself.
 - Do not add task logs, transient status, broad summaries, or speculative plans.
 
 ## Required Shape

--- a/skills/memory-md/SKILL.md
+++ b/skills/memory-md/SKILL.md
@@ -1,21 +1,23 @@
 ---
 name: memory-md
-description: Use when creating, reviewing, updating, or deciding whether to consult a repository MEMORY.md file. Use when the user mentions MEMORY.md, asks to record a durable gotcha or taste preference, or when non-trivial debugging/design work may depend on prior repo context.
+description: Use at the start of repository conversations to check whether MEMORY.md should guide the work, and use whenever creating, reviewing, or updating repository MEMORY.md files. Use when the user mentions MEMORY.md, asks to record a gotcha or preference, when an error should be remembered to avoid repeating it, or when existing MEMORY.md content may be wrong and needs correction.
 ---
 
 # MEMORY.md
 
-Use `MEMORY.md` as a concise repository-local memory file. It is not automatically loaded, so check for it explicitly when prior project context may matter.
+Use `MEMORY.md` as a concise repository-local memory file. It is not automatically loaded, so check for it explicitly at the start of repository conversations and whenever prior project context may matter.
 
 ## When To Read
 
-- Check whether `MEMORY.md` exists before non-trivial debugging, design work, workflow changes, or skill maintenance where past project choices may affect the answer.
+- At the start of a repository conversation, check whether `MEMORY.md` exists and skim it for relevant context before planning or editing.
+- Check it again before non-trivial debugging, design work, workflow changes, or skill maintenance where past project choices may affect the answer.
 - Treat a missing `MEMORY.md` as normal. Do not invent entries or assume the file exists.
 - Use current repository evidence as the source of truth when memory and files disagree.
 
 ## When To Update
 
-- Add an entry after a non-trivial error, discovery, or user preference only when it will help future work.
+- Add or revise an entry after a mistake, discovery, or user preference when it will help avoid repeating the same issue.
+- If an existing `MEMORY.md` entry is wrong, stale, or contradicted by current evidence, correct that entry instead of adding a conflicting note.
 - Keep entries short, reusable, and grounded in the current repo.
 - Do not add task logs, transient status, broad summaries, or speculative plans.
 

--- a/skills/memory-md/SKILL.md
+++ b/skills/memory-md/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: memory-md
+description: Use when creating, reviewing, updating, or deciding whether to consult a repository MEMORY.md file. Use when the user mentions MEMORY.md, asks to record a durable gotcha or taste preference, or when non-trivial debugging/design work may depend on prior repo context.
+---
+
+# MEMORY.md
+
+Use `MEMORY.md` as a concise repository-local memory file. It is not automatically loaded, so check for it explicitly when prior project context may matter.
+
+## When To Read
+
+- Check whether `MEMORY.md` exists before non-trivial debugging, design work, workflow changes, or skill maintenance where past project choices may affect the answer.
+- Treat a missing `MEMORY.md` as normal. Do not invent entries or assume the file exists.
+- Use current repository evidence as the source of truth when memory and files disagree.
+
+## When To Update
+
+- Add an entry after a non-trivial error, discovery, or user preference only when it will help future work.
+- Keep entries short, reusable, and grounded in the current repo.
+- Do not add task logs, transient status, broad summaries, or speculative plans.
+
+## Required Shape
+
+- Keep exactly these top-level sections: `## GOTCHA` and `## TASTE`.
+- Use `## GOTCHA` for traps, failure modes, commands that behave unexpectedly, and verified recovery steps.
+- Use `## TASTE` for durable project or user preferences that shape future edits.
+- Prefer one concise bullet per entry. If a similar entry already exists, revise it instead of adding a duplicate.
+
+## Entry Pattern
+
+For gotchas, capture the failure and the fix:
+
+```markdown
+- Symptom: <what went wrong>. Cause: <why>. Fix: <specific future action>.
+```
+
+For taste, capture the preference and its practical effect:
+
+```markdown
+- Prefer <choice> when <context>; avoid <alternative> because <reason>.
+```

--- a/skills/memory-md/SKILL.md
+++ b/skills/memory-md/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memory-md
-description: Use at the start of repository conversations to check whether MEMORY.md should guide the work, and use whenever creating, reviewing, or updating repository MEMORY.md files. Use when the user mentions MEMORY.md, asks to record a gotcha or preference, when an error should be remembered to avoid repeating it, or when existing MEMORY.md content may be wrong and needs correction.
+description: Maintains concise repository MEMORY.md notes for gotchas, stale memory corrections, and durable user preferences. Use at the start of repository conversations, when the user mentions MEMORY.md, when an error should be remembered to avoid repeating it, or when MEMORY.md content may be wrong.
 ---
 
 # MEMORY.md
@@ -41,3 +41,9 @@ For taste, capture the preference and its practical effect:
 ```markdown
 - Prefer <choice> when <context>; avoid <alternative> because <reason>.
 ```
+
+## Examples
+
+- `GOTCHA`: command failed because a tool needed `UV_CACHE_DIR=/tmp/uv-cache`; record the symptom, cause, and future command pattern.
+- `TASTE`: the user prefers thin skills with only `SKILL.md` unless supporting files solve a concrete problem.
+- Do not record: "finished PR #12" or "ran tests today." Those are task logs, not reusable memory.

--- a/skills/memory-md/agents/openai.yaml
+++ b/skills/memory-md/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "MEMORY.md Keeper"
   short_description: "Maintain concise repository MEMORY.md notes."
-  default_prompt: "Use $memory-md to decide whether to read or update repository MEMORY.md, and keep entries concise under GOTCHA or TASTE."
+  default_prompt: "Use $memory-md to check repository MEMORY.md at conversation start, record repeatable mistakes as GOTCHA, and keep durable preferences under TASTE."

--- a/skills/memory-md/agents/openai.yaml
+++ b/skills/memory-md/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "MEMORY.md Keeper"
+  short_description: "Maintain concise repository MEMORY.md notes."
+  default_prompt: "Use $memory-md to decide whether to read or update repository MEMORY.md, and keep entries concise under GOTCHA or TASTE."


### PR DESCRIPTION
## Summary
- add the `memory-md` skill for repository memory guidance
- add OpenAI metadata for discovery
- update README, slide discovery, and repo MEMORY.md

## Verification
- `quick_validate.py skills/memory-md` with `UV_CACHE_DIR=/tmp/uv-cache`
- OpenAI metadata PyYAML parse and field check
- `marp -I examples/slides -o build/slides`
- `prek run -a`