### PR TITLE
docs(applying-tdd): exclude scripts from TDD

### DIFF
--- a/skills/applying-tdd/SKILL.md
+++ b/skills/applying-tdd/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: applying-tdd
-description: "Use when implementing non-trivial code changes with Test-Driven Development (TDD): write a failing test first, make the smallest passing change, then refactor safely."
+description: "Use when implementing non-trivial product or library code changes with Test-Driven Development (TDD): write a failing test first, make the smallest passing change, then refactor safely. Do not apply TDD to files under a repository's scripts/ directory."
 ---
 
 # Applying TDD
 
-- Non-trivial changes SHOULD begin with a test.
+These rules apply only to in-scope product and library code; files under `scripts/` follow the separate validation boundary below.
+
+- Non-trivial in-scope changes SHOULD begin with a test.
 - A test SHOULD fail before implementation begins whenever practical (red → green → refactor).
 - Implementation SHOULD follow the red → green → refactor cycle.
 - Implement the smallest change required to make the test pass.
@@ -13,7 +15,7 @@ description: "Use when implementing non-trivial code changes with Test-Driven De
 - Tests MUST act as executable specifications of behavior, not merely coverage.
 - Tests MUST assert observable behavior, not implementation details.
 - Bug fixes SHOULD include a regression test when feasible.
-- Code changes SHOULD include corresponding test updates when behavior changes.
+- In-scope code changes SHOULD include corresponding test updates when behavior changes.
 - Tests MUST be deterministic and isolated from uncontrolled inputs (for example network, time, or randomness).
 - Tests SHOULD avoid reliance on external systems unless explicitly intended.
 - External dependencies SHOULD be controlled appropriately.
@@ -25,11 +27,17 @@ description: "Use when implementing non-trivial code changes with Test-Driven De
   - why testing is not feasible
   - what risk remains
   - how the change was validated
-- Skipping TDD for non-trivial changes REQUIRES explicit justification.
+- Skipping TDD for non-trivial in-scope changes REQUIRES explicit justification.
+
+## Script Boundary
+
+- Files under a repository's `scripts/` directory are outside TDD scope and do not require a failing test or the red → green → refactor cycle.
+- Script changes MUST still receive proportionate validation, such as representative execution, dry-run, lint, syntax, or smoke checks.
+- Reusable product, library, business, or query logic SHOULD be extracted from `scripts/` into `src/` or the repository's equivalent source root; the extracted logic remains in TDD scope.
 
 ## Scope
 
-- Non-trivial changes include:
+- Non-trivial in-scope product or library changes include:
   - Bug fixes
   - New features
   - Behavior changes
@@ -37,6 +45,7 @@ description: "Use when implementing non-trivial code changes with Test-Driven De
   - Business logic or query changes
 
 - Excluded:
+  - Files under a repository's `scripts/` directory, including standalone scripts, repository automation, migrations, and one-off helpers
   - Pure formatting changes
   - Renames without behavior change
   - Comment or documentation updates

--- a/skills/applying-tdd/agents/openai.yaml
+++ b/skills/applying-tdd/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Applying TDD"
-  short_description: "Implement non-trivial changes with TDD."
-  default_prompt: "Use $applying-tdd to drive this non-trivial change with a failing test first, then the smallest passing implementation."
+  short_description: "Apply TDD to non-trivial product and library code."
+  default_prompt: "Use $applying-tdd for this non-trivial product or library change: start with a failing test, then make the smallest passing implementation. Do not apply TDD to files under scripts/; validate those scripts directly."


### PR DESCRIPTION
## Summary
- exclude files under repository `scripts/` directories from the TDD cycle
- retain direct script validation through execution, dry-run, lint, syntax, or smoke checks
- keep reusable logic extracted into product/library source code under TDD
- align the skill metadata and default prompt with the boundary

## Verification
- `prek run -a`
- parsed `SKILL.md` frontmatter and `agents/openai.yaml` as YAML
- verified the canonical and active skill copies are byte-identical