### PR TITLE
feat: add Telegraph publishing skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ If Codex does not pick up a local skill change, restart Codex and try again.
 | `grilling-designs` | One-question-at-a-time plan and design grilling. |
 | `applying-imrad` | IMRaD fit checks, drafting, transformation, and review. |
 | `researching-gourmet-venues` | Evidence-based dining research with scoring and audit files. |
+| `creating-telegraph-pages` | Publishing structured public articles to Telegra.ph. |
 
 ### Learning & Explanation
 

--- a/skills/creating-telegraph-pages/SKILL.md
+++ b/skills/creating-telegraph-pages/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: creating-telegraph-pages
+description: Create and publish public Telegra.ph articles through the official Telegraph API, including account setup, content conversion to Telegraph nodes, credential handling, and publication verification. Use when the user asks to create, publish, or post a page or article on telegra.ph.
+---
+
+# Creating Telegraph Pages
+
+Publish structured articles with the bundled `scripts/telegraph.py` helper. Treat page creation as an external write: verify the final title, author details, and content before publishing unless the user's request already makes them explicit.
+
+## Workflow
+
+1. Prepare the article.
+   - Preserve the user's wording and language unless editing was requested.
+   - Confirm ambiguous title, byline, links, or publication intent before the external write.
+   - Do not publish secrets, private data, or local-only asset paths.
+
+2. Convert the body to a JSON array of Telegraph nodes in a temporary file. Use strings for text and objects shaped as `{"tag": "p", "children": ["Text"]}` for elements.
+   - Use only `a`, `aside`, `b`, `blockquote`, `br`, `code`, `em`, `figcaption`, `figure`, `h3`, `h4`, `hr`, `i`, `iframe`, `img`, `li`, `ol`, `p`, `pre`, `s`, `strong`, `u`, `ul`, or `video`.
+   - Use only `href` and `src` attributes.
+   - Keep the encoded content at or below 64 KB.
+   - Convert Markdown headings to `h3` or `h4`; Telegraph does not support `h1` or `h2` nodes.
+
+3. Obtain an access token.
+   - Prefer an existing token supplied through `TELEGRAPH_ACCESS_TOKEN`.
+   - Never place the token in a command argument, committed file, log, or response.
+   - If the user has no account, ask before creating one because it changes external state. Run:
+
+     ```shell
+     uv run python scripts/telegraph.py create-account --short-name '<account-name>'
+     ```
+
+   - Treat the returned `access_token` as a secret and ask the user to store it securely. Do not create repeated accounts to avoid managing a token.
+
+4. Publish only after the content is ready:
+
+   ```shell
+   uv run python scripts/telegraph.py create-page \
+     --title '<title>' \
+     --author-name '<author>' \
+     /tmp/telegraph-content.json
+   ```
+
+   Omit `--author-name` or add `--author-url` when appropriate. Inject `TELEGRAPH_ACCESS_TOKEN` through the execution environment; do not write the literal token into shell history.
+
+5. Verify the result.
+   - Check that the command returned an `https://telegra.ph/...` URL.
+   - Open or fetch the public page when tools permit and verify the title, byline, links, and content structure.
+   - Report the published URL and any verification limitation.
+   - Remove temporary content files after successful publication when they contain sensitive drafts.
+
+## Failure Handling
+
+- Preserve API errors exactly enough to diagnose them, but never echo the token.
+- On `ACCESS_TOKEN_INVALID`, stop and request a valid token; do not create a replacement account automatically.
+- On content validation errors, fix the unsupported node or attribute before retrying.
+- Do not repeatedly retry ambiguous or rate-related API errors; report the failure and retain the prepared content for a later attempt.
+
+Use the [official Telegraph API documentation](https://telegra.ph/api) for methods or fields not covered by the helper.

--- a/skills/creating-telegraph-pages/SKILL.md
+++ b/skills/creating-telegraph-pages/SKILL.md
@@ -7,6 +7,12 @@ description: Create and publish public Telegra.ph articles through the official 
 
 Publish structured articles with the bundled `scripts/telegraph.py` helper. Treat page creation as an external write: verify the final title, author details, and content before publishing unless the user's request already makes them explicit.
 
+Resolve `scripts/telegraph.py` against this skill directory before running it, then use its absolute path throughout:
+
+```shell
+CREATING_TELEGRAPH_PAGES_SKILL_DIR="/absolute/path/to/creating-telegraph-pages"
+```
+
 ## Workflow
 
 1. Prepare the article.
@@ -22,25 +28,35 @@ Publish structured articles with the bundled `scripts/telegraph.py` helper. Trea
 
 3. Obtain an access token.
    - Prefer an existing token supplied through `TELEGRAPH_ACCESS_TOKEN`.
-   - Never place the token in a command argument, committed file, log, or response.
-   - If the user has no account, ask before creating one because it changes external state. Run:
+   - Never place the token in a command argument, committed file, tool output, log, or response.
+   - If the user has no account, ask before creating one because it changes external state. Also agree on a new secret-file path, then run:
 
      ```shell
-     uv run python scripts/telegraph.py create-account --short-name '<account-name>'
+     uv run python "$CREATING_TELEGRAPH_PAGES_SKILL_DIR/scripts/telegraph.py" create-account \
+       --short-name '<account-name>' \
+       --token-file '<user-approved-secret-path>'
      ```
 
-   - Treat the returned `access_token` as a secret and ask the user to store it securely. Do not create repeated accounts to avoid managing a token.
+   - The helper refuses to overwrite an existing file, stores the token with owner-only permissions, and omits `access_token` and `auth_url` from its output. Do not read the token with a tool that captures output or create repeated accounts to avoid managing one.
 
 4. Publish only after the content is ready:
 
    ```shell
-   uv run python scripts/telegraph.py create-page \
+   uv run python "$CREATING_TELEGRAPH_PAGES_SKILL_DIR/scripts/telegraph.py" create-page \
      --title '<title>' \
      --author-name '<author>' \
      /tmp/telegraph-content.json
    ```
 
-   Omit `--author-name` or add `--author-url` when appropriate. Inject `TELEGRAPH_ACCESS_TOKEN` through the execution environment; do not write the literal token into shell history.
+   Omit `--author-name` or add `--author-url` when appropriate. Inject `TELEGRAPH_ACCESS_TOKEN` through the execution environment; do not write the literal token into shell history. If using the restricted token file, load it without printing it:
+
+   ```shell
+   TOKEN_FILE='<user-approved-secret-path>'
+   TELEGRAPH_ACCESS_TOKEN="$(cat "$TOKEN_FILE")" \
+     uv run python "$CREATING_TELEGRAPH_PAGES_SKILL_DIR/scripts/telegraph.py" create-page \
+       --title '<title>' \
+       /tmp/telegraph-content.json
+   ```
 
 5. Verify the result.
    - Check that the command returned an `https://telegra.ph/...` URL.

--- a/skills/creating-telegraph-pages/SKILL.md
+++ b/skills/creating-telegraph-pages/SKILL.md
@@ -32,7 +32,7 @@ CREATING_TELEGRAPH_PAGES_SKILL_DIR="/absolute/path/to/creating-telegraph-pages"
    - If the user has no account, ask before creating one because it changes external state. Also agree on a new secret-file path, then run:
 
      ```shell
-     uv run python "$CREATING_TELEGRAPH_PAGES_SKILL_DIR/scripts/telegraph.py" create-account \
+     uv run --no-project python "$CREATING_TELEGRAPH_PAGES_SKILL_DIR/scripts/telegraph.py" create-account \
        --short-name '<account-name>' \
        --token-file '<user-approved-secret-path>'
      ```
@@ -42,7 +42,7 @@ CREATING_TELEGRAPH_PAGES_SKILL_DIR="/absolute/path/to/creating-telegraph-pages"
 4. Publish only after the content is ready:
 
    ```shell
-   uv run python "$CREATING_TELEGRAPH_PAGES_SKILL_DIR/scripts/telegraph.py" create-page \
+   uv run --no-project python "$CREATING_TELEGRAPH_PAGES_SKILL_DIR/scripts/telegraph.py" create-page \
      --title '<title>' \
      --author-name '<author>' \
      /tmp/telegraph-content.json
@@ -53,7 +53,7 @@ CREATING_TELEGRAPH_PAGES_SKILL_DIR="/absolute/path/to/creating-telegraph-pages"
    ```shell
    TOKEN_FILE='<user-approved-secret-path>'
    TELEGRAPH_ACCESS_TOKEN="$(cat "$TOKEN_FILE")" \
-     uv run python "$CREATING_TELEGRAPH_PAGES_SKILL_DIR/scripts/telegraph.py" create-page \
+     uv run --no-project python "$CREATING_TELEGRAPH_PAGES_SKILL_DIR/scripts/telegraph.py" create-page \
        --title '<title>' \
        /tmp/telegraph-content.json
    ```

--- a/skills/creating-telegraph-pages/SKILL.md
+++ b/skills/creating-telegraph-pages/SKILL.md
@@ -22,7 +22,7 @@ CREATING_TELEGRAPH_PAGES_SKILL_DIR="/absolute/path/to/creating-telegraph-pages"
 
 2. Convert the body to a JSON array of Telegraph nodes in a temporary file. Use strings for text and objects shaped as `{"tag": "p", "children": ["Text"]}` for elements.
    - Use only `a`, `aside`, `b`, `blockquote`, `br`, `code`, `em`, `figcaption`, `figure`, `h3`, `h4`, `hr`, `i`, `iframe`, `img`, `li`, `ol`, `p`, `pre`, `s`, `strong`, `u`, `ul`, or `video`.
-   - Use only `href` and `src` attributes.
+   - Use only `tag`, `attrs`, and `children` object fields. Attribute names must be `href` or `src`, and attribute values must be strings.
    - Keep the encoded content at or below 64 KB.
    - Convert Markdown headings to `h3` or `h4`; Telegraph does not support `h1` or `h2` nodes.
 

--- a/skills/creating-telegraph-pages/agents/openai.yaml
+++ b/skills/creating-telegraph-pages/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Creating Telegraph Pages"
+  short_description: "Publish structured articles to Telegra.ph"
+  default_prompt: "Use $creating-telegraph-pages to publish this article as a Telegra.ph page."

--- a/skills/creating-telegraph-pages/scripts/telegraph.py
+++ b/skills/creating-telegraph-pages/scripts/telegraph.py
@@ -97,6 +97,39 @@ def create_account(short_name, author_name=None, author_url=None):
     return _post("createAccount", fields)
 
 
+def create_account_with_token_file(
+    short_name, token_file, author_name=None, author_url=None
+):
+    token_file = Path(token_file)
+    fd = os.open(token_file, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    keep_file = False
+    try:
+        account = create_account(short_name, author_name, author_url)
+        if not isinstance(account, dict):
+            raise RuntimeError("Telegraph API returned an invalid account")
+        access_token = account.get("access_token")
+        if not isinstance(access_token, str) or not access_token:
+            raise RuntimeError("Telegraph API response did not include an access token")
+
+        with os.fdopen(fd, "w", encoding="utf-8") as secret_file:
+            fd = None
+            secret_file.write(access_token)
+        keep_file = True
+    finally:
+        if fd is not None:
+            os.close(fd)
+        if not keep_file:
+            token_file.unlink(missing_ok=True)
+
+    public_account = {
+        key: account[key]
+        for key in ("short_name", "author_name", "author_url")
+        if key in account
+    }
+    public_account["token_file"] = str(token_file)
+    return public_account
+
+
 def create_page(access_token, title, content, author_name=None, author_url=None):
     if not 1 <= len(title) <= 256:
         raise ValueError("title must contain 1 to 256 characters")
@@ -121,6 +154,12 @@ def build_parser():
     account.add_argument("--short-name", required=True)
     account.add_argument("--author-name")
     account.add_argument("--author-url")
+    account.add_argument(
+        "--token-file",
+        required=True,
+        type=Path,
+        help="New owner-readable file in which to store the access token",
+    )
 
     page = commands.add_parser("create-page", help="Publish a Telegraph page")
     page.add_argument("content", type=Path, help="JSON file containing Telegraph nodes")
@@ -133,7 +172,9 @@ def build_parser():
 def main(argv=None):
     args = build_parser().parse_args(argv)
     if args.command == "create-account":
-        result = create_account(args.short_name, args.author_name, args.author_url)
+        result = create_account_with_token_file(
+            args.short_name, args.token_file, args.author_name, args.author_url
+        )
     else:
         token = os.environ.get("TELEGRAPH_ACCESS_TOKEN")
         if not token:

--- a/skills/creating-telegraph-pages/scripts/telegraph.py
+++ b/skills/creating-telegraph-pages/scripts/telegraph.py
@@ -38,6 +38,7 @@ ALLOWED_TAGS = {
     "video",
 }
 ALLOWED_ATTRIBUTES = {"href", "src"}
+ALLOWED_NODE_FIELDS = {"tag", "attrs", "children"}
 MAX_CONTENT_BYTES = 64 * 1024
 
 
@@ -50,21 +51,34 @@ def validate_content(content):
             return
         if not isinstance(node, dict):
             raise ValueError("Each node must be a string or object")
+        for field in node:
+            if field not in ALLOWED_NODE_FIELDS:
+                raise ValueError(f"Unsupported node field: {field}")
         tag = node.get("tag")
+        if not isinstance(tag, str):
+            raise ValueError("Node tag must be a string")
         if tag not in ALLOWED_TAGS:
             raise ValueError(f"Unsupported tag: {tag}")
-        for attribute in node.get("attrs", {}):
+        attrs = node.get("attrs", {})
+        if not isinstance(attrs, dict):
+            raise ValueError("Node attrs must be an object")
+        for attribute, value in attrs.items():
             if attribute not in ALLOWED_ATTRIBUTES:
                 raise ValueError(f"Unsupported attribute: {attribute}")
+            if not isinstance(value, str):
+                raise ValueError("Attribute values must be strings")
         children = node.get("children", [])
         if not isinstance(children, list):
             raise ValueError("Node children must be an array")
         for child in children:
             validate_node(child)
 
-    for item in content:
-        validate_node(item)
-    encoded = json.dumps(content, ensure_ascii=False, separators=(",", ":"))
+    try:
+        for item in content:
+            validate_node(item)
+        encoded = json.dumps(content, ensure_ascii=False, separators=(",", ":"))
+    except RecursionError as error:
+        raise ValueError("Content nesting is too deep") from error
     if len(encoded.encode("utf-8")) > MAX_CONTENT_BYTES:
         raise ValueError("Content exceeds Telegraph's 64 KB limit")
     return encoded
@@ -78,17 +92,38 @@ def _post(method, fields):
         method="POST",
     )
     with urlopen(request, timeout=30) as response:
-        payload = json.loads(response.read().decode("utf-8"))
-    if not payload.get("ok"):
-        raise RuntimeError(
-            f"Telegraph API error: {payload.get('error', 'UNKNOWN_ERROR')}"
-        )
+        try:
+            payload = json.loads(response.read().decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise RuntimeError("Telegraph API returned invalid JSON") from error
+    if not isinstance(payload, dict) or not isinstance(payload.get("ok"), bool):
+        raise RuntimeError("Telegraph API returned an invalid response")
+    if not payload["ok"]:
+        message = str(payload.get("error", "UNKNOWN_ERROR"))
+        access_token = fields.get("access_token")
+        if isinstance(access_token, str) and access_token:
+            message = message.replace(access_token, "[REDACTED]")
+        raise RuntimeError(f"Telegraph API error: {message}")
+    if "result" not in payload:
+        raise RuntimeError("Telegraph API returned an invalid response")
     return payload["result"]
 
 
+def _validate_string(name, value, minimum, maximum):
+    if not isinstance(value, str) or not minimum <= len(value) <= maximum:
+        raise ValueError(f"{name} must contain {minimum} to {maximum} characters")
+
+
+def _validate_author(author_name, author_url):
+    if author_name is not None:
+        _validate_string("author_name", author_name, 0, 128)
+    if author_url is not None:
+        _validate_string("author_url", author_url, 0, 512)
+
+
 def create_account(short_name, author_name=None, author_url=None):
-    if not 1 <= len(short_name) <= 32:
-        raise ValueError("short_name must contain 1 to 32 characters")
+    _validate_string("short_name", short_name, 1, 32)
+    _validate_author(author_name, author_url)
     fields = {"short_name": short_name}
     if author_name is not None:
         fields["author_name"] = author_name
@@ -131,8 +166,10 @@ def create_account_with_token_file(
 
 
 def create_page(access_token, title, content, author_name=None, author_url=None):
-    if not 1 <= len(title) <= 256:
-        raise ValueError("title must contain 1 to 256 characters")
+    if not isinstance(access_token, str) or not access_token:
+        raise ValueError("access_token must be a non-empty string")
+    _validate_string("title", title, 1, 256)
+    _validate_author(author_name, author_url)
     fields = {
         "access_token": access_token,
         "title": title,
@@ -143,7 +180,10 @@ def create_page(access_token, title, content, author_name=None, author_url=None)
         fields["author_name"] = author_name
     if author_url is not None:
         fields["author_url"] = author_url
-    return _post("createPage", fields)
+    page = _post("createPage", fields)
+    if not isinstance(page, dict) or not isinstance(page.get("url"), str):
+        raise RuntimeError("Telegraph API returned an invalid page")
+    return page
 
 
 def build_parser():

--- a/skills/creating-telegraph-pages/scripts/telegraph.py
+++ b/skills/creating-telegraph-pages/scripts/telegraph.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Create Telegraph accounts and publish Telegraph pages with the standard library."""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+
+API_ROOT = "https://api.telegra.ph"
+ALLOWED_TAGS = {
+    "a",
+    "aside",
+    "b",
+    "blockquote",
+    "br",
+    "code",
+    "em",
+    "figcaption",
+    "figure",
+    "h3",
+    "h4",
+    "hr",
+    "i",
+    "iframe",
+    "img",
+    "li",
+    "ol",
+    "p",
+    "pre",
+    "s",
+    "strong",
+    "u",
+    "ul",
+    "video",
+}
+ALLOWED_ATTRIBUTES = {"href", "src"}
+MAX_CONTENT_BYTES = 64 * 1024
+
+
+def validate_content(content):
+    if not isinstance(content, list):
+        raise ValueError("Content must be a JSON array of Telegraph nodes")
+
+    def validate_node(node):
+        if isinstance(node, str):
+            return
+        if not isinstance(node, dict):
+            raise ValueError("Each node must be a string or object")
+        tag = node.get("tag")
+        if tag not in ALLOWED_TAGS:
+            raise ValueError(f"Unsupported tag: {tag}")
+        for attribute in node.get("attrs", {}):
+            if attribute not in ALLOWED_ATTRIBUTES:
+                raise ValueError(f"Unsupported attribute: {attribute}")
+        children = node.get("children", [])
+        if not isinstance(children, list):
+            raise ValueError("Node children must be an array")
+        for child in children:
+            validate_node(child)
+
+    for item in content:
+        validate_node(item)
+    encoded = json.dumps(content, ensure_ascii=False, separators=(",", ":"))
+    if len(encoded.encode("utf-8")) > MAX_CONTENT_BYTES:
+        raise ValueError("Content exceeds Telegraph's 64 KB limit")
+    return encoded
+
+
+def _post(method, fields):
+    request = Request(
+        f"{API_ROOT}/{method}",
+        data=urlencode(fields).encode("utf-8"),
+        headers={"Content-Type": "application/x-www-form-urlencoded; charset=utf-8"},
+        method="POST",
+    )
+    with urlopen(request, timeout=30) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+    if not payload.get("ok"):
+        raise RuntimeError(
+            f"Telegraph API error: {payload.get('error', 'UNKNOWN_ERROR')}"
+        )
+    return payload["result"]
+
+
+def create_account(short_name, author_name=None, author_url=None):
+    if not 1 <= len(short_name) <= 32:
+        raise ValueError("short_name must contain 1 to 32 characters")
+    fields = {"short_name": short_name}
+    if author_name is not None:
+        fields["author_name"] = author_name
+    if author_url is not None:
+        fields["author_url"] = author_url
+    return _post("createAccount", fields)
+
+
+def create_page(access_token, title, content, author_name=None, author_url=None):
+    if not 1 <= len(title) <= 256:
+        raise ValueError("title must contain 1 to 256 characters")
+    fields = {
+        "access_token": access_token,
+        "title": title,
+        "content": validate_content(content),
+        "return_content": "false",
+    }
+    if author_name is not None:
+        fields["author_name"] = author_name
+    if author_url is not None:
+        fields["author_url"] = author_url
+    return _post("createPage", fields)
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    account = commands.add_parser("create-account", help="Create a Telegraph account")
+    account.add_argument("--short-name", required=True)
+    account.add_argument("--author-name")
+    account.add_argument("--author-url")
+
+    page = commands.add_parser("create-page", help="Publish a Telegraph page")
+    page.add_argument("content", type=Path, help="JSON file containing Telegraph nodes")
+    page.add_argument("--title", required=True)
+    page.add_argument("--author-name")
+    page.add_argument("--author-url")
+    return parser
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+    if args.command == "create-account":
+        result = create_account(args.short_name, args.author_name, args.author_url)
+    else:
+        token = os.environ.get("TELEGRAPH_ACCESS_TOKEN")
+        if not token:
+            raise SystemExit("TELEGRAPH_ACCESS_TOKEN is required for create-page")
+        with args.content.open(encoding="utf-8") as content_file:
+            content = json.load(content_file)
+        result = create_page(
+            token, args.title, content, args.author_name, args.author_url
+        )
+    json.dump(result, sys.stdout, ensure_ascii=False, indent=2)
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/creating-telegraph-pages/scripts/telegraph.py
+++ b/skills/creating-telegraph-pages/scripts/telegraph.py
@@ -6,7 +6,7 @@ import json
 import os
 import sys
 from pathlib import Path
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlsplit
 from urllib.request import Request, urlopen
 
 
@@ -84,6 +84,19 @@ def validate_content(content):
     return encoded
 
 
+def _redact_secret(value, secret):
+    if isinstance(value, str):
+        return value.replace(secret, "[REDACTED]")
+    if isinstance(value, list):
+        return [_redact_secret(item, secret) for item in value]
+    if isinstance(value, dict):
+        return {
+            _redact_secret(key, secret): _redact_secret(item, secret)
+            for key, item in value.items()
+        }
+    return value
+
+
 def _post(method, fields):
     request = Request(
         f"{API_ROOT}/{method}",
@@ -98,15 +111,18 @@ def _post(method, fields):
             raise RuntimeError("Telegraph API returned invalid JSON") from error
     if not isinstance(payload, dict) or not isinstance(payload.get("ok"), bool):
         raise RuntimeError("Telegraph API returned an invalid response")
+    access_token = fields.get("access_token")
     if not payload["ok"]:
         message = str(payload.get("error", "UNKNOWN_ERROR"))
-        access_token = fields.get("access_token")
         if isinstance(access_token, str) and access_token:
-            message = message.replace(access_token, "[REDACTED]")
+            message = _redact_secret(message, access_token)
         raise RuntimeError(f"Telegraph API error: {message}")
     if "result" not in payload:
         raise RuntimeError("Telegraph API returned an invalid response")
-    return payload["result"]
+    result = payload["result"]
+    if isinstance(access_token, str) and access_token:
+        result = _redact_secret(result, access_token)
+    return result
 
 
 def _validate_string(name, value, minimum, maximum):
@@ -182,6 +198,16 @@ def create_page(access_token, title, content, author_name=None, author_url=None)
         fields["author_url"] = author_url
     page = _post("createPage", fields)
     if not isinstance(page, dict) or not isinstance(page.get("url"), str):
+        raise RuntimeError("Telegraph API returned an invalid page")
+    try:
+        page_url = urlsplit(page["url"])
+    except ValueError as error:
+        raise RuntimeError("Telegraph API returned an invalid page") from error
+    if (
+        page_url.scheme != "https"
+        or page_url.netloc != "telegra.ph"
+        or not page_url.path.strip("/")
+    ):
         raise RuntimeError("Telegraph API returned an invalid page")
     return page
 

--- a/skills/creating-telegraph-pages/scripts/test_telegraph.py
+++ b/skills/creating-telegraph-pages/scripts/test_telegraph.py
@@ -1,0 +1,71 @@
+import json
+import os
+from unittest.mock import patch
+
+import pytest
+
+import telegraph
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def read(self):
+        return json.dumps(self.payload).encode()
+
+
+def test_create_page_posts_validated_content_and_returns_page():
+    content = [{"tag": "p", "children": ["Hello"]}]
+    response = FakeResponse(
+        {"ok": True, "result": {"url": "https://telegra.ph/Hello-01-01"}}
+    )
+
+    with patch("telegraph.urlopen", return_value=response) as urlopen:
+        page = telegraph.create_page("token", "Hello", content, "Author", None)
+
+    request = urlopen.call_args.args[0]
+    form = request.data.decode()
+    assert page["url"] == "https://telegra.ph/Hello-01-01"
+    assert "access_token=token" in form
+    assert "title=Hello" in form
+    assert "content=%5B" in form
+
+
+def test_rejects_unsupported_tags_before_request():
+    with patch("telegraph.urlopen") as urlopen:
+        with pytest.raises(ValueError, match="Unsupported tag: script"):
+            telegraph.create_page(
+                "token", "Unsafe", [{"tag": "script", "children": ["x"]}]
+            )
+
+    urlopen.assert_not_called()
+
+
+def test_rejects_unsupported_attributes():
+    content = [{"tag": "a", "attrs": {"onclick": "x"}, "children": ["link"]}]
+
+    with pytest.raises(ValueError, match="Unsupported attribute: onclick"):
+        telegraph.validate_content(content)
+
+
+def test_api_error_is_reported_without_exposing_token():
+    response = FakeResponse({"ok": False, "error": "ACCESS_TOKEN_INVALID"})
+
+    with patch("telegraph.urlopen", return_value=response):
+        with pytest.raises(RuntimeError, match="ACCESS_TOKEN_INVALID") as raised:
+            telegraph.create_page("secret-token", "Hello", ["text"])
+
+    assert "secret-token" not in str(raised.value)
+
+
+def test_cli_requires_token_from_environment():
+    with patch.dict(os.environ, {}, clear=True):
+        with pytest.raises(SystemExit, match="TELEGRAPH_ACCESS_TOKEN"):
+            telegraph.main(["create-page", "--title", "Hello", "content.json"])

--- a/skills/creating-telegraph-pages/scripts/test_telegraph.py
+++ b/skills/creating-telegraph-pages/scripts/test_telegraph.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sys
 from unittest.mock import patch
 
 import pytest
@@ -18,6 +19,8 @@ class FakeResponse:
         return False
 
     def read(self):
+        if isinstance(self.payload, bytes):
+            return self.payload
         return json.dumps(self.payload).encode()
 
 
@@ -55,14 +58,81 @@ def test_rejects_unsupported_attributes():
         telegraph.validate_content(content)
 
 
+@pytest.mark.parametrize(
+    ("node", "message"),
+    [
+        ({"tag": [], "children": []}, "Node tag must be a string"),
+        ({"tag": "a", "attrs": None}, "Node attrs must be an object"),
+        ({"tag": "a", "attrs": ["href"]}, "Node attrs must be an object"),
+        (
+            {"tag": "a", "attrs": {"href": None}},
+            "Attribute values must be strings",
+        ),
+        (
+            {"tag": "p", "childen": ["lost text"]},
+            "Unsupported node field: childen",
+        ),
+    ],
+)
+def test_rejects_malformed_node_shapes(node, message):
+    with pytest.raises(ValueError, match=message):
+        telegraph.validate_content([node])
+
+
+def test_rejects_content_with_excessive_nesting():
+    node = "text"
+    for _ in range(sys.getrecursionlimit() + 10):
+        node = {"tag": "p", "children": [node]}
+
+    with pytest.raises(ValueError, match="nesting is too deep"):
+        telegraph.validate_content([node])
+
+
+def test_rejects_invalid_scalar_fields_before_request():
+    with patch("telegraph.urlopen") as urlopen:
+        with pytest.raises(ValueError, match="author_name.*128"):
+            telegraph.create_account("Writer", author_name="a" * 129)
+        with pytest.raises(ValueError, match="author_url.*512"):
+            telegraph.create_page(
+                "token", "Hello", ["text"], author_url="https://" + "a" * 505
+            )
+        with pytest.raises(ValueError, match="access_token.*non-empty"):
+            telegraph.create_page("", "Hello", ["text"])
+
+    urlopen.assert_not_called()
+
+
 def test_api_error_is_reported_without_exposing_token():
-    response = FakeResponse({"ok": False, "error": "ACCESS_TOKEN_INVALID"})
+    response = FakeResponse(
+        {"ok": False, "error": "ACCESS_TOKEN_INVALID: secret-token"}
+    )
 
     with patch("telegraph.urlopen", return_value=response):
         with pytest.raises(RuntimeError, match="ACCESS_TOKEN_INVALID") as raised:
             telegraph.create_page("secret-token", "Hello", ["text"])
 
     assert "secret-token" not in str(raised.value)
+
+
+@pytest.mark.parametrize(
+    ("response", "message"),
+    [
+        (FakeResponse([]), "invalid response"),
+        (FakeResponse(b"not JSON"), "invalid JSON"),
+    ],
+)
+def test_malformed_api_response_is_reported_cleanly(response, message):
+    with patch("telegraph.urlopen", return_value=response):
+        with pytest.raises(RuntimeError, match=message):
+            telegraph.create_page("token", "Hello", ["text"])
+
+
+def test_create_page_rejects_malformed_result():
+    response = FakeResponse({"ok": True, "result": []})
+
+    with patch("telegraph.urlopen", return_value=response):
+        with pytest.raises(RuntimeError, match="invalid page"):
+            telegraph.create_page("token", "Hello", ["text"])
 
 
 def test_create_account_stores_token_without_printing_secrets(tmp_path, capsys):
@@ -134,6 +204,23 @@ def test_create_account_failure_removes_reserved_token_file(tmp_path):
             )
 
     assert not token_file.exists()
+
+
+def test_cli_rejects_deeply_nested_json_before_request(tmp_path):
+    depth = sys.getrecursionlimit() + 10
+    content_file = tmp_path / "content.json"
+    content_file.write_text(
+        "[" + '{"tag":"p","children":[' * depth + '"text"' + "]}" * depth + "]"
+    )
+
+    with (
+        patch.dict(os.environ, {"TELEGRAPH_ACCESS_TOKEN": "token"}, clear=True),
+        patch("telegraph.urlopen") as urlopen,
+        pytest.raises(ValueError, match="nesting is too deep"),
+    ):
+        telegraph.main(["create-page", "--title", "Hello", str(content_file)])
+
+    urlopen.assert_not_called()
 
 
 def test_cli_requires_token_from_environment():

--- a/skills/creating-telegraph-pages/scripts/test_telegraph.py
+++ b/skills/creating-telegraph-pages/scripts/test_telegraph.py
@@ -65,6 +65,77 @@ def test_api_error_is_reported_without_exposing_token():
     assert "secret-token" not in str(raised.value)
 
 
+def test_create_account_stores_token_without_printing_secrets(tmp_path, capsys):
+    token_file = tmp_path / "telegraph-token"
+    account = {
+        "short_name": "Writer",
+        "author_name": "Author",
+        "access_token": "secret-token",
+        "auth_url": "https://edit.telegra.ph/auth/secret",
+    }
+
+    with patch("telegraph.create_account", return_value=account):
+        telegraph.main(
+            [
+                "create-account",
+                "--short-name",
+                "Writer",
+                "--token-file",
+                str(token_file),
+            ]
+        )
+
+    output_text = capsys.readouterr().out
+    output = json.loads(output_text)
+    assert token_file.read_text() == "secret-token"
+    assert token_file.stat().st_mode & 0o777 == 0o600
+    assert output == {
+        "short_name": "Writer",
+        "author_name": "Author",
+        "token_file": str(token_file),
+    }
+    assert "secret-token" not in output_text
+    assert account["auth_url"] not in output_text
+
+
+def test_create_account_refuses_existing_token_file_before_request(tmp_path):
+    token_file = tmp_path / "telegraph-token"
+    token_file.write_text("existing-token")
+
+    with patch("telegraph.create_account") as create_account:
+        with pytest.raises(FileExistsError):
+            telegraph.main(
+                [
+                    "create-account",
+                    "--short-name",
+                    "Writer",
+                    "--token-file",
+                    str(token_file),
+                ]
+            )
+
+    create_account.assert_not_called()
+    assert token_file.read_text() == "existing-token"
+
+
+def test_create_account_failure_removes_reserved_token_file(tmp_path):
+    token_file = tmp_path / "telegraph-token"
+
+    with patch("telegraph.create_account", side_effect=RuntimeError("API unavailable")):
+        with pytest.raises(RuntimeError, match="API unavailable"):
+            telegraph.main(
+                [
+                    "create-account",
+                    "--short-name",
+                    "Writer",
+                    "--token-file",
+                    str(token_file),
+                ]
+            )
+
+    assert not token_file.exists()
+
+
 def test_cli_requires_token_from_environment():
     with patch.dict(os.environ, {}, clear=True):
         with pytest.raises(SystemExit, match="TELEGRAPH_ACCESS_TOKEN"):

--- a/skills/creating-telegraph-pages/scripts/test_telegraph.py
+++ b/skills/creating-telegraph-pages/scripts/test_telegraph.py
@@ -135,6 +135,41 @@ def test_create_page_rejects_malformed_result():
             telegraph.create_page("token", "Hello", ["text"])
 
 
+@pytest.mark.parametrize(
+    "url",
+    [
+        "",
+        "http://telegra.ph/Hello-01-01",
+        "https://example.com/Hello-01-01",
+        "https://telegra.ph/",
+    ],
+)
+def test_create_page_rejects_invalid_public_url(url):
+    response = FakeResponse({"ok": True, "result": {"url": url}})
+
+    with patch("telegraph.urlopen", return_value=response):
+        with pytest.raises(RuntimeError, match="invalid page"):
+            telegraph.create_page("token", "Hello", ["text"])
+
+
+def test_create_page_redacts_reflected_token_from_success_response():
+    response = FakeResponse(
+        {
+            "ok": True,
+            "result": {
+                "url": "https://telegra.ph/Hello-01-01",
+                "description": "unexpected secret-token reflection",
+            },
+        }
+    )
+
+    with patch("telegraph.urlopen", return_value=response):
+        page = telegraph.create_page("secret-token", "Hello", ["text"])
+
+    assert "secret-token" not in json.dumps(page)
+    assert "[REDACTED]" in page["description"]
+
+
 def test_create_account_stores_token_without_printing_secrets(tmp_path, capsys):
     token_file = tmp_path / "telegraph-token"
     account = {


### PR DESCRIPTION
## Summary

- add a `creating-telegraph-pages` skill for safe Telegra.ph publishing
- include a standard-library Telegraph API helper and unit tests
- resolve bundled helpers by absolute skill-directory paths
- run bundled helpers with `uv --no-project` so unrelated workspaces are not discovered or synced
- store newly created account tokens in exclusive owner-only files without logging secrets
- validate Telegraph node schemas and documented scalar limits before requests
- reject malformed or excessively nested content and malformed API responses cleanly
- verify published page URLs and redact token reflections from successful responses
- add the skill to the README catalog

## Affected paths

- `README.md`
- `skills/creating-telegraph-pages/`

## Verification

- `prek run -a`
- `UV_CACHE_DIR=/tmp/uv-cache uv run --no-project --python 3.13 --with pytest pytest -q skills/creating-telegraph-pages/scripts/test_telegraph.py` (24 passed)
- `quick_validate.py skills/creating-telegraph-pages` (Skill is valid)