### PR TITLE
[codex] add creating agent skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ If Codex does not pick up a local skill change, restart Codex and try again.
 
 | Skill | Use it for |
 | --- | --- |
+| `creating-agent-skills` | Creating concise, valid, discoverable agent skills. |
 | `naming-agent-skills` | Predictable, searchable skill names. |
 | `checking-cli-help` | Deciding whether to inspect `--help`, built-in `help`, or `man`. |
 | `using-jira-cli` | Jira setup, queries, mutations, epics, sprints, releases, projects, and boards. |

--- a/skills/creating-agent-skills/SKILL.md
+++ b/skills/creating-agent-skills/SKILL.md
@@ -24,7 +24,7 @@ Create skills that another agent can reliably select and use. Keep each skill co
    - Keep the folder name exactly equal to the frontmatter `name`.
 
 3. Plan reusable contents.
-   - Use only `SKILL.md` and `agents/openai.yaml` for judgment or workflow skills.
+   - Default to `SKILL.md` and `agents/openai.yaml` for judgment or workflow skills when no bundled resources are needed.
    - Add `scripts/` only when deterministic repeated code is useful.
    - Add `references/` only for detail that should be loaded on demand.
    - Add `assets/` only for files that should be copied or used in outputs.

--- a/skills/creating-agent-skills/SKILL.md
+++ b/skills/creating-agent-skills/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: creating-agent-skills
+description: Create, update, or review agent skills with correct structure, triggering metadata, bundled resources, UI metadata, repository integration, and validation. Use when the user asks to create a new skill, improve an existing skill, turn a workflow into a reusable skill, scaffold skill files, or check whether a skill is concise, discoverable, and valid.
+---
+
+# Creating Agent Skills
+
+## Purpose
+
+Create skills that another agent can reliably select and use. Keep each skill concise, task-focused, and grounded in the workflow it teaches.
+
+## Workflow
+
+1. Clarify the target only when needed.
+   - Infer the destination from the current repo or explicit path when possible.
+   - Ask at most one question if the skill's trigger condition or destination is genuinely ambiguous.
+   - Treat user-provided requirements, naming rules, and examples as authoritative.
+
+2. Choose the name.
+   - Use lowercase kebab-case.
+   - Prefer short, action-oriented names such as `<verb-ing>-<object>`.
+   - Avoid vague names like `helper`, `utils`, `tools`, `assistant`, `general`, `data`, `files`, and `documents`.
+   - Keep the folder name exactly equal to the frontmatter `name`.
+
+3. Plan reusable contents.
+   - Use only `SKILL.md` and `agents/openai.yaml` for judgment or workflow skills.
+   - Add `scripts/` only when deterministic repeated code is useful.
+   - Add `references/` only for detail that should be loaded on demand.
+   - Add `assets/` only for files that should be copied or used in outputs.
+   - Do not create README, changelog, quick-reference, or installation documents inside a skill.
+
+4. Create or update the skill files.
+   - New active skills belong in `skills/<skill-name>/SKILL.md` in this repo.
+   - Deprecated skills belong in `skills/deprecated/<skill-name>/SKILL.md`.
+   - If a scaffold tool is available, use it before editing manually.
+   - Keep edits bounded to the skill directory and required catalog files.
+
+5. Write `SKILL.md`.
+   - Include only `name` and `description` in YAML frontmatter.
+   - Put all trigger conditions in `description`; do not rely on a body "when to use" section.
+   - Write imperative, reusable instructions for the agent using the skill.
+   - Prefer concise checklists, decision rules, and examples over broad explanations.
+   - Reference bundled resources directly from `SKILL.md` and explain when to read or use them.
+   - Avoid duplicating detailed reference content in both `SKILL.md` and `references/`.
+
+6. Write `agents/openai.yaml`.
+   - Include `interface.display_name`, `interface.short_description`, and `interface.default_prompt`.
+   - Quote all string values.
+   - Make `default_prompt` explicitly mention `$skill-name`.
+   - Add icons, colors, dependencies, or policy fields only when explicitly needed.
+
+7. Integrate repository discovery.
+   - Add active skills to the relevant `README.md` catalog section.
+   - Do not duplicate README product messaging in `AGENTS.md`.
+   - Update install or clean recipes only when supported paths or install behavior changes.
+
+8. Validate.
+   - Run the available skill validator for the changed skill.
+   - Run the repository verification gate when preparing a PR.
+   - Test added scripts by executing a representative path.
+   - Forward-test complex skills when the workflow is subtle enough that metadata and syntax validation are not enough.
+
+## Review Checklist
+
+- The skill has one clear purpose and trigger condition.
+- The frontmatter description says both what the skill does and when to use it.
+- The body contains instructions that are useful after the skill has already triggered.
+- Optional resources are justified by repeated use or context savings.
+- `agents/openai.yaml` matches the skill and includes a `$skill-name` default prompt.
+- The README catalog entry is present for active repo skills.
+- Validation commands passed or failures are explicitly reported.

