### PR TITLE
feat: add resolving edge cases skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ If Codex does not pick up a local skill change, restart Codex and try again.
 | --- | --- |
 | `creating-agent-skills` | Creating concise, valid, discoverable agent skills. |
 | `reviewing-code` | Code review for correctness, edge cases, tests, security, and integration risk. |
+| `resolving-edge-cases` | Iteratively finding, fixing, and verifying plausible edge cases in code flows. |
 | `naming-agent-skills` | Predictable, searchable skill names. |
 | `checking-cli-help` | Deciding whether to inspect `--help`, built-in `help`, or `man`. |
 | `using-jira-cli` | Jira setup, queries, mutations, epics, sprints, releases, projects, and boards. |

--- a/skills/resolving-edge-cases/SKILL.md
+++ b/skills/resolving-edge-cases/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: resolving-edge-cases
+description: Use when implementing or debugging code and the goal is to keep finding and fixing plausible edge cases, harden a flow, resolve repeated review comments, or prevent adjacent regressions revealed by each fix.
+---
+
+# Resolving Edge Cases
+
+Use this before editing code when the task is to find, fix, or harden edge cases.
+
+## Loop
+
+1. State the intended behavior and the boundary being hardened.
+2. Trace the real flow end to end, including callers, sibling routes, cleanup paths, and stored state.
+3. List only plausible edge cases for that flow; skip generic checklists that cannot occur.
+4. Fix the shared root path, not only the reported symptom.
+5. Add the smallest regression test or executable check that fails without the fix.
+6. Run the narrow check, then scan sibling callers/routes for the same pattern.
+7. Repeat while each fix exposes a concrete adjacent edge case.
+8. Run the repo's normal verification gate before final response.
+
+## Edge-Case Families
+
+Consider these only when relevant:
+
+- empty, single, duplicate, huge, unsorted, missing, null, undefined, NaN, malformed, or wrong-type inputs
+- inclusive/exclusive bounds, off-by-one behavior, overflow, divide-by-zero, and precision loss
+- trust boundaries: HTTP, WebSocket, CLI args, files, environment, database rows, external APIs
+- path containment, authz/authn, tenant ownership, unsafe deserialization, and sensitive logging
+- stale state, reconnect/disconnect, cancellation, retries, idempotency, races, and partial failure
+- timeout, cleanup, file handles, sockets, locks, transactions, subscriptions, and memory growth
+- time zones, DST, clock skew, expiry windows, ordering assumptions, and eventual consistency
+- response shape, schema migration, backward compatibility, packaging/runtime/config mismatches
+
+## Fix Rules
+
+- Prefer one guard or normalization in the shared boundary over repeated caller patches.
+- Preserve existing contracts unless the task explicitly changes them.
+- If retained state is introduced, add the minimal eviction or cleanup path.
+- If a timeout or cancellation can fire, close or clear the resource too.
+- If input crosses a trust boundary, validate type and shape before use.
+- If a package/config points to code, prove the referenced file exists in the packaged/runtime form.
+- Stop when checks pass and the sibling scan finds no same-pattern bug; report any unverified risk plainly.

--- a/skills/resolving-edge-cases/agents/openai.yaml
+++ b/skills/resolving-edge-cases/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Resolving Edge Cases"
+  short_description: "Find and fix plausible edge cases in code flows."
+  default_prompt: "Use $resolving-edge-cases to harden this code path by finding plausible edge cases, fixing the shared root cause, and verifying each fix."


### PR DESCRIPTION
## Summary
- Add `resolving-edge-cases` for iterative edge-case hardening.
- Add OpenAI metadata for the new skill.
- Add the skill to the README catalog.

## Affected paths
- `skills/resolving-edge-cases/SKILL.md`
- `skills/resolving-edge-cases/agents/openai.yaml`
- `README.md`

## Verification
- `UV_CACHE_DIR=/tmp/uv-cache uv run --with pyyaml python /home/narumi/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/resolving-edge-cases`
- `UV_CACHE_DIR=/tmp/uv-cache prek run -a`
