### PR TITLE
fix(skills): resolve repository review findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Use this when you want the collection without linking a local checkout:
 npx skills add narumiruna/skills
 ```
 
+Standard discovery exposes active skills only; deprecated skills are marked internal and remain available solely for repository reference or explicit local use.
+
 ### 2. Local Codex development with `just`
 
 Use this when you want repo-managed local copies in `~/.codex/skills`:

--- a/skills/authoring-marp-slides/references/best-practices.md
+++ b/skills/authoring-marp-slides/references/best-practices.md
@@ -27,10 +27,11 @@ Use Markdown first. Use inline HTML only when Marp Markdown cannot express the l
 
 ## Pre-Commit Check
 
-Before handing off a deck:
+Before handing off a deck, resolve `scripts/validate_marpit.sh` against the `authoring-marp-slides` skill directory, then run it by absolute path:
 
 ```shell
-bash skills/authoring-marp-slides/scripts/validate_marpit.sh deck.md
+AUTHORING_MARP_SLIDES_SKILL_DIR="/absolute/path/to/authoring-marp-slides"
+bash "$AUTHORING_MARP_SLIDES_SKILL_DIR/scripts/validate_marpit.sh" deck.md
 ```
 
 Then preview or export the deck and inspect at least title, densest content slide, and every slide with an SVG/background image.

--- a/skills/authoring-marp-slides/references/syntax-guide.md
+++ b/skills/authoring-marp-slides/references/syntax-guide.md
@@ -76,8 +76,9 @@ Use Markdown tables only for small comparisons. For dense data, simplify or use 
 
 ## Validation
 
-Run the local syntax check when available:
+Resolve `scripts/validate_marpit.sh` against the `authoring-marp-slides` skill directory, then run the local syntax check by absolute path:
 
 ```shell
-bash skills/authoring-marp-slides/scripts/validate_marpit.sh deck.md
+AUTHORING_MARP_SLIDES_SKILL_DIR="/absolute/path/to/authoring-marp-slides"
+bash "$AUTHORING_MARP_SLIDES_SKILL_DIR/scripts/validate_marpit.sh" deck.md
 ```

--- a/skills/authoring-marp-slides/scripts/validate_marpit.sh
+++ b/skills/authoring-marp-slides/scripts/validate_marpit.sh
@@ -28,22 +28,21 @@ if ! head -n 1 "$FILE" | grep -q "^---$"; then
     ERRORS=$((ERRORS + 1))
 fi
 
-# Check marp: true
-if ! head -n 10 "$FILE" | grep -q "marp: true"; then
-    echo "❌ Missing 'marp: true' in frontmatter"
+# Locate the frontmatter closing delimiter.
+FRONTMATTER_END=$(awk 'NR > 1 && $0 == "---" { print NR; exit }' "$FILE")
+if [ -z "$FRONTMATTER_END" ]; then
+    echo "❌ Missing frontmatter closing delimiter (---)"
     ERRORS=$((ERRORS + 1))
-fi
-
-# Check frontmatter closing
-if ! head -n 10 "$FILE" | tail -n +2 | grep -q "^---$"; then
-    echo "⚠️  Frontmatter may not be properly closed with ---"
+else
+    # Check marp: true inside frontmatter only.
+    if ! awk -v end="$FRONTMATTER_END" 'NR > 1 && NR < end' "$FILE" | grep -Eq '^marp:[[:space:]]*true[[:space:]]*$'; then
+        echo "❌ Missing 'marp: true' in frontmatter"
+        ERRORS=$((ERRORS + 1))
+    fi
 fi
 
 # Check slide separators
 SEPARATOR_COUNT=$(grep -c "^---$" "$FILE" || true)
-if [ "$SEPARATOR_COUNT" -lt 2 ]; then
-    echo "⚠️  Only $SEPARATOR_COUNT separator(s) found. Expected at least 2 (frontmatter + slides)"
-fi
 
 # Count slides (separators minus frontmatter)
 SLIDE_COUNT=$((SEPARATOR_COUNT - 1))

--- a/skills/authoring-marp-slides/scripts/validate_marpit.sh
+++ b/skills/authoring-marp-slides/scripts/validate_marpit.sh
@@ -3,7 +3,7 @@
 
 set -e
 
-if [ $# -eq 0 ]; then
+if [ $# -ne 1 ]; then
     echo "Usage: validate_marpit.sh <file.md>"
     echo ""
     echo "Validates Marpit Markdown files for:"
@@ -14,6 +14,10 @@ if [ $# -eq 0 ]; then
 fi
 
 FILE="$1"
+case "$FILE" in
+    /*) ;;
+    *) FILE="./$FILE" ;;
+esac
 
 if [ ! -f "$FILE" ]; then
     echo "❌ File not found: $FILE"
@@ -22,30 +26,34 @@ fi
 
 ERRORS=0
 
-# Check frontmatter opening
-if ! head -n 1 "$FILE" | grep -q "^---$"; then
+# Check frontmatter opening, accepting CRLF input.
+FIRST_LINE=$(head -n 1 -- "$FILE")
+FIRST_LINE=${FIRST_LINE%$'\r'}
+if [ "$FIRST_LINE" != "---" ]; then
     echo "❌ Missing frontmatter opening (---) on line 1"
     ERRORS=$((ERRORS + 1))
 fi
 
 # Locate the frontmatter closing delimiter.
-FRONTMATTER_END=$(awk 'NR > 1 && $0 == "---" { print NR; exit }' "$FILE")
+FRONTMATTER_END=$(awk '{ sub(/\r$/, "") } NR > 1 && $0 == "---" { print NR; exit }' "$FILE")
 if [ -z "$FRONTMATTER_END" ]; then
     echo "❌ Missing frontmatter closing delimiter (---)"
     ERRORS=$((ERRORS + 1))
 else
     # Check marp: true inside frontmatter only.
-    if ! awk -v end="$FRONTMATTER_END" 'NR > 1 && NR < end' "$FILE" | grep -Eq '^marp:[[:space:]]*true[[:space:]]*$'; then
+    if ! awk -v end="$FRONTMATTER_END" '{ sub(/\r$/, "") } NR > 1 && NR < end' "$FILE" | grep -Eq '^marp:[[:space:]]*[Tt][Rr][Uu][Ee]([[:space:]]*#.*)?[[:space:]]*$'; then
         echo "❌ Missing 'marp: true' in frontmatter"
         ERRORS=$((ERRORS + 1))
     fi
 fi
 
-# Check slide separators
-SEPARATOR_COUNT=$(grep -c "^---$" "$FILE" || true)
-
-# Count slides (separators minus frontmatter)
-SLIDE_COUNT=$((SEPARATOR_COUNT - 1))
+# Count separators and slides, accepting CRLF input and avoiding negative counts.
+SEPARATOR_COUNT=$(awk '{ sub(/\r$/, "") } $0 == "---" { count++ } END { print count + 0 }' "$FILE")
+if [ "$SEPARATOR_COUNT" -gt 0 ]; then
+    SLIDE_COUNT=$((SEPARATOR_COUNT - 1))
+else
+    SLIDE_COUNT=0
+fi
 
 if [ $ERRORS -eq 0 ]; then
     echo "✅ Marpit syntax valid"

--- a/skills/configuring-python-logging/references/logging.md
+++ b/skills/configuring-python-logging/references/logging.md
@@ -61,17 +61,29 @@ Configure handlers once at process startup. If setup code can run more than once
 
 ## Structured Context
 
+When a formatter reads custom fields, provide defaults so records from third-party libraries do not fail formatting.
+
 ```python
 import logging
+import sys
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s | %(levelname)s | %(name)s:%(lineno)d | %(user_id)s | %(message)s",
+handler = logging.StreamHandler(sys.stderr)
+handler.setFormatter(
+    logging.Formatter(
+        "%(asctime)s | %(levelname)s | %(name)s | %(user_id)s | %(message)s",
+        defaults={"user_id": "-"},
+    )
 )
 