--- a/skills/creating-agent-skills/SKILL.md
+++ b/skills/creating-agent-skills/SKILL.md
@@ -17,7 +17,8 @@ Create skills that another agent can reliably select and use. Keep each skill co
    - Treat user-provided requirements, naming rules, and examples as authoritative.
 
 2. Choose the name.
-   - Use lowercase kebab-case.
+   - Use lowercase letters, meaningful digits, and hyphens.
+   - Avoid leading, trailing, or consecutive hyphens.
    - Prefer short, action-oriented names such as `<verb-ing>-<object>`.
    - Avoid vague names like `helper`, `utils`, `tools`, `assistant`, `general`, `data`, `files`, and `documents`.
    - Keep the folder name exactly equal to the frontmatter `name`.
@@ -30,13 +31,15 @@ Create skills that another agent can reliably select and use. Keep each skill co
    - Do not create README, changelog, quick-reference, or installation documents inside a skill.
 
 4. Create or update the skill files.
-   - New active skills belong in `skills/<skill-name>/SKILL.md` in this repo.
-   - Deprecated skills belong in `skills/deprecated/<skill-name>/SKILL.md`.
-   - If a scaffold tool is available, use it before editing manually.
+   - Use the target repo's documented skill root.
+   - In this repo, new active skills belong in `skills/<skill-name>/SKILL.md`.
+   - In this repo, deprecated skills belong in `skills/deprecated/<skill-name>/SKILL.md`.
+   - If the target repo, skill framework, or active instructions document or expose a scaffold tool, use it before editing manually.
    - Keep edits bounded to the skill directory and required catalog files.
 
 5. Write `SKILL.md`.
-   - Include only `name` and `description` in YAML frontmatter.
+   - Include required `name` and `description` in YAML frontmatter.
+   - Add official optional frontmatter fields only when the target repo or skill use case needs them.
    - Put all trigger conditions in `description`; do not rely on a body "when to use" section.
    - Write imperative, reusable instructions for the agent using the skill.
    - Prefer concise checklists, decision rules, and examples over broad explanations.
@@ -50,11 +53,13 @@ Create skills that another agent can reliably select and use. Keep each skill co
    - Add icons, colors, dependencies, or policy fields only when explicitly needed.
 
 7. Integrate repository discovery.
-   - Add active skills to the relevant `README.md` catalog section.
+   - Add active skills to the relevant `README.md` catalog section when this repo maintains one.
    - Do not duplicate README product messaging in `AGENTS.md`.
    - Update install or clean recipes only when supported paths or install behavior changes.
 
 8. Validate.
+   - Prefer documented validation commands from README, AGENTS.md, Makefile, package scripts, or existing CI config.
+   - When `skills-ref` is available, run `skills-ref validate <skill-dir>`.
    - Run the available skill validator for the changed skill.
    - Run the repository verification gate when preparing a PR.
    - Test added scripts by executing a representative path.
@@ -64,8 +69,9 @@ Create skills that another agent can reliably select and use. Keep each skill co
 
 - The skill has one clear purpose and trigger condition.
 - The frontmatter description says both what the skill does and when to use it.
+- Optional frontmatter fields are official and justified by the skill or repo.
 - The body contains instructions that are useful after the skill has already triggered.
 - Optional resources are justified by repeated use or context savings.
 - `agents/openai.yaml` matches the skill and includes a `$skill-name` default prompt.
-- The README catalog entry is present for active repo skills.
+- The README catalog entry is present when the repo maintains a skill catalog.
 - Validation commands passed or failures are explicitly reported.

--- a/skills/creating-agent-skills/agents/openai.yaml
+++ b/skills/creating-agent-skills/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Creating Agent Skills"
+  short_description: "Create concise, valid agent skills."
+  default_prompt: "Use $creating-agent-skills to turn this skill idea into a concise, validated agent skill."


### PR DESCRIPTION
## Summary

- Add `creating-agent-skills` as an active workflow skill for creating, updating, and reviewing agent skills.
- Include UI metadata in `agents/openai.yaml`.
- Add the skill to the README catalog under workflow and repository maintenance.

## Verification

- `env UV_CACHE_DIR=/tmp/uv-cache uv run --with pyyaml --no-project python /home/narumi/.codex/skills/.system/skill-creator/scripts/quick_validate.py /home/narumi/workspace/skills/skills/creating-agent-skills` -> `Skill is valid!`
- `prek run -a` -> passed
- commit hooks -> passed
