### PR TITLE
feat(memory-md): create file on first durable entry

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,6 +1,6 @@
 ## GOTCHA
 
-- `skill-creator`'s `quick_validate.py` requires `PyYAML`; in this repo, `uv run --with pyyaml python /home/narumi/.codex/skills/.system/skill-creator/scripts/quick_validate.py <skill-dir>` is more reliable than plain `uv run python`.
+- Symptom: `skill-creator`'s `quick_validate.py` raises `ModuleNotFoundError: yaml` even with `uv run --with pyyaml` under the default Python 3.14. Cause: that one-off environment did not inject PyYAML. Fix: run `UV_CACHE_DIR=/tmp/uv-cache uv run --no-project --python 3.13 --with pyyaml python "$HOME/.codex/skills/.system/skill-creator/scripts/quick_validate.py" <skill-dir>`.
 - `skill-creator`'s `init_skill.py` creates the target skill directory and `SKILL.md` before it validates `agents/openai.yaml` metadata, so a bad `--interface short_description` can leave a partially initialized skill directory behind.
 - In this sandbox, `~/.cache/uv` may be read-only; when running one-off `uv run --with ...` tools, set `UV_CACHE_DIR=/tmp/uv-cache` first for more reliable behavior.
 - In this sandbox, the first run of skill metadata tools like `uv run --with pyyaml` may still need temporary network access if the local cache does not already contain the package, so `uv` can fetch `PyYAML`.
@@ -14,4 +14,4 @@
 ## TASTE
 - Prefer preserving a skill's original user intent when naming or renaming skills; do not force `<verb-ing>-<object>` if it changes the meaning.
 - `writing-git-commits` should rely on the repo-level `AGENTS.md` for the Git baseline; `SKILL.md` should keep only the flow and judgment from diff to commit message, while less common Conventional Commits details belong in `references/`.
-- `maintaining-memory-md` should trigger at the start of repository conversations, record repeatable mistakes as `GOTCHA`, correct wrong or stale memory entries in place, and store durable user preferences under `TASTE`.
+- `maintaining-memory-md` should check at conversation start without creating `MEMORY.md` merely because it is missing; when the first qualifying `GOTCHA` or durable `TASTE` emerges, it should create the repository-root file without extra confirmation and revise stale or similar entries in place.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ If Codex does not pick up a local skill change, restart Codex and try again.
 | `using-jira-cli` | Jira setup, queries, mutations, epics, sprints, releases, projects, and boards. |
 | `applying-tdd` | TDD red-green-refactor workflow for non-trivial code changes. |
 | `writing-git-commits` | Focused Conventional Commits from real diffs. |
-| `maintaining-memory-md` | Concise repository `MEMORY.md` `GOTCHA` and `TASTE` entries. |
+| `maintaining-memory-md` | Creates repository `MEMORY.md` on the first durable `GOTCHA` or `TASTE`, then keeps entries concise and current. |
 | `writing-agents-md` | Creating or updating repository `AGENTS.md` guidance. |
 
 ## 🗄️ Deprecated Skills

--- a/skills/maintaining-memory-md/SKILL.md
+++ b/skills/maintaining-memory-md/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: maintaining-memory-md
-description: Maintains concise repository MEMORY.md notes for gotchas, stale memory corrections, and durable user preferences. Use at the start of repository conversations, when the user mentions MEMORY.md, when an error should be remembered to avoid repeating it, or when MEMORY.md content may be wrong.
+description: Creates and maintains concise repository MEMORY.md notes for gotchas, stale memory corrections, and durable user preferences. Use at the start of repository conversations, when the user mentions MEMORY.md, when an error or preference should be remembered for future work, when MEMORY.md content may be wrong, or when the first qualifying memory emerges in a repository that has no MEMORY.md yet.
 ---
 
 # MEMORY.md
@@ -9,15 +9,31 @@ Use `MEMORY.md` as a concise repository-local memory file. It is not automatical
 
 ## When To Read
 