-logger = logging.getLogger(__name__)
-logger.info("User action", extra={"user_id": 123})
+root_logger = logging.getLogger()
+root_logger.setLevel(logging.INFO)
+root_logger.addHandler(handler)
+
+logging.getLogger("my_app").info("User action", extra={"user_id": 123})
+logging.getLogger("third_party").info("Record without user context")
 ```
+
+For larger applications, use a `LoggerAdapter`, filter, or structured logging handler to add request context at a defined boundary.
 
 ## Exceptions
 

--- a/skills/creating-slide-decks/SKILL.md
+++ b/skills/creating-slide-decks/SKILL.md
@@ -9,7 +9,7 @@ Create professional Marp/Marpit presentations, diagrams, and color systems with 
 
 ## Core rules
 
-- **Use `bg` (background) syntax for all images** - Reduces manual resizing with `fit` modifier
+- Use `bg` syntax for full-slide or split-layout visuals; keep logos, icons, and other small images inline.
 - Define one 7-role color palette and reuse it in slides and SVGs.
 - Define one spacing unit (e.g., 8px or 16px) and reuse it across layouts.
 - Define text hierarchy tiers (title/section/body) with sizes and weights; use them consistently.
@@ -61,8 +61,11 @@ Pick one task and follow the exact reading path:
 ### Two Ways to Start
 
 **Option 1: Use scripts** (automated):
+Load `authoring-marp-slides`, resolve `scripts/init_presentation.py` against that skill directory, and run it by absolute path:
+
 ```bash
-uv run skills/authoring-marp-slides/scripts/init_presentation.py technical-dark my-deck.md "My Title" "Author"
+AUTHORING_MARP_SLIDES_SKILL_DIR="/absolute/path/to/authoring-marp-slides"
+uv run "$AUTHORING_MARP_SLIDES_SKILL_DIR/scripts/init_presentation.py" technical-dark my-deck.md "My Title" "Author"
 ```
 
 **Option 2: Work manually** (full control):

--- a/skills/creating-slide-decks/references/troubleshooting-common.md
+++ b/skills/creating-slide-decks/references/troubleshooting-common.md
@@ -54,10 +54,11 @@ svglint diagrams/flow.svg
 Symptom: Text is readable in preview but fails contrast in PDF/HTML export.
 
 Fix:
-1. Check contrast ratio:
+1. Load `designing-slide-colors`, resolve `scripts/check_contrast.py` against that skill directory, and check the ratio by absolute path:
 
 ```bash
-uv run skills/designing-slide-colors/scripts/check_contrast.py '#D4D4D4' '#1E1E1E'
+DESIGNING_SLIDE_COLORS_SKILL_DIR="/absolute/path/to/designing-slide-colors"
+uv run "$DESIGNING_SLIDE_COLORS_SKILL_DIR/scripts/check_contrast.py" '#D4D4D4' '#1E1E1E'
 ```
 
 2. Aim for 7:1 (AAA) when possible.

--- a/skills/deprecated/building-codex-hooks/SKILL.md
+++ b/skills/deprecated/building-codex-hooks/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: building-codex-hooks
 description: Use when designing, implementing, reviewing, or debugging Codex CLI hooks, including `hooks.json`, `.codex/hooks.json`, feature-flag setup, matcher behavior, event-specific stdin/stdout payloads, and hook scripts for `SessionStart`, `PreToolUse`, `PostToolUse`, `UserPromptSubmit`, or `Stop`.
+metadata:
+  internal: true
 ---
 
 # Codex CLI Hooks

--- a/skills/deprecated/cleaning-atuin-history/SKILL.md
+++ b/skills/deprecated/cleaning-atuin-history/SKILL.md
@@ -9,7 +9,7 @@ metadata:
 
 ## Overview
 
-Audit first, delete second. Use the bundled script to summarize duplicate pressure and high-confidence typo-like retries. For typo cleanup, prefer the transactional `cleanup-typos` command so the flow snapshots `history.db`, uploads the current host history store, deletes candidates, and verifies the result. It rolls back automatically only when no history rows were added after the snapshot; otherwise it preserves the live database and backup for manual recovery.
+Audit first, delete second. Use the bundled script to summarize duplicate pressure and high-confidence typo-like retries. For typo cleanup, prefer the transactional `cleanup-typos` command so the flow snapshots `history.db`, uploads the current host history store, deletes candidates, and verifies the result. If verification fails, it preserves both the live database and snapshot for race-free manual recovery instead of automatically replacing the whole database.
 
 Read `references/atuin-cli.md` when you need the exact delete, dedup, or prune behavior.
 
@@ -18,7 +18,7 @@ Read `references/atuin-cli.md` when you need the exact delete, dedup, or prune b
 - Reviewing a noisy Atuin `history.db` before removing anything.
 - Estimating how much `atuin history dedup` would remove while still keeping the newest repeated entries.
 - Looking for typo-like retries such as `gti status` followed by `git status`.
-- Running a transactional typo cleanup with backup, verification, and rollback.
+- Running a transactional typo cleanup with backup, verification, and manual recovery artifacts.
 - Rechecking an Atuin cleanup plan without mutating the database directly.
 
 ## Guardrails
@@ -28,7 +28,7 @@ Read `references/atuin-cli.md` when you need the exact delete, dedup, or prune b
 - `atuin search --delete` is query-wide and follows Atuin's active search semantics. Do not use it manually for typo cleanup.
 - `cleanup-typos` is the only approved automation path for typo deletion. It may use `atuin search --delete` only after a strict uniqueness gate; any ambiguous match must fall back to the interactive inspector path.
 - `cleanup-typos` must snapshot `history.db` before deletion and delay the final remote sync until verification passes.
-- Rollback is a whole-database restore, so skip automatic restore when concurrent history rows would be lost and preserve both databases for manual recovery.
+- Do not automatically restore the whole database after failure; a check-then-restore race can still discard concurrent history. Preserve the live database and snapshot for manual recovery.
 - Re-confirm every destructive command immediately before running it.
 - Do not delete rows directly from SQLite.
 - Do not edit Atuin config as part of this skill. `history_filter` and `cwd_filter` tuning is out of scope for v1.

--- a/skills/deprecated/cleaning-atuin-history/SKILL.md
+++ b/skills/deprecated/cleaning-atuin-history/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: cleaning-atuin-history
 description: Use when auditing Atuin shell history for noisy duplicates or high-confidence typo/retry pairs and when preparing safe preview-first cleanup steps without editing the SQLite database directly.
+metadata:
+  internal: true
 ---
 
 # Atuin History Cleanup
 
 ## Overview
 
-Audit first, delete second. Use the bundled script to summarize duplicate pressure and high-confidence typo-like retries. For typo cleanup, prefer the transactional `cleanup-typos` command so the flow snapshots `history.db`, uploads the current host history store, deletes candidates, verifies the result, and rolls back automatically if verification fails.
+Audit first, delete second. Use the bundled script to summarize duplicate pressure and high-confidence typo-like retries. For typo cleanup, prefer the transactional `cleanup-typos` command so the flow snapshots `history.db`, uploads the current host history store, deletes candidates, and verifies the result. It rolls back automatically only when no history rows were added after the snapshot; otherwise it preserves the live database and backup for manual recovery.
 
 Read `references/atuin-cli.md` when you need the exact delete, dedup, or prune behavior.
 
@@ -26,7 +28,7 @@ Read `references/atuin-cli.md` when you need the exact delete, dedup, or prune b
 - `atuin search --delete` is query-wide and follows Atuin's active search semantics. Do not use it manually for typo cleanup.
 - `cleanup-typos` is the only approved automation path for typo deletion. It may use `atuin search --delete` only after a strict uniqueness gate; any ambiguous match must fall back to the interactive inspector path.
 - `cleanup-typos` must snapshot `history.db` before deletion and delay the final remote sync until verification passes.
-- Rollback is whole-database restore, not selective row restore.
+- Rollback is a whole-database restore, so skip automatic restore when concurrent history rows would be lost and preserve both databases for manual recovery.
 - Re-confirm every destructive command immediately before running it.
 - Do not delete rows directly from SQLite.
 - Do not edit Atuin config as part of this skill. `history_filter` and `cwd_filter` tuning is out of scope for v1.
@@ -39,16 +41,17 @@ Read `references/atuin-cli.md` when you need the exact delete, dedup, or prune b
 atuin info
 ```
 
-2. Run the audit:
+2. Resolve `scripts/atuin_history_cleanup.py` against this skill directory and run the audit by absolute path:
 
 ```bash
-uv run python skills/deprecated/cleaning-atuin-history/scripts/atuin_history_cleanup.py audit
+ATUIN_HISTORY_SKILL_DIR="/absolute/path/to/cleaning-atuin-history"
+uv run python "$ATUIN_HISTORY_SKILL_DIR/scripts/atuin_history_cleanup.py" audit
 ```
 
 Useful flags:
 
 ```bash
-uv run python skills/deprecated/cleaning-atuin-history/scripts/atuin_history_cleanup.py audit --db-path ~/.local/share/atuin/history.db --dupkeep 3 --before now --typo-window-seconds 300 --max-typos 20
+uv run python "$ATUIN_HISTORY_SKILL_DIR/scripts/atuin_history_cleanup.py" audit --db-path ~/.local/share/atuin/history.db --dupkeep 3 --before now --typo-window-seconds 300 --max-typos 20
 ```
 
 3. Review the `duplicates` section first.
