### PR TITLE
docs(resolving-edge-cases): document default diff scope

### DIFF
--- a/skills/resolving-edge-cases/SKILL.md
+++ b/skills/resolving-edge-cases/SKILL.md
@@ -7,6 +7,10 @@ description: Use when implementing or debugging code and the goal is to keep fin
 
 Use this before editing code when the task is to find, fix, or harden edge cases.
 
+## Default Scope
+
+When the user does not provide files, a commit, or a diff, run `git diff <base>...HEAD` against the merge base with `main` or `master`, then use the changed paths as the starting point for the loop below.
+
 ## Loop
 
 1. State the intended behavior and the boundary being hardened.

--- a/skills/resolving-edge-cases/SKILL.md
+++ b/skills/resolving-edge-cases/SKILL.md
@@ -9,7 +9,7 @@ Use this before editing code when the task is to find, fix, or harden edge cases
 
 ## Default Scope
 
-When the user does not provide files, a commit, or a diff, run `git diff <base>...HEAD` against the merge base with `main` or `master`, then use the changed paths as the starting point for the loop below.
+When the user does not provide files, a commit, or a diff, run `git diff --name-only main...HEAD`; if the repo uses `master`, run `git diff --name-only master...HEAD` instead. Use those changed paths as the starting point for the loop below.
 
 ## Loop
 


### PR DESCRIPTION
## Summary
- add default scope guidance for unresolved resolving-edge-cases tasks
- instruct agents to diff the current branch against main/master and use changed paths for the loop

## Verification
- prek run -a