-- At the start of a repository conversation, check whether `MEMORY.md` exists and skim it for relevant context before planning or editing.
+- At the start of a repository conversation, resolve the repository root, then check whether its `MEMORY.md` exists and skim it for relevant context before planning or editing. Do not create a competing file from a nested working directory.
 - Check it again before non-trivial debugging, design work, workflow changes, or skill maintenance where past project choices may affect the answer.
-- Treat a missing `MEMORY.md` as normal. Do not invent entries or assume the file exists.
+- Treat a missing `MEMORY.md` as normal. Its absence alone is not a reason to create it.
 - Use current repository evidence as the source of truth when memory and files disagree.
+
+## When To Create
+
+- During repository work, proactively notice qualifying memories even when the user does not explicitly ask to save them.
+- A `GOTCHA` qualifies when repository evidence verifies a reusable trap or failure mode and its cause, recovery, or future avoidance step is known.
+- A `TASTE` qualifies when the user expresses a durable preference that will change how future repository work should be performed.
+- If the repository root has no `MEMORY.md`, the first qualifying entry emerges, and neither the user nor repository instructions prohibit the file, create `MEMORY.md` without asking for confirmation solely because it is missing. Create both required sections and put the entry under the correct one:
+
+```markdown
+## GOTCHA
+
+## TASTE
+```
+
+- Create the file only when repository writes are permitted. In read-only or plan-only work, explicitly include the creation and entry in the next writable step instead of silently dropping the memory.
+- Do not create `MEMORY.md` for transient status, task history, speculation, or sensitive material when no reusable sanitized lesson remains.
 
 ## When To Update
 
-- Add or revise an entry after a mistake, discovery, or user preference when it will help avoid repeating the same issue.
-- If an existing `MEMORY.md` entry is wrong, stale, or contradicted by current evidence, correct that entry instead of adding a conflicting note.
+- Add or revise an entry after a qualifying mistake, discovery, or user preference when it will help future work avoid the same issue or preserve the preference.
+- If an existing `MEMORY.md` entry is wrong, stale, contradicted by current evidence, or similar to the new memory, revise that entry instead of adding a conflicting or duplicate note.
 - Keep entries short, reusable, and grounded in the current repo.
 - Never store secrets or sensitive data in `MEMORY.md`, including credentials, tokens, API keys, cookies, private endpoints, proprietary/internal-only details, or sensitive personal data.
 - When a gotcha or preference involves sensitive material, record only the sanitized lesson, not the secret or identifying detail.

--- a/skills/maintaining-memory-md/agents/openai.yaml
+++ b/skills/maintaining-memory-md/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "MEMORY.md Keeper"
-  short_description: "Maintain concise repository MEMORY.md notes."
-  default_prompt: "Use $maintaining-memory-md to check repository MEMORY.md at conversation start, record repeatable mistakes as GOTCHA, and keep durable preferences under TASTE."
+  short_description: "Create and maintain concise repository MEMORY.md notes."
+  default_prompt: "Use $maintaining-memory-md to check repository MEMORY.md without creating it merely because it is missing; when the first qualifying GOTCHA or TASTE emerges, create repository-root MEMORY.md and record it."


### PR DESCRIPTION
## Summary

- Create repository-root `MEMORY.md` when the first qualifying `GOTCHA` or durable `TASTE` emerges, rather than merely when the file is absent.
- Define qualification, deduplication, sanitization, nested-directory, explicit-prohibition, and read-only/plan-only behavior.
- Update skill discovery metadata and repository memory to match the strengthened behavior.

## Affected paths

- `skills/maintaining-memory-md/SKILL.md`
- `skills/maintaining-memory-md/agents/openai.yaml`
- `README.md`
- `MEMORY.md`

## Verification

- `skills-ref validate skills/maintaining-memory-md` was unavailable because `skills-ref` is not installed.
- `quick_validate.py skills/maintaining-memory-md` — passed (`Skill is valid!`).
- Behavioral checks for missing files, first entries, duplicate/stale entries, sensitive data, nested working directories, explicit prohibitions, and read-only/plan-only work — all passed.
- `prek run -a` — all hooks passed.
- `git diff --check origin/main...HEAD` — passed.