@@ -58,13 +61,13 @@ uv run python skills/deprecated/cleaning-atuin-history/scripts/atuin_history_cle
    Preferred transactional path:
 
 ```bash
-uv run python skills/deprecated/cleaning-atuin-history/scripts/atuin_history_cleanup.py cleanup-typos
+uv run python "$ATUIN_HISTORY_SKILL_DIR/scripts/atuin_history_cleanup.py" cleanup-typos
 ```
 
    Useful flags:
 
 ```bash
-uv run python skills/deprecated/cleaning-atuin-history/scripts/atuin_history_cleanup.py cleanup-typos --db-path ~/.local/share/atuin/history.db --before now --typo-window-seconds 300 --max-typos 20 --backup-dir ~/.local/share/atuin/cleanup-backups/manual-run
+uv run python "$ATUIN_HISTORY_SKILL_DIR/scripts/atuin_history_cleanup.py" cleanup-typos --db-path ~/.local/share/atuin/history.db --before now --typo-window-seconds 300 --max-typos 20 --backup-dir ~/.local/share/atuin/cleanup-backups/manual-run
 ```
 
    Manual review path:

--- a/skills/deprecated/cleaning-atuin-history/scripts/atuin_history_cleanup.py
+++ b/skills/deprecated/cleaning-atuin-history/scripts/atuin_history_cleanup.py
@@ -157,7 +157,7 @@ def parse_cli_args(argv: list[str] | None = None) -> argparse.Namespace:
 
     cleanup = subparsers.add_parser(
         "cleanup-typos",
-        help="Transactionally delete high-confidence typo entries with backup and rollback.",
+        help="Transactionally delete high-confidence typo entries with backup and recovery artifacts.",
     )
     add_shared_history_scope_args(cleanup)
     cleanup.add_argument(
@@ -847,7 +847,7 @@ def cleanup_typos(
 
         detail = str(exc)
         if rollback_warnings:
-            detail += " Rollback warnings: " + "; ".join(rollback_warnings)
+            detail += " Recovery notes: " + "; ".join(rollback_warnings)
         detail += f" Backup dir: {backup_root}"
         raise AuditError(detail) from exc
 

--- a/skills/deprecated/cleaning-atuin-history/scripts/atuin_history_cleanup_transactional.py
+++ b/skills/deprecated/cleaning-atuin-history/scripts/atuin_history_cleanup_transactional.py
@@ -440,28 +440,13 @@ def verify_cleanup_result(
 
 
 def rollback_cleanup(snapshot_db_path: Path, live_db_path: Path) -> list[str]:
-    """Restore the snapshot unless concurrent history writes would be lost."""
-    snapshot_ids = read_history_ids(snapshot_db_path)
-    live_ids = read_history_ids(live_db_path)
-    added_ids = live_ids - snapshot_ids
-    if added_ids:
-        row_phrase = (
-            "1 history row was"
-            if len(added_ids) == 1
-            else f"{len(added_ids)} history rows were"
-        )
-        return [
-            f"Skipped automatic rollback because {row_phrase} added after the snapshot; "
-            "the live database and backup were preserved for manual recovery."
-        ]
-
-    warnings: list[str] = []
-    sqlite_backup(snapshot_db_path, live_db_path)
-    try:
-        run_cli_command(["atuin", "sync", "-f"])
-    except CleanupError as exc:
-        warnings.append(str(exc))
-    return warnings
+    """Preserve live and snapshot databases for race-free manual recovery."""
+    del snapshot_db_path, live_db_path
+    return [
+        "Skipped automatic whole-database rollback to avoid racing with concurrent "
+        "history writes; the live database and backup were preserved for manual "
+        "recovery."
+    ]
 
 
 def render_cleanup_report(result: dict[str, Any]) -> str:

--- a/skills/deprecated/cleaning-atuin-history/scripts/atuin_history_cleanup_transactional.py
+++ b/skills/deprecated/cleaning-atuin-history/scripts/atuin_history_cleanup_transactional.py
@@ -440,7 +440,21 @@ def verify_cleanup_result(
 
 
 def rollback_cleanup(snapshot_db_path: Path, live_db_path: Path) -> list[str]:
-    """Restore the saved database snapshot and best-effort re-align sync state."""
+    """Restore the snapshot unless concurrent history writes would be lost."""
+    snapshot_ids = read_history_ids(snapshot_db_path)
+    live_ids = read_history_ids(live_db_path)
+    added_ids = live_ids - snapshot_ids
+    if added_ids:
+        row_phrase = (
+            "1 history row was"
+            if len(added_ids) == 1
+            else f"{len(added_ids)} history rows were"
+        )
+        return [
+            f"Skipped automatic rollback because {row_phrase} added after the snapshot; "
+            "the live database and backup were preserved for manual recovery."
+        ]
+
     warnings: list[str] = []
     sqlite_backup(snapshot_db_path, live_db_path)
     try:

--- a/skills/deprecated/cleaning-atuin-history/scripts/atuin_history_cleanup_transactional.py
+++ b/skills/deprecated/cleaning-atuin-history/scripts/atuin_history_cleanup_transactional.py
@@ -410,10 +410,11 @@ def verify_cleanup_result(
     target_ids: list[str],
     post_audit: dict[str, Any],
 ) -> dict[str, Any]:
-    """Confirm that only the intended ids disappeared and no typo candidates remain."""
+    """Confirm intended removals while allowing concurrent history additions."""
     if post_audit["typos"]["candidate_count"] != 0:
         raise CleanupError(
-            "Post-delete audit still found high-confidence typo candidates. Rolling back."
+            "Post-delete audit still found high-confidence typo candidates. "
+            "Manual recovery may be required."
         )
 
     snapshot_ids = read_history_ids(snapshot_db_path)
@@ -424,10 +425,9 @@ def verify_cleanup_result(
     target_id_set = set(target_ids)
     unexpected_removed_ids = sorted(set(removed_ids) - target_id_set)
     missing_removed_ids = sorted(target_id_set - set(removed_ids))
-    if added_ids or unexpected_removed_ids or missing_removed_ids:
+    if unexpected_removed_ids or missing_removed_ids:
         raise CleanupError(
             "Post-delete verification failed: "
-            + f"added_ids={added_ids}, "
             + f"unexpected_removed_ids={unexpected_removed_ids}, "
             + f"missing_removed_ids={missing_removed_ids}."
         )

--- a/skills/deprecated/cleaning-atuin-history/tests/test_atuin_history_cleanup.py
+++ b/skills/deprecated/cleaning-atuin-history/tests/test_atuin_history_cleanup.py
@@ -332,6 +332,26 @@ def test_verify_cleanup_result_rejects_unexpected_removed_ids(tmp_path: Path) ->
     assert "unexpected_removed_ids=['2']" in str(excinfo.value)
 
 
+def test_verify_cleanup_result_allows_concurrent_added_ids(tmp_path: Path) -> None:
+    snapshot_db = tmp_path / "history-before.db"
+    live_db = tmp_path / "history-live.db"
+    create_history_db(snapshot_db, ["target", "existing"])
+    create_history_db(live_db, ["existing", "concurrent"])
+
+    result = MODULE.verify_cleanup_result(
+        snapshot_db,
+        live_db,
+        target_ids=["target"],
+        post_audit={"typos": {"candidate_count": 0}},
+    )
+
+    assert result == {
+        "removed_ids": ["target"],
+        "added_ids": ["concurrent"],
+        "target_ids": ["target"],
+    }
+
+
 def test_rollback_preserves_live_database_without_concurrent_rows(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/skills/deprecated/cleaning-atuin-history/tests/test_atuin_history_cleanup.py
+++ b/skills/deprecated/cleaning-atuin-history/tests/test_atuin_history_cleanup.py
@@ -332,6 +332,31 @@ def test_verify_cleanup_result_rejects_unexpected_removed_ids(tmp_path: Path) ->
     assert "unexpected_removed_ids=['2']" in str(excinfo.value)
 
 
+def test_rollback_preserves_concurrent_history_rows(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    snapshot_db = tmp_path / "history-before.db"
+    live_db = tmp_path / "history-live.db"
+    create_history_db(snapshot_db, ["existing"])
+    create_history_db(live_db, ["existing", "concurrent"])
+
+    commands: list[list[str]] = []
+    monkeypatch.setattr(
+        MODULE.transactional,
+        "run_cli_command",
+        lambda parts, **kwargs: commands.append(parts),
+    )
+
+    warnings = MODULE.rollback_cleanup(snapshot_db, live_db)
+
+    assert MODULE.read_history_ids(live_db) == {"existing", "concurrent"}
+    assert commands == []
+    assert warnings == [
+        "Skipped automatic rollback because 1 history row was added after the snapshot; "
+        "the live database and backup were preserved for manual recovery."
+    ]
+
+
 def test_cleanup_typos_runs_transactional_flow(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/skills/deprecated/cleaning-atuin-history/tests/test_atuin_history_cleanup.py
+++ b/skills/deprecated/cleaning-atuin-history/tests/test_atuin_history_cleanup.py
@@ -332,6 +332,32 @@ def test_verify_cleanup_result_rejects_unexpected_removed_ids(tmp_path: Path) ->
     assert "unexpected_removed_ids=['2']" in str(excinfo.value)
 
 
+def test_rollback_preserves_live_database_without_concurrent_rows(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    snapshot_db = tmp_path / "history-before.db"
+    live_db = tmp_path / "history-live.db"
+    create_history_db(snapshot_db, ["deleted", "existing"])
+    create_history_db(live_db, ["existing"])
+
+    commands: list[list[str]] = []
+    monkeypatch.setattr(
+        MODULE.transactional,
+        "run_cli_command",
+        lambda parts, **kwargs: commands.append(parts),
+    )
+
+    warnings = MODULE.rollback_cleanup(snapshot_db, live_db)
+
+    assert MODULE.read_history_ids(live_db) == {"existing"}
+    assert commands == []
+    assert warnings == [
+        "Skipped automatic whole-database rollback to avoid racing with concurrent "
+        "history writes; the live database and backup were preserved for manual "
+        "recovery."
+    ]
+
+
 def test_rollback_preserves_concurrent_history_rows(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -352,8 +378,9 @@ def test_rollback_preserves_concurrent_history_rows(
     assert MODULE.read_history_ids(live_db) == {"existing", "concurrent"}
     assert commands == []
     assert warnings == [
-        "Skipped automatic rollback because 1 history row was added after the snapshot; "
-        "the live database and backup were preserved for manual recovery."
+        "Skipped automatic whole-database rollback to avoid racing with concurrent "
+        "history writes; the live database and backup were preserved for manual "
+        "recovery."
     ]
 
 

--- a/skills/deprecated/writing-work-logs/SKILL.md
+++ b/skills/deprecated/writing-work-logs/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: writing-work-logs
 description: Use only when the user explicitly names the writing-work-logs skill; never auto-activate from generic work log, daily log, EOD summary, status update, or date-range summary requests.
+metadata:
+  internal: true
 ---
 
 # Work Log Writer

--- a/skills/designing-slide-colors/assets/examples/with-palette.md
+++ b/skills/designing-slide-colors/assets/examples/with-palette.md
@@ -29,7 +29,7 @@ This presentation uses the **Light Professional** strategy:
 * Text Primary: `#2C2C2C` — Body text
 * Text Secondary: `#666666` — Captions
 
-Generated using: `uv run skills/designing-slide-colors/scripts/generate_palette.py show clean-corporate`
+Generated with `scripts/generate_palette.py show clean-corporate`, resolved from the `designing-slide-colors` skill directory.
 
 ---
 

--- a/skills/designing-slide-colors/references/color-design/output-template.md
+++ b/skills/designing-slide-colors/references/color-design/output-template.md
@@ -84,11 +84,11 @@ Always use this exact structure:
 
 ## Validation Checklist
 
-- [x] Text contrast ratio ≥ 4.5:1 for body text (≥ 7:1 for AAA)
-- [x] Accent color stands out clearly from primary
-- [x] Palette limited to 5-7 colors maximum
-- [x] Colors work on projector (avoid pure black #000000 / pure white #FFFFFF)
-- [x] Consistent color usage across all slide types
+- [ ] Verify body-text contrast is ≥ 4.5:1 (≥ 7:1 for AAA)
+- [ ] Verify the accent remains distinct from the primary color
+- [ ] Verify the palette is limited to 5-7 colors
+- [ ] Verify the exported deck on the target projector
+- [ ] Verify color meanings stay consistent across slide types
 ```
 
 ---
@@ -123,17 +123,17 @@ Dark Technical — chosen because the presentation focuses on system architectur
 
 ## Notes & Constraints
 
-* All text contrasts exceed 7:1 for WCAG AAA accessibility
-* Tested on projector—colors remain distinct even in bright rooms
+* Text Primary/Background is 11.25:1 (AAA); Text Secondary/Background is 4.52:1 (AA)
+* Projector performance remains unverified until the exported deck is tested in the target room
 * Amber accent used sparingly (max 5-10% of visual space) to maintain focus
 * Avoid pure white text to reduce eye strain in dark rooms
 
 ## Validation Checklist
 
-- [x] Text contrast ratio ≥ 4.5:1 for body text (≥ 7:1 for AAA)
+- [x] Text Primary and Text Secondary contrast ratios are calculated above
 - [x] Accent color stands out clearly from primary
 - [x] Palette limited to 5-7 colors maximum
-- [x] Colors work on projector (avoid pure black #000000 / pure white #FFFFFF)
+- [ ] Verify the exported deck on the target projector
 - [x] Consistent color usage across all slide types
 
 ---
@@ -168,17 +168,17 @@ Light Professional — chosen for a formal business setting with mixed audience 
 
 ## Notes & Constraints
 
-* Text Primary/Background contrast is 14.2:1 (exceeds AAA)
-* All colors print well on standard office printers
+* Text Primary/Background contrast is 13.38:1 (exceeds AAA)
+* Print performance remains unverified until a representative handout is printed
 * Accent color (orange) used only for positive metrics and emphasis (< 10% usage)
 * Conservative palette appropriate for C-level audience
 
 ## Validation Checklist
 
-- [x] Text contrast ratio ≥ 4.5:1 for body text (≥ 7:1 for AAA)
+- [x] Text Primary/Background contrast exceeds 7:1
 - [x] Accent color stands out clearly from primary
 - [x] Palette limited to 5-7 colors maximum
-- [x] Colors work on projector (avoid pure black #000000 / pure white #FFFFFF)
+- [ ] Verify a representative print and the exported deck on the target projector
 - [x] Consistent color usage across all slide types
 
 ---
@@ -214,16 +214,16 @@ Accent-Driven — chosen for a high-impact product launch requiring strong visua
 ## Notes & Constraints
 
 * Accent color used sparingly—only for product name, CTAs, and critical stats (< 10%)
-* High contrast (16.8:1 for text) ensures readability in large venues
+* Text Primary/Background contrast is 15.43:1; venue readability still requires an exported-deck check
 * Minimal design philosophy: every element must serve a purpose
 * Ample whitespace between elements
 
 ## Validation Checklist
 
-- [x] Text contrast ratio ≥ 4.5:1 for body text (≥ 7:1 for AAA)
+- [x] Text Primary/Background contrast exceeds 7:1
 - [x] Accent color stands out clearly from primary
 - [x] Palette limited to 5-7 colors maximum
-- [x] Colors work on projector (avoid pure black #000000 / pure white #FFFFFF)
+- [ ] Verify the exported deck in the target venue
 - [x] Consistent color usage across all slide types
 
 ---

--- a/skills/designing-slide-colors/references/color-design/strategies.md
+++ b/skills/designing-slide-colors/references/color-design/strategies.md
@@ -142,7 +142,7 @@ See [../color-palettes.md](../color-palettes.md) for:
 ### Tips
 
 - Use #FAFAFA instead of pure white (#FFFFFF) to reduce glare
-- Ensure text contrast is very high (≥ 7:1 for AA)
+- Ensure text contrast is very high (≥ 7:1 for AAA)
 - Conservative colors are safer for business contexts
 - Test printed versions—some blues may appear too dark
 

--- a/skills/designing-slide-colors/references/color-palettes.md
+++ b/skills/designing-slide-colors/references/color-palettes.md
@@ -10,31 +10,32 @@ These palettes define full 7-role color systems for comprehensive slide design. 
 
 ### Available Palettes
 
-Use the palette generation script to browse and retrieve palette details:
+Resolve `scripts/generate_palette.py` against the `designing-slide-colors` skill directory and use its absolute path to browse palette details.
 
 **List all available palettes:**
 ```bash
-uv run skills/designing-slide-colors/scripts/generate_palette.py list
+DESIGNING_SLIDE_COLORS_SKILL_DIR="/absolute/path/to/designing-slide-colors"
+uv run "$DESIGNING_SLIDE_COLORS_SKILL_DIR/scripts/generate_palette.py" list
 ```
 
 **Show details for a specific palette:**
 ```bash
-uv run skills/designing-slide-colors/scripts/generate_palette.py show <palette-name>
+uv run "$DESIGNING_SLIDE_COLORS_SKILL_DIR/scripts/generate_palette.py" show <palette-name>
 ```
 
 **Examples:**
 ```bash
 # List all palettes grouped by category
-uv run skills/designing-slide-colors/scripts/generate_palette.py list
+uv run "$DESIGNING_SLIDE_COLORS_SKILL_DIR/scripts/generate_palette.py" list
 
 # Show Code-Focused Blue palette
-uv run skills/designing-slide-colors/scripts/generate_palette.py show code-blue
+uv run "$DESIGNING_SLIDE_COLORS_SKILL_DIR/scripts/generate_palette.py" show code-blue
 
 # Show Modern Minimal palette
-uv run skills/designing-slide-colors/scripts/generate_palette.py show modern-minimal
+uv run "$DESIGNING_SLIDE_COLORS_SKILL_DIR/scripts/generate_palette.py" show modern-minimal
 
 # Show Data Visualization palette
-uv run skills/designing-slide-colors/scripts/generate_palette.py show data-viz
+uv run "$DESIGNING_SLIDE_COLORS_SKILL_DIR/scripts/generate_palette.py" show data-viz
 ```
 
 ### Palette Categories
@@ -69,10 +70,10 @@ uv run skills/designing-slide-colors/scripts/generate_palette.py show data-viz
 **Generate from brand color:**
 ```bash
 # Generate light theme from brand color
-uv run skills/designing-slide-colors/scripts/generate_palette.py brand "#2E75B6" light
+uv run "$DESIGNING_SLIDE_COLORS_SKILL_DIR/scripts/generate_palette.py" brand "#2E75B6" light
 
 # Generate dark theme from brand color
-uv run skills/designing-slide-colors/scripts/generate_palette.py brand "#569CD6" dark
+uv run "$DESIGNING_SLIDE_COLORS_SKILL_DIR/scripts/generate_palette.py" brand "#569CD6" dark
 ```
 
 ---
@@ -83,31 +84,31 @@ Quick color schemes with SVG code examples for rapid illustration creation.
 
 ### Available SVG Palettes
 
-Use the palette generation script to browse and retrieve SVG palette details:
+Use the resolved palette script path to browse and retrieve SVG palette details:
 
 **List all available SVG palettes:**
 ```bash
-uv run skills/designing-slide-colors/scripts/generate_palette.py svg-list
+uv run "$DESIGNING_SLIDE_COLORS_SKILL_DIR/scripts/generate_palette.py" svg-list
 ```
 
 **Show details for a specific SVG palette:**
 ```bash
-uv run skills/designing-slide-colors/scripts/generate_palette.py svg-show <palette-name>
+uv run "$DESIGNING_SLIDE_COLORS_SKILL_DIR/scripts/generate_palette.py" svg-show <palette-name>
 ```
 
 **Examples:**
 ```bash
 # List all SVG palettes
-uv run skills/designing-slide-colors/scripts/generate_palette.py svg-list
+uv run "$DESIGNING_SLIDE_COLORS_SKILL_DIR/scripts/generate_palette.py" svg-list
 
 # Show Default palette
-uv run skills/designing-slide-colors/scripts/generate_palette.py svg-show default
+uv run "$DESIGNING_SLIDE_COLORS_SKILL_DIR/scripts/generate_palette.py" svg-show default
 
 # Show Creative & Modern palette
-uv run skills/designing-slide-colors/scripts/generate_palette.py svg-show creative
+uv run "$DESIGNING_SLIDE_COLORS_SKILL_DIR/scripts/generate_palette.py" svg-show creative
 
 # Show Dark Mode palette
-uv run skills/designing-slide-colors/scripts/generate_palette.py svg-show dark-mode
+uv run "$DESIGNING_SLIDE_COLORS_SKILL_DIR/scripts/generate_palette.py" svg-show dark-mode
 ```
 
 ### SVG Palette List

--- a/skills/designing-slide-colors/references/output-examples.md
+++ b/skills/designing-slide-colors/references/output-examples.md
@@ -46,7 +46,7 @@ Format structure: see `color-design/output-template.md`.
 - [x] Contrast ratio Text Primary/Background = 11.25:1 (exceeds WCAG AAA)
 - [x] Contrast ratio Primary/Background = 5.65:1 (meets WCAG AA, close to AAA)
 - [x] Palette limited to 7 colors
-- [x] Colors tested on projector (high contrast maintained)
+- [ ] Verify the exported deck on the target projector; do not infer projector performance from contrast ratios alone
 - [x] Consistent with VS Code theme (familiar to developers)
 ```
 
@@ -89,10 +89,10 @@ Format structure: see `color-design/output-template.md`.
 
 ## Validation Checklist
 
-- [x] Contrast ratio Text Primary/Background = 14.2:1 (exceeds WCAG AAA)
-- [x] Contrast ratio Primary/Background = 5.8:1 (meets WCAG AA)
+- [x] Contrast ratio Text Primary/Background = 13.38:1 (exceeds WCAG AAA)
+- [x] Contrast ratio Primary/Background = 4.64:1 (meets WCAG AA)
 - [x] Palette limited to 7 colors
-- [x] Colors work for printing and projection
+- [ ] Verify a representative print and the exported deck on the target projector
 - [x] Professional, conservative appearance suitable for business
 ```
 

--- a/skills/designing-slide-colors/scripts/check_contrast.py
+++ b/skills/designing-slide-colors/scripts/check_contrast.py
@@ -73,7 +73,7 @@ if __name__ == "__main__":
             f"WCAG AA (normal text):  {'✅ Pass' if wcag['AA_normal'] else '❌ Fail'} (≥4.5:1)"
         )
         print(
-            f"WCAG AA (large text):   {'✅ Pass' if wcag['AA_large'] else '✅ Pass'} (≥3.0:1)"
+            f"WCAG AA (large text):   {'✅ Pass' if wcag['AA_large'] else '❌ Fail'} (≥3.0:1)"
         )
         print(
             f"WCAG AAA (normal text): {'✅ Pass' if wcag['AAA_normal'] else '❌ Fail'} (≥7.0:1)"

--- a/skills/designing-slide-colors/scripts/check_contrast.py
+++ b/skills/designing-slide-colors/scripts/check_contrast.py
@@ -4,17 +4,20 @@
 # ///
 """Check color contrast ratios for WCAG compliance."""
 
+import re
 import sys
 
 
 def hex_to_rgb(hex_color: str) -> tuple[int, int, int]:
-    """Convert hex color to RGB tuple."""
-    hex_color = hex_color.lstrip("#")
-    if len(hex_color) != 6:
-        raise ValueError(f"Invalid hex color: {hex_color} (must be 6 characters)")
-    r = int(hex_color[0:2], 16)
-    g = int(hex_color[2:4], 16)
-    b = int(hex_color[4:6], 16)
+    """Convert a three-channel hexadecimal color to an RGB tuple."""
+    normalized = hex_color.removeprefix("#")
+    if re.fullmatch(r"[0-9A-Fa-f]{6}", normalized) is None:
+        raise ValueError(
+            f"Invalid hex color: {hex_color!r} (expected #RRGGBB or RRGGBB)"
+        )
+    r = int(normalized[0:2], 16)
+    g = int(normalized[2:4], 16)
+    b = int(normalized[4:6], 16)
     return (r, g, b)
 
 

--- a/skills/designing-slide-colors/scripts/generate_palette.py
+++ b/skills/designing-slide-colors/scripts/generate_palette.py
@@ -4,9 +4,14 @@
 # ///
 """Generate slide color palettes from brand colors or strategies."""
 
-from colorsys import hls_to_rgb, rgb_to_hls
+import shlex
 import sys
+from colorsys import hls_to_rgb, rgb_to_hls
+from pathlib import Path
 from typing import Any, cast
+
+SCRIPT_PATH = Path(__file__).resolve()
+CONTRAST_CHECKER_PATH = SCRIPT_PATH.with_name("check_contrast.py")
 
 
 def hex_to_rgb(hex_color: str) -> tuple[int, int, int]:
@@ -24,6 +29,30 @@ def rgb_to_hex(rgb: tuple[int, int, int]) -> str:
     """Convert RGB tuple to hex color."""
     r, g, b = [max(0, min(255, int(x))) for x in rgb]
     return f"#{r:02x}{g:02x}{b:02x}"
+
+
+def relative_luminance(rgb: tuple[int, int, int]) -> float:
+    """Calculate WCAG relative luminance for an RGB color."""
+
+    def adjust(value: int) -> float:
+        channel = value / 255.0
+        return (
+            channel / 12.92
+            if channel <= 0.03928
+            else ((channel + 0.055) / 1.055) ** 2.4
+        )
+
+    red, green, blue = rgb
+    return 0.2126 * adjust(red) + 0.7152 * adjust(green) + 0.0722 * adjust(blue)
+
+
+def contrast_ratio(color1: str, color2: str) -> float:
+    """Calculate the WCAG contrast ratio between two hex colors."""
+    luminance1 = relative_luminance(hex_to_rgb(color1))
+    luminance2 = relative_luminance(hex_to_rgb(color2))
+    lighter = max(luminance1, luminance2)
+    darker = min(luminance1, luminance2)
+    return (lighter + 0.05) / (darker + 0.05)
 
 
 def adjust_lightness(hex_color: str, factor: float) -> str:
@@ -206,71 +235,61 @@ PALETTE_METADATA = {
         "name": "Code-Focused Blue",
         "category": "Dark Technical",
         "best_for": "Code-heavy presentations, technical demos, system architecture",
-        "contrast": "Text Primary/Background = 8.2:1, Primary/Background = 4.8:1",
         "notes": "Inspired by VS Code theme; familiar to developers",
     },
     "terminal-dark": {
         "name": "Terminal Dark",
         "category": "Dark Technical",
         "best_for": "Terminal commands, CLI tools, DevOps presentations",
-        "contrast": "Text Primary/Background = 10.5:1, Primary/Background = 6.2:1",
         "notes": "High contrast for projectors; three-color semantic system",
     },
     "midnight-professional": {
         "name": "Midnight Professional",
         "category": "Dark Technical",
         "best_for": "Professional technical presentations with a softer feel",
-        "contrast": "Text Primary/Background = 9.8:1, Primary/Background = 4.5:1",
         "notes": "Less harsh than pure black backgrounds",
     },
     "clean-corporate": {
         "name": "Clean Corporate",
         "category": "Light Professional",
         "best_for": "Business presentations, documentation, formal settings",
-        "contrast": "Text Primary/Background = 14.2:1, Primary/Background = 5.8:1",
         "notes": "Conservative and widely acceptable",
     },
     "modern-minimal": {
         "name": "Modern Minimal",
         "category": "Light Professional",
         "best_for": "Modern tech companies, product presentations, startups",
-        "contrast": "Text Primary/Background = 15.8:1, Primary/Background = 7.1:1",
         "notes": "Material Design inspired; clean and modern",
     },
     "warm-professional": {
         "name": "Warm Professional",
         "category": "Light Professional",
         "best_for": "Creative presentations, design reviews, brand-focused decks",
-        "contrast": "Text Primary/Background = 13.5:1, Primary/Background = 6.8:1",
         "notes": "Warm palette for approachable, friendly tone",
     },
     "minimal-teal": {
         "name": "Minimal with Teal Focus",
         "category": "Accent-Driven",
         "best_for": "Story-driven presentations, keynotes, single-message slides",
-        "contrast": "Text Primary/Background = 16.8:1, Accent/Background = 3.8:1",
         "notes": "Minimal design; let content breathe; use accent sparingly (5-10% of elements)",
     },
     "grayscale-red": {
         "name": "Gray Scale with Red Accent",
         "category": "Accent-Driven",
         "best_for": "High-impact messages, problem-solution narratives, urgent topics",
-        "contrast": "Text Primary/Background = 13.2:1, Accent/Background = 5.5:1",
         "notes": "Red accent should be reserved for 1-2 key elements per slide",
     },
     "data-viz": {
         "name": "Data Visualization (Categorical)",
         "category": "Specialized",
         "best_for": "Charts, graphs, multi-category data",
-        "contrast": "N/A",
         "notes": "Tableau-inspired; colorblind-friendly; maximizes distinction",
     },
     "accessibility": {
         "name": "Accessibility First (High Contrast)",
         "category": "Specialized",
         "best_for": "Accessibility requirements, large audiences, recorded content",
-        "contrast": "All combinations meet WCAG AAA (7:1 minimum)",
-        "notes": "Maximum legibility; suitable for vision-impaired audiences",
+        "notes": "Validate each foreground/background role pairing before use",
     },
 }
 
@@ -389,10 +408,26 @@ def format_palette_markdown(palette: dict[str, str], preset_name: str = "") -> s
         output.append(f"## {meta['name']}\n")
         output.append(f"**Category:** {meta['category']}")
         output.append(f"**Best for:** {meta['best_for']}")
-        output.append(f"**Contrast:** {meta['contrast']}")
-        output.append(f"**Notes:** {meta['notes']}\n")
+        output.append(f"**Notes:** {meta['notes']}")
     else:
-        output.append("## Color Palette\n")
+        output.append("## Color Palette")
+
+    background = palette.get("Background")
+    if background:
+        ratios = [
+            f"{role}/Background = {contrast_ratio(color, background):.2f}:1"
+            for role in (
+                "Text Primary",
+                "Text Secondary",
+                "Primary",
+                "Secondary",
+                "Accent",
+            )
+            if (color := palette.get(role)) is not None
+        ]
+        output.append(f"**Calculated contrast:** {', '.join(ratios)}\n")
+    else:
+        output.append("")
 
     # Display colors
     for role, color in palette.items():
@@ -418,7 +453,8 @@ def format_palette_markdown(palette: dict[str, str], preset_name: str = "") -> s
         output.append("\n## Validation\n")
         output.append("Check contrast ratios:")
         output.append(
-            f"```bash\nuv run skills/designing-slide-colors/scripts/check_contrast.py '{palette['Text Primary']}' '{palette['Background']}'\n```"
+            f"```bash\nuv run {shlex.quote(str(CONTRAST_CHECKER_PATH))} "
+            f"'{palette['Text Primary']}' '{palette['Background']}'\n```"
         )
 
     return "\n".join(output)
@@ -452,15 +488,11 @@ def list_palettes() -> str:
     output.append("\n## Usage\n")
     output.append("Show details for a specific palette:")
     output.append("```bash")
-    output.append(
-        "uv run skills/designing-slide-colors/scripts/generate_palette.py show <palette-name>"
-    )
+    output.append(f"uv run {shlex.quote(str(SCRIPT_PATH))} show <palette-name>")
     output.append("```\n")
     output.append("Example:")
     output.append("```bash")
-    output.append(
-        "uv run skills/designing-slide-colors/scripts/generate_palette.py show code-blue"
-    )
+    output.append(f"uv run {shlex.quote(str(SCRIPT_PATH))} show code-blue")
     output.append("```")
 
     return "\n".join(output)
@@ -478,18 +510,12 @@ def list_svg_palettes() -> str:
     output.append("\n## Usage\n")
     output.append("Show details for a specific SVG palette:")
     output.append("```bash")
-    output.append(
-        "uv run skills/designing-slide-colors/scripts/generate_palette.py svg-show <palette-name>"
-    )
+    output.append(f"uv run {shlex.quote(str(SCRIPT_PATH))} svg-show <palette-name>")
     output.append("```\n")
     output.append("Example:")
     output.append("```bash")
-    output.append(
-        "uv run skills/designing-slide-colors/scripts/generate_palette.py svg-show default"
-    )
-    output.append(
-        "uv run skills/designing-slide-colors/scripts/generate_palette.py svg-show creative"
-    )
+    output.append(f"uv run {shlex.quote(str(SCRIPT_PATH))} svg-show default")
+    output.append(f"uv run {shlex.quote(str(SCRIPT_PATH))} svg-show creative")
     output.append("```")
 
     return "\n".join(output)

--- a/skills/designing-slide-colors/scripts/generate_palette.py
+++ b/skills/designing-slide-colors/scripts/generate_palette.py
@@ -4,6 +4,7 @@
 # ///
 """Generate slide color palettes from brand colors or strategies."""
 
+import re
 import shlex
 import sys
 from colorsys import hls_to_rgb, rgb_to_hls
@@ -15,13 +16,15 @@ CONTRAST_CHECKER_PATH = SCRIPT_PATH.with_name("check_contrast.py")
 
 
 def hex_to_rgb(hex_color: str) -> tuple[int, int, int]:
-    """Convert hex color to RGB tuple."""
-    hex_color = hex_color.lstrip("#")
-    if len(hex_color) != 6:
-        raise ValueError(f"Invalid hex color: {hex_color}")
-    r = int(hex_color[0:2], 16)
-    g = int(hex_color[2:4], 16)
-    b = int(hex_color[4:6], 16)
+    """Convert a three-channel hexadecimal color to an RGB tuple."""
+    normalized = hex_color.removeprefix("#")
+    if re.fullmatch(r"[0-9A-Fa-f]{6}", normalized) is None:
+        raise ValueError(
+            f"Invalid hex color: {hex_color!r} (expected #RRGGBB or RRGGBB)"
+        )
+    r = int(normalized[0:2], 16)
+    g = int(normalized[2:4], 16)
+    b = int(normalized[4:6], 16)
     return (r, g, b)
 
 
@@ -86,6 +89,10 @@ def generate_palette_from_brand(
     Returns:
         Dictionary with 7 color roles
     """
+    if style not in {"light", "dark"}:
+        raise ValueError("Style must be 'light' or 'dark'")
+    brand_color = rgb_to_hex(hex_to_rgb(brand_color)).upper()
+
     if style == "dark":
         return {
             "Background": "#1E1E1E",

--- a/skills/managing-python-with-uv/references/packaging.md
+++ b/skills/managing-python-with-uv/references/packaging.md
@@ -80,15 +80,21 @@ uv run --with dist/my_package-1.0.0-py3-none-any.whl python -c "import my_packag
 
 ## Publishing
 
+Keep upload tokens out of command arguments. Set `UV_PUBLISH_TOKEN` through the shell's secure environment or CI secret store, then publish without a token flag.
+
 **To PyPI:**
 ```bash
-uv publish --token $PYPI_TOKEN
+UV_PUBLISH_TOKEN="$PYPI_TOKEN" uv publish
 ```
 
 **To Test PyPI (recommended first):**
 ```bash
-uv publish --publish-url https://test.pypi.org/legacy/ --token $TEST_PYPI_TOKEN
+UV_PUBLISH_TOKEN="$TEST_PYPI_TOKEN" \
+UV_PUBLISH_URL="https://test.pypi.org/legacy/" \
+uv publish
 ```
+
+Prefer trusted publishing in supported CI environments so no long-lived upload token is required.
 
 **Test installation from Test PyPI:**
 ```bash

--- a/skills/researching-gourmet-venues/SKILL.md
+++ b/skills/researching-gourmet-venues/SKILL.md
@@ -28,17 +28,17 @@ Template-first workflow for traceable, comparable, auditable food recommendation
 
 ## Ranking Retrieval (When user asks for “highest score”)
 Before extracting any “top N” list, **confirm the scope**:
-- **Geography**: Okinawa *prefecture* vs *main island only* vs *specific subarea*.
+- **Geography**: requested city, administrative region, island group, or subarea boundaries.
 - **Category**: overall vs cuisine category.
 - **Source URL**: must match the user’s intent exactly.
 
 **Checklist (must pass):**
-1. URL matches the requested scope (prefecture vs category).
-2. If “main island only” is required, exclude island subareas (A4705/A4706).
-3. Page title confirms the intended ranking.
-4. Language modal handled so list items actually render.
+1. URL and page title match the requested geography and category.
+2. Exclude outlying islands, suburbs, or neighboring regions when the requested boundary omits them.
+3. Record any source-specific area identifiers used to enforce the boundary.
+4. Handle consent, language, or location modals so list items actually render.
 
-If static scraping fails or content is blocked, **use Playwright** to load the page, close the language modal (日本語), and then extract items.
+If static scraping fails or content is blocked, use available browser automation, close blocking modals in the appropriate locale, and then extract items.
 
 ## Evidence & Negative Review Rules
 - Sources must include: **Maps + local reviews + guide/editorial + official channel** (where available).

--- a/skills/writing-agents-md/agents/openai.yaml
+++ b/skills/writing-agents-md/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "AGENTS.md Writer"
-  short_description: "Create, review, audit, and update AGENTS.md guides, including nested monorepo instructions."
+  short_description: "Create and review scoped AGENTS.md repository guides."
   default_prompt: "Use $writing-agents-md to draft, review, or update repository AGENTS.md agent guidelines."

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -106,9 +106,9 @@ Treat a plan as complete only when all of these are true:
 
 Do not infer completion from implementation work alone. If evidence is missing, report which checks remain open instead of calling the plan complete.
 
-At the end of any task that uses this skill, inspect `./docs/plans/*.md` for active plans that appear complete. If an active plan appears complete, run the Completion Review rules before responding.
+At the end of a task that executes a saved plan, run the Completion Review only for the current plan. Do not inspect, update, or archive unrelated plan files merely because this skill was active.
 
-When the plan is complete, create `./docs/plans/archived/` if needed, archive the plan there immediately, and report the archived path. Do not archive if completion evidence is missing. Do not leave a completed plan in `./docs/plans/`. If an archived file with the same name already exists, stop and report the conflict instead of overwriting.
+When the current plan is complete, create `./docs/plans/archived/` if needed, archive that plan there immediately, and report the archived path. Do not archive if completion evidence is missing. If an archived file with the same name already exists, stop and report the conflict instead of overwriting.
 
 ## Useful Distinctions
 

--- a/tests/test_skill_repository.py
+++ b/tests/test_skill_repository.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from pathlib import Path
+from types import ModuleType
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILLS = ROOT / "skills"
+
+
+def load_module(path: Path, name: str) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_deprecated_skills_are_hidden_from_standard_discovery() -> None:
+    for skill_md in sorted((SKILLS / "deprecated").glob("*/SKILL.md")):
+        frontmatter = yaml.safe_load(skill_md.read_text().split("---", 2)[1])
+        assert frontmatter.get("metadata", {}).get("internal") is True, skill_md
+
+
+def test_openai_short_descriptions_fit_supported_ui_length() -> None:
+    for metadata_path in sorted(SKILLS.glob("**/agents/openai.yaml")):
+        metadata = yaml.safe_load(metadata_path.read_text())
+        description = metadata["interface"]["short_description"]
+        assert 25 <= len(description) <= 64, metadata_path
+
+
+def test_bundled_script_commands_do_not_assume_source_checkout_layout() -> None:
+    offenders: list[Path] = []
+    for markdown_path in sorted(SKILLS.glob("**/*.md")):
+        if "/assets/" in markdown_path.as_posix():
+            continue
+        if (
+            "skills/" in markdown_path.read_text()
+            and "/scripts/" in markdown_path.read_text()
+        ):
+            offenders.append(markdown_path)
+    assert offenders == []
+
+
+def test_marp_validator_rejects_unclosed_frontmatter(tmp_path: Path) -> None:
+    deck = tmp_path / "invalid.md"
+    deck.write_text("---\nmarp: true\n# Missing closing delimiter\n")
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(SKILLS / "authoring-marp-slides/scripts/validate_marpit.sh"),
+            str(deck),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "syntax valid" not in result.stdout
+
+
+def test_contrast_checker_reports_failed_large_text(tmp_path: Path) -> None:
+    del tmp_path
+    result = subprocess.run(
+        [
+            "uv",
+            "run",
+            "--no-project",
+            str(SKILLS / "designing-slide-colors/scripts/check_contrast.py"),
+            "#999999",
+            "#FFFFFF",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "WCAG AA (large text):   ❌ Fail" in result.stdout
+
+
+def test_generated_palette_contrast_is_calculated_from_colors() -> None:
+    generator = load_module(
+        SKILLS / "designing-slide-colors/scripts/generate_palette.py",
+        "generate_palette_for_test",
+    )
+    checker = load_module(
+        SKILLS / "designing-slide-colors/scripts/check_contrast.py",
+        "check_contrast_for_test",
+    )
+    palette = generator.generate_preset_palette("accessibility")
+    output = generator.format_palette_markdown(palette, "accessibility")
+    expected = checker.contrast_ratio(palette["Primary"], palette["Background"])
+
+    assert "All combinations meet WCAG AAA" not in output
+    assert f"Primary/Background = {expected:.2f}:1" in output
+
+
+def test_publish_examples_keep_tokens_out_of_argv() -> None:
+    packaging = (SKILLS / "managing-python-with-uv/references/packaging.md").read_text()
+    assert "--token" not in packaging
+    assert "UV_PUBLISH_TOKEN" in packaging
+
+
+def test_logging_context_has_a_default_for_unrelated_records() -> None:
+    logging_reference = (
+        SKILLS / "configuring-python-logging/references/logging.md"
+    ).read_text()
+    assert 'defaults={"user_id": "-"}' in logging_reference
+
+
+def test_plan_archival_is_scoped_to_the_current_plan() -> None:
+    plan_skill = (SKILLS / "writing-plans/SKILL.md").read_text()
+    assert "inspect `./docs/plans/*.md`" not in plan_skill
+    assert "current plan" in plan_skill
+
+
+def test_generic_gourmet_ranking_is_not_hardcoded_to_okinawa() -> None:
+    gourmet_skill = (SKILLS / "researching-gourmet-venues/SKILL.md").read_text()
+    ranking_section = gourmet_skill.split("## Ranking Retrieval", 1)[1].split("## ", 1)[
+        0
+    ]
+    assert "Okinawa" not in ranking_section
+    assert "A4705" not in ranking_section
+
+
+def test_slide_image_guidance_preserves_inline_images() -> None:
+    slide_skill = (SKILLS / "creating-slide-decks/SKILL.md").read_text()
+    assert "for all images" not in slide_skill
+    assert "inline" in slide_skill

--- a/tests/test_skill_repository.py
+++ b/tests/test_skill_repository.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import re
 import subprocess
 import sys
@@ -8,7 +9,6 @@ from pathlib import Path
 from types import ModuleType
 
 import pytest
-import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
 SKILLS = ROOT / "skills"
@@ -25,14 +25,19 @@ def load_module(path: Path, name: str) -> ModuleType:
 
 def test_deprecated_skills_are_hidden_from_standard_discovery() -> None:
     for skill_md in sorted((SKILLS / "deprecated").glob("*/SKILL.md")):
-        frontmatter = yaml.safe_load(skill_md.read_text().split("---", 2)[1])
-        assert frontmatter.get("metadata", {}).get("internal") is True, skill_md
+        frontmatter = skill_md.read_text().split("---", 2)[1]
+        assert "\nmetadata:\n  internal: true\n" in f"\n{frontmatter}\n", skill_md
 
 
 def test_openai_short_descriptions_fit_supported_ui_length() -> None:
     for metadata_path in sorted(SKILLS.glob("**/agents/openai.yaml")):
-        metadata = yaml.safe_load(metadata_path.read_text())
-        description = metadata["interface"]["short_description"]
+        description_line = next(
+            line
+            for line in metadata_path.read_text().splitlines()
+            if line.lstrip().startswith("short_description:")
+        )
+        description = json.loads(description_line.split(":", 1)[1].strip())
+        assert isinstance(description, str), metadata_path
         assert 25 <= len(description) <= 64, metadata_path
 
 

--- a/tests/test_skill_repository.py
+++ b/tests/test_skill_repository.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import importlib.util
+import re
 import subprocess
+import sys
 from pathlib import Path
 from types import ModuleType
 
+import pytest
 import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -34,14 +37,12 @@ def test_openai_short_descriptions_fit_supported_ui_length() -> None:
 
 
 def test_bundled_script_commands_do_not_assume_source_checkout_layout() -> None:
+    checkout_script = re.compile(r"(?<![\w/])skills/[^\s`\"']+/scripts/")
     offenders: list[Path] = []
     for markdown_path in sorted(SKILLS.glob("**/*.md")):
         if "/assets/" in markdown_path.as_posix():
             continue
-        if (
-            "skills/" in markdown_path.read_text()
-            and "/scripts/" in markdown_path.read_text()
-        ):
+        if checkout_script.search(markdown_path.read_text()):
             offenders.append(markdown_path)
     assert offenders == []
 
@@ -65,13 +66,72 @@ def test_marp_validator_rejects_unclosed_frontmatter(tmp_path: Path) -> None:
     assert "syntax valid" not in result.stdout
 
 
-def test_contrast_checker_reports_failed_large_text(tmp_path: Path) -> None:
-    del tmp_path
+def test_marp_validator_requires_exactly_one_file(tmp_path: Path) -> None:
+    deck = tmp_path / "valid.md"
+    deck.write_text("---\nmarp: true\n---\n# Slide\n")
+
     result = subprocess.run(
         [
-            "uv",
-            "run",
-            "--no-project",
+            "bash",
+            str(SKILLS / "authoring-marp-slides/scripts/validate_marpit.sh"),
+            str(deck),
+            "unexpected.md",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "Usage:" in result.stdout
+
+
+def test_marp_validator_accepts_relative_path_starting_with_dash(
+    tmp_path: Path,
+) -> None:
+    deck = tmp_path / "--deck.md"
+    deck.write_text("---\nmarp: true\n---\n# Slide\n")
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(SKILLS / "authoring-marp-slides/scripts/validate_marpit.sh"),
+            deck.name,
+        ],
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_marp_validator_accepts_crlf_and_yaml_comment(tmp_path: Path) -> None:
+    deck = tmp_path / "windows.md"
+    deck.write_bytes(
+        b"---\r\nmarp: TRUE  # enable Marp\r\ntheme: default\r\n---\r\n# Slide\r\n"
+    )
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(SKILLS / "authoring-marp-slides/scripts/validate_marpit.sh"),
+            str(deck),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout
+    assert "Slides: 1" in result.stdout
+
+
+def test_contrast_checker_reports_failed_large_text() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
             str(SKILLS / "designing-slide-colors/scripts/check_contrast.py"),
             "#999999",
             "#FFFFFF",
@@ -82,6 +142,34 @@ def test_contrast_checker_reports_failed_large_text(tmp_path: Path) -> None:
     )
 
     assert "WCAG AA (large text):   ❌ Fail" in result.stdout
+
+
+def test_color_parsers_reject_malformed_six_character_values() -> None:
+    generator = load_module(
+        SKILLS / "designing-slide-colors/scripts/generate_palette.py",
+        "generate_palette_invalid_color_test",
+    )
+    checker = load_module(
+        SKILLS / "designing-slide-colors/scripts/check_contrast.py",
+        "check_contrast_invalid_color_test",
+    )
+
+    for module in (generator, checker):
+        with pytest.raises(ValueError, match="Invalid hex color"):
+            module.hex_to_rgb("-12345")
+
+
+def test_brand_palette_normalizes_color_and_rejects_unknown_style() -> None:
+    generator = load_module(
+        SKILLS / "designing-slide-colors/scripts/generate_palette.py",
+        "generate_palette_brand_test",
+    )
+
+    palette = generator.generate_palette_from_brand("2e75b6", "light")
+
+    assert palette["Primary"] == "#2E75B6"
+    with pytest.raises(ValueError, match="Style must be 'light' or 'dark'"):
+        generator.generate_palette_from_brand("#2E75B6", "sepia")
 
 
 def test_generated_palette_contrast_is_calculated_from_colors() -> None:


### PR DESCRIPTION
## Summary

- hide deprecated skills from standard discovery and repair OpenAI UI metadata
- make bundled script guidance installation-safe and fix Marp, contrast, logging, publishing, planning, gourmet, and slide-image correctness issues
- harden Marp validation for CRLF, YAML boolean variants, exact arguments, and dash-prefixed paths
- strictly validate and normalize palette colors and reject unsupported palette styles
- preserve live Atuin history and snapshots for race-free manual recovery while treating harmless concurrent additions as informational
- keep repository tests runnable with pytest and the standard library only
- add repository-wide regression coverage

## Affected paths

- `README.md`
- `skills/authoring-marp-slides/`
- `skills/configuring-python-logging/`
- `skills/creating-slide-decks/`
- `skills/deprecated/`
- `skills/designing-slide-colors/`
- `skills/managing-python-with-uv/`
- `skills/researching-gourmet-venues/`
- `skills/writing-agents-md/`
- `skills/writing-plans/`
- `tests/test_skill_repository.py`

## Verification

- `uv run --no-project --python 3.13 --with pytest pytest -q tests skills/deprecated/cleaning-atuin-history/tests` — 34 passed
- `quick_validate.py` across all skill directories — 27 valid
- `npx skills@1.5.17 add . --list` — 24 active skills; all 3 deprecated skills hidden
- `prek run -a` — all hooks passed
- Marp validator checked every bundled template and example successfully
