### PR TITLE
[skills] clarify jira-cli issue guidance

### DIFF
--- a/skills/jira-cli/SKILL.md
+++ b/skills/jira-cli/SKILL.md
@@ -72,7 +72,11 @@ jira issue list -c ./jira-config.yaml --plain
 
 ## Write Workflow
 
-Use explicit issue keys and quote values with spaces. If a project name is known, format Jira issue titles/summaries as `[<project_name>] <title/summary>` (for example: `[skills] add jira-cli skill`).
+Use explicit issue keys and quote values with spaces. Prefix issue titles/summaries with the project name when known: `[<project_name>] <title/summary>`.
+
+Examples:
+- Known project name: `[skills] add jira-cli skill`
+- Unknown project name: `add jira-cli skill`
 
 ```sh
 # Create

--- a/skills/jira-cli/SKILL.md
+++ b/skills/jira-cli/SKILL.md
@@ -78,6 +78,16 @@ Examples:
 - Known project name: `[skills] add jira-cli skill`
 - Unknown project name: `add jira-cli skill`
 
+For issue descriptions, use this compact template unless the user provides another one:
+
+```md
+## Summary
+<what changes>
+
+## Acceptance Criteria
+- [ ] <done condition>
+```
+
 ```sh
 # Create
 jira issue create -tTask -s"Summary" -b"Description" --no-input

--- a/skills/jira-cli/SKILL.md
+++ b/skills/jira-cli/SKILL.md
@@ -86,6 +86,11 @@ For issue descriptions, use this compact template unless the user provides anoth
 
 ## Acceptance Criteria
 - [ ] <done condition>
+
+## Optional
+- Context: <why now>
+- Scope: <in/out of scope>
+- Links: <related issue, PR, doc>
 ```
 
 ```sh


### PR DESCRIPTION
## Summary
- document project-prefixed Jira issue summaries, including known and unknown project examples
- add a compact Jira issue description template
- include optional context, scope, and links fields for richer tickets when useful

## Verification
- prek run -a