### PR TITLE
feat(designing-user-interfaces): strengthen workspace guidance

### DIFF
--- a/skills/designing-user-interfaces/SKILL.md
+++ b/skills/designing-user-interfaces/SKILL.md
@@ -26,6 +26,7 @@ Before proposing a design, identify the primary user, current context, primary t
 11. **Avoid false simplicity.** A cleaner surface is worse if it increases search time, navigation depth, repeated effort, uncertainty, hidden dependencies, context loss, or inaccessible interaction.
 12. **Adapt without losing identity.** Preserve recognizable structure and priority across viewport sizes, text sizes, localization, right-to-left layout, input methods, permissions, and content states.
 13. **Follow conventions deliberately.** Prefer established platform and product patterns unless deviation produces a specific, testable usability gain. On Apple platforms, consult the relevant HIG platform and component topics.
+14. **Give each workspace a distinct responsibility.** When multiple surfaces handle the same objects, assign one canonical owner for each workflow instead of duplicating full editors. Keep cross-workspace handoffs shallow, predictable, and context preserving.
 
 ## Visibility Decision
 
@@ -50,6 +51,7 @@ For each element, ask:
 6. Is the proposed entry point labeled and predictable?
 7. Would hiding it increase memory, search, navigation, or recovery burden?
 8. Does the design reduce complexity, or merely move it elsewhere?
+9. Does the action apply to the object’s current lifecycle state, or should it appear only after a prerequisite such as saving?
 
 When evidence is missing, state the assumption that drives the classification. Do not pretend frequency or user priority is known.
 
@@ -65,20 +67,21 @@ Organize the interface in this order:
 4. Separate primary, secondary/supporting, contextual, and advanced layers.
 5. Make scanning order and action priority clear through layout before decoration; account for right-to-left reading order.
 6. Check narrow and wide layouts, large text, long localization, empty and dense data, loading, errors, offline behavior, permissions, and assistive-technology focus order; hierarchy must survive them all.
+7. Make each title, status, badge, summary, and instruction answer a distinct question. Remove synonymous layers that repeat identity or state without helping the next decision.
 
 Prefer the fewest visible elements that still support efficient, predictable use. Fewer elements are not automatically better.
 
 ## Design Workflow
 
 1. **Frame the task.** Identify user, purpose, context, frequency, stakes, constraints, input methods, and success signal.
-2. **Inventory capability and state.** List actions, information, dependencies, current location, loading, empty, success, error, offline, disabled, permission-denied, and unsaved-work states before simplifying.
+2. **Inventory capability, state, and ownership.** List actions, information, dependencies, current location, loading, empty, success, error, offline, disabled, permission-denied, and unsaved-work states before simplifying. Identify which surface owns selection and drafts so disclosure, responsive presentation, refreshes, and handoffs do not reset work.
 3. **Classify visibility.** Apply the visibility table and explain uncertain classifications.
 4. **Structure the hierarchy.** Define regions, groups, reading and focus order, primary action, and disclosure paths. Generally limit prominent actions to one or two per view.
 5. **Protect discoverability.** Give every hidden capability a clear label, obvious entry point, predictable location, minimal depth, return path, and consistent interaction.
 6. **Protect accessibility.** Check semantic labels, contrast, noncolor cues, text scaling and reflow, target size and spacing, keyboard and assistive operation, gesture alternatives, and reduced motion.
 7. **Match feedback to stakes.** Put routine status and validation near the affected object. Use interruption only when the information is critical and actionable; make irreversible or unexpected consequences explicit.
 8. **Audit overload and false simplicity.** Check competing emphasis, dense choices, decorative noise, extra steps, menu hunting, context loss, hidden status, recall, and repeated work.
-9. **Test adaptation and edge states.** Exercise the smallest and largest layouts, largest text, long translated and right-to-left content, empty and dense data, all supported inputs, errors, offline operation, permissions, cancellation, and recovery.
+9. **Test adaptation, transitions, and edge states.** Exercise the smallest and largest layouts, largest text, long translated and right-to-left content, empty and dense data, all supported inputs, errors, offline operation, permissions, cancellation, and recovery. Test stateful transitions — create, switch panel/item/workspace, refresh, reject or accept discard, save, fail, and retry — because static screenshots cannot prove draft preservation or recovery.
 10. **Explain and validate tradeoffs.** Tie each choice to purpose, frequency, consequence, context, evidence, accessibility, or convention; name what user evidence or testing would change it.
 
 ## Required Output

--- a/skills/designing-user-interfaces/references/cases.md
+++ b/skills/designing-user-interfaces/references/cases.md
@@ -8,11 +8,17 @@ Use these examples as contextual precedents, not rigid templates. Match the unde
 
 **Avoid:** Put search, filters, export, and create into one unlabeled overflow menu merely to produce an empty header. This increases search cost and hides the primary path.
 
+## Catalog and Canonical Editor
+
+**Prefer:** Give catalog and editing work distinct responsibilities. Let the catalog own browsing, search, sharing, deletion, and lifecycle management; let one canonical editor own spatial or otherwise specialized changes. Make `Open on map` or its equivalent a one-step handoff that carries the selected object and returns predictably.
+
+**Avoid:** Mount the same full editor in both the catalog and workbench, or require a second `Edit` mode after opening the canonical editor. Duplicate editors create competing mental models, state synchronization risk, and redundant controls.
+
 ## Object Detail View
 
-**Prefer:** Show identity, current status, essential metadata, and the next likely action near the top. Put long history, diagnostics, and specialized metadata in labeled sections or tabs while preserving object context.
+**Prefer:** Show identity, current status, essential metadata, and the next likely action near the top. Give each header layer a separate purpose — for example, object name, meaningful revision, and actionable validation near Save. Put long history, diagnostics, and specialized metadata in labeled sections or tabs while preserving object context.
 
-**Avoid:** Reduce the page to a name and one button, forcing users through separate screens to understand status or consequences.
+**Avoid:** Reduce the page to a name and one button, forcing users through separate screens to understand status or consequences. Also avoid stacking synonymous labels such as `Draft route`, `New route`, and a generic draft instruction when they do not change the next decision.
 
 ## Settings
 
@@ -58,9 +64,9 @@ Use these examples as contextual precedents, not rigid templates. Match the unde
 
 ## Mobile or Narrow Viewports
 
-**Prefer:** Keep the primary task, essential status, and current location apparent. Collapse secondary groups behind labeled controls while maintaining a shallow, reversible path. Reflow at large text sizes instead of shrinking targets or truncating useful content.
+**Prefer:** Keep the primary task, essential status, and current location apparent. For a desktop picker/canvas/inspector workspace, show one primary region at a time behind explicit labels such as `Map`, `Choose`, and `Edit`, while keeping selection and draft state in shared ownership. Reflow at large text sizes instead of shrinking targets or truncating useful content.
 
-**Avoid:** Treat an unlabeled hamburger or swipe gesture as a universal solution. Constrained space changes presentation, not the need for discoverability, readable text, or accessible targets.
+**Avoid:** Stack every desktop region into one long mobile page, remount panels in a way that loses drafts, or treat an unlabeled hamburger or swipe gesture as a universal solution. Constrained space changes presentation, not the need for discoverability, readable text, accessible targets, or state continuity.
 
 ## Modal Tasks
 
@@ -73,6 +79,12 @@ Use these examples as contextual precedents, not rigid templates. Match the unde
 **Prefer:** Let people experience the product quickly, teach one relevant action in context, make tutorials optional and findable later, and postpone nonessential setup.
 
 **Avoid:** Front-load a feature tour people must memorize, repeatedly show skipped onboarding, explain standard controls, or require configuration that a useful default can avoid.
+
+## Utility Typography Across Scripts
+
+**Prefer:** In an operational interface that mixes Latin and CJK or other scripts, use a compatible, legible UI family across headings and body text. Reserve monospaced type for coordinates, identifiers, or technical values, and use decorative display type only when expression is a real product goal and the script pairing has been tested.
+
+**Avoid:** Apply a decorative Latin display face to hierarchy labels while unsupported scripts fall back to an unrelated system font. The split makes one hierarchy feel like two visual systems and can make a dense tool harder to scan.
 
 ## Accessibility and Multiple Inputs
 

--- a/skills/designing-user-interfaces/references/preferences.md
+++ b/skills/designing-user-interfaces/references/preferences.md
@@ -9,6 +9,7 @@ Read this file when the task reaches visual direction or when comparing multiple
 | Containers | Use open grouping and whitespace before cards or bordered panels | A boundary communicates interaction, selection, ownership, or a distinct state |
 | Corners | Use restrained, consistent radii | Existing design-system tokens or platform conventions specify otherwise |
 | Color | Use a limited functional palette for hierarchy, state, and feedback, with noncolor cues for essential meaning | Brand expression is important and does not compete with meaning, contrast, or appearance adaptation |
+| Typography | Use a legible, compatible UI family for operational surfaces; reserve monospaced type for technical values | Editorial or expressive presentation is a product goal, the full script set has been tested, and display type does not weaken scanning or fallback consistency |
 | Motion | Use brief, cancellable motion to explain continuity, causality, or state change | Reduced-motion preferences, urgency, performance, repeated use, or discomfort argues for a reduced or static alternative |
 | Labels | Prefer concise verb labels and familiar symbols; use text when it is clearer | Space is constrained and the icon is conventional, unambiguous, labeled for assistive technology, and not the only route to a core action |
 | Action emphasis | Prefer one primary nondestructive action, with at most one additional prominent action | Evidence shows that multiple peer actions are equally central; never make a destructive action the default |


### PR DESCRIPTION
## Summary

- assign canonical ownership across catalog and editing workspaces
- preserve selection and draft state through responsive layouts and transitions
- add guidance for lifecycle-aware actions, nonredundant hierarchy, and multilingual utility typography

## Verification

- `prek run -a`
- `quick_validate.py skills/designing-user-interfaces`