### PR TITLE
Narrow resolving-edge-cases trigger

### DIFF
--- a/skills/resolving-edge-cases/SKILL.md
+++ b/skills/resolving-edge-cases/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: resolving-edge-cases
-description: Use when asked to proactively find, fix, and harden plausible edge-case bugs in a code flow, or when implementing/debugging code must prevent adjacent regressions.
+description: Use when asked to proactively find, fix, or harden edge-case bugs in a specific code flow, or when a concrete bug fix suggests nearby same-pattern regression risks that should be inspected.
 ---
 
 # Resolving Edge Cases


### PR DESCRIPTION
## Summary
- Narrow the resolving-edge-cases skill description so it triggers only for explicit edge-case hardening or concrete same-pattern regression risk.

## Verification
- `prek run -a`
- `git diff --check origin/main...HEAD`