### PR TITLE
docs(python): prefer explicit tests target for pytest

### DIFF
--- a/skills/python/SKILL.md
+++ b/skills/python/SKILL.md
@@ -23,7 +23,7 @@ Use uv as the default workflow for Python projects, standalone scripts, dependen
 2. For a brand-new project, run `uv init <name>`, then install the default dev toolchain with `uv add --dev ruff ty pytest pytest-cov`.
 3. Use pytest as the default test framework for new projects: function-based `tests/test_*.py` files with plain `assert`.
 4. Add dependencies with `uv add`; remove them with `uv remove`; reconcile external dependency changes with `uv sync`.
-5. Run project Python, tests, and tools through `uv run` unless the repository provides a documented wrapper command.
+5. Run project Python, tests, and tools through `uv run` unless the repository provides a documented wrapper command; for pytest, default to an explicit `tests` target when the project does not document another test location.
 6. Run the repository quality gate before finalizing dependency or code changes.
 
 ## Standalone Script Workflow
@@ -39,7 +39,7 @@ Use uv as the default workflow for Python projects, standalone scripts, dependen
 ## Non-Negotiable Rules
 
 - Manage dependencies with `uv add`, `uv remove`, and `uv sync`; do not use `pip install` to mutate a project environment.
-- Run Python, pytest, scripts, and Python tools with `uv run` unless a repository command wraps them.
+- Run Python, pytest, scripts, and Python tools with `uv run` unless a repository command wraps them; when no project-specific pytest target is documented, include `tests` explicitly (for example, `uv run pytest tests`) rather than bare `uv run pytest`.
 - Follow existing repository choices; do not migrate test frameworks, hook runners, or tool configuration unless asked.
 - For a brand-new project, immediately add `ruff`, `ty`, `pytest`, and `pytest-cov`; do not start with `unittest`, `unittest.TestCase`, or class-based `Test*` suites.
 - Do not create a `pyproject.toml` only to run a one-file script.

--- a/skills/python/references/quality.md
+++ b/skills/python/references/quality.md
@@ -19,7 +19,7 @@ For a brand-new `uv init` project, install the default quality baseline immediat
 uv add --dev ruff ty pytest pytest-cov
 ```
 
-`pytest` is the default test framework for new projects. Write tests as function-based `tests/test_*.py` files, use plain `assert`, prefer fixtures for setup and teardown, and use `@pytest.mark.parametrize` for matrix-style cases.
+`pytest` is the default test framework for new projects. Write tests as function-based `tests/test_*.py` files, use plain `assert`, prefer fixtures for setup and teardown, and use `@pytest.mark.parametrize` for matrix-style cases. Unless project docs or configuration specify a different test location, treat `tests/` as the pytest target and include it in commands instead of relying on implicit discovery.
 
 Keep `ruff` and `ty` on defaults unless the project has a concrete need for custom configuration.
 
@@ -87,23 +87,23 @@ uv add --dev pytest pytest-cov
 
 ```bash
 # Run all tests
-uv run pytest
+uv run pytest tests
 
 # Run with coverage
-uv run pytest --cov=<package-or-src-path> --cov-report=term-missing
+uv run pytest --cov=<package-or-src-path> --cov-report=term-missing tests
 
 # Run specific tests
 uv run pytest tests/test_specific.py
 uv run pytest tests/test_specific.py::test_function
 
 # Verbose output
-uv run pytest -v
+uv run pytest -v tests
 
 # Stop on first failure
-uv run pytest -x
+uv run pytest -x tests
 
 # Run tests matching pattern
-uv run pytest -k "test_user"
+uv run pytest -k "test_user" tests
 ```
 
 ## Pre-merge Quality Gate
@@ -122,7 +122,7 @@ If no aggregate gate exists, run the tools directly through uv:
 uv run ruff check --fix
 uv run ruff format
 uv run ty check
-uv run pytest --cov=<package-or-src-path> --cov-report=term-missing --cov-fail-under=80
+uv run pytest --cov=<package-or-src-path> --cov-report=term-missing --cov-fail-under=80 tests
 ```
 
 Use function-based pytest tests. Avoid class-based `Test*` suites and `unittest.TestCase` unless the repository already requires them. Prefer plain `assert`, pytest fixtures, and `@pytest.mark.parametrize` over framework-style test classes.
@@ -161,5 +161,5 @@ jobs:
         run: uv run ty check
 
       - name: Test
-        run: uv run pytest --cov=<package-or-src-path> --cov-report=xml
+        run: uv run pytest --cov=<package-or-src-path> --cov-report=xml tests
 ```


### PR DESCRIPTION
## Summary
- Document `tests/` as the default pytest target when a project does not specify another test location.
- Update Python skill pytest examples to pass `tests` explicitly instead of using bare `uv run pytest`.

## Affected paths
- `skills/python/SKILL.md`
- `skills/python/references/quality.md`

## Verification
- `prek run -a` — passed
