### PR TITLE
Restore applying TDD skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ If Codex does not pick up a local skill change, restart Codex and try again.
 | `naming-agent-skills` | Predictable, searchable skill names. |
 | `checking-cli-help` | Deciding whether to inspect `--help`, built-in `help`, or `man`. |
 | `using-jira-cli` | Jira setup, queries, mutations, epics, sprints, releases, projects, and boards. |
+| `applying-tdd` | TDD red-green-refactor workflow for non-trivial code changes. |
 | `writing-git-commits` | Focused Conventional Commits from real diffs. |
 | `maintaining-memory-md` | Concise repository `MEMORY.md` `GOTCHA` and `TASTE` entries. |
 | `writing-agents-md` | Creating or updating repository `AGENTS.md` guidance. |
@@ -118,5 +119,4 @@ Deprecated skills remain in `skills/deprecated/<skill-name>/` for reference and 
 | --- | --- |
 | `cleaning-atuin-history` | Preview-first cleanup planning for noisy Atuin shell history. |
 | `building-codex-hooks` | Codex CLI hooks and `hooks.json` behavior. |
-| `writing-tests-first` | Red-green-refactor workflow for non-trivial code changes. |
 | `writing-work-logs` | Explicitly invoked work logs from repository evidence. |

--- a/skills/applying-tdd/SKILL.md
+++ b/skills/applying-tdd/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: writing-tests-first
-description: Use when implementing non-trivial code changes that should follow TDD (write a failing test first, make the smallest passing change, then refactor safely).
+name: applying-tdd
+description: Use when implementing non-trivial code changes with Test-Driven Development (TDD): write a failing test first, make the smallest passing change, then refactor safely.
 ---
 
-# TDD Policy
+# Applying TDD
 
 - Non-trivial changes SHOULD begin with a test.
 - A test SHOULD fail before implementation begins whenever practical (red → green → refactor).

--- a/skills/applying-tdd/agents/openai.yaml
+++ b/skills/applying-tdd/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Applying TDD"
+  short_description: "Implement non-trivial changes with TDD."
+  default_prompt: "Use $applying-tdd to drive this non-trivial change with a failing test first, then the smallest passing implementation."

--- a/skills/deprecated/writing-tests-first/agents/openai.yaml
+++ b/skills/deprecated/writing-tests-first/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Test-Driven Development"
-  short_description: "Implement non-trivial changes with TDD."
-  default_prompt: "Use $writing-tests-first to drive this non-trivial change with a failing test first, then the smallest passing implementation."


### PR DESCRIPTION
## Summary
- Restore the deprecated TDD workflow as active `applying-tdd`.
- Rename the skill from `writing-tests-first` to preserve the Test-Driven Development intent.
- Update README catalog entries for active/deprecated skills.

## Affected paths
- `skills/applying-tdd/`
- `skills/deprecated/writing-tests-first/`
- `README.md`

## Verification
- Frontmatter name/directory check passed.
- `prek run -a` passed.
- Commit hooks passed.