### PR TITLE
feat: add explicit Git workflow skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ If Codex does not pick up a local skill change, restart Codex and try again.
 | `using-jira-cli` | Jira setup, queries, mutations, epics, sprints, releases, projects, and boards. |
 | `applying-tdd` | TDD red-green-refactor workflow for non-trivial code changes. |
 | `writing-git-commits` | Focused Conventional Commits from real diffs. |
-| `syncing-main-branch` | Explicitly invoked clean switch to `main` and fast-forward pull. |
+| `syncing-main-branch` | Explicitly invoked clean switch to `main` and protected fast-forward update. |
 | `managing-git-worktrees` | Safe Git worktree creation, repair, removal, pruning, and branch cleanup. |
 | `maintaining-memory-md` | Creates repository `MEMORY.md` on the first durable `GOTCHA` or `TASTE`, then keeps entries concise and current. |
 | `writing-agents-md` | Creating or updating repository `AGENTS.md` guidance. |

--- a/README.md
+++ b/README.md
@@ -119,11 +119,13 @@ If Codex does not pick up a local skill change, restart Codex and try again.
 | --- | --- |
 | `creating-agent-skills` | Creating concise, valid, discoverable agent skills. |
 | `reviewing-code` | Code review for correctness, edge cases, tests, security, and integration risk. |
+| `resolving-pr-review-comments` | Explicitly invoked PR feedback assessment, fixes, replies, commits, and pushes. |
 | `resolving-edge-cases` | Iteratively finding, fixing, and verifying plausible edge cases in code flows. |
 | `naming-agent-skills` | Predictable, searchable skill names. |
 | `using-jira-cli` | Jira setup, queries, mutations, epics, sprints, releases, projects, and boards. |
 | `applying-tdd` | TDD red-green-refactor workflow for non-trivial code changes. |
 | `writing-git-commits` | Focused Conventional Commits from real diffs. |
+| `syncing-main-branch` | Explicitly invoked clean switch to `main` and fast-forward pull. |
 | `managing-git-worktrees` | Safe Git worktree creation, repair, removal, pruning, and branch cleanup. |
 | `maintaining-memory-md` | Creates repository `MEMORY.md` on the first durable `GOTCHA` or `TASTE`, then keeps entries concise and current. |
 | `writing-agents-md` | Creating or updating repository `AGENTS.md` guidance. |

--- a/skills/resolving-pr-review-comments/SKILL.md
+++ b/skills/resolving-pr-review-comments/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: resolving-pr-review-comments
+description: Inspect all feedback on a pull request, assess whether each comment is valid against the current code, address reasonable findings, verify the changes, reply to and resolve eligible threads, commit, and push. Use only when the user explicitly invokes $resolving-pr-review-comments or names resolving-pr-review-comments; never auto-activate from ordinary requests about reviews, comments, pull requests, commits, or pushes.
+---
+
+# Resolving PR Review Comments
+
+Use this skill only after explicit invocation. Treat review comments as claims to verify, not instructions to apply blindly. External actions covered by the invocation are review replies, thread resolution, commits, and a normal push to the current pull-request branch.
+
+## Establish Scope
+
+1. Inspect the worktree and current branch. Preserve unrelated staged, unstaged, and untracked changes; never blanket-stage them.
+2. Resolve the pull request, repository, head branch, base branch, number, URL, and current state from the hosting provider. For GitHub, start with:
+
+   ```bash
+   gh pr view --json number,url,state,baseRefName,headRefName
+   ```
+
+3. Confirm that the checked-out branch is the pull request head. Stop rather than editing or pushing another branch accidentally.
+4. Compare the pull request against the merge base of its reported base branch. Do not assume the base is `main`.
+
+## Read All Feedback
+
+Collect every feedback surface, not only the summary shown by `gh pr view`:
+
+- top-level pull-request or issue comments
+- submitted reviews and their bodies
+- inline review comments
+- review threads, including resolution and outdated state
+
+On GitHub, use paginated REST endpoints for issue comments, reviews, and inline comments, plus the GraphQL `reviewThreads` connection for thread IDs, `isResolved`, `isOutdated`, and all thread comments. Paginate beyond the first page. Do not treat an empty top-level comment list as proof that no inline feedback exists.
+
+Ignore non-actionable service messages such as quota notices, but do not silently omit substantive feedback. Re-query after pushing because comments can arrive while work is in progress.
+
+## Assess Each Comment
+
+Trace each concern against the current HEAD, pull-request intent, repository instructions, tests, and relevant callers.
+
+Classify it as one of:
+
+- **Reasonable and unresolved:** the issue reproduces or the current change violates a documented contract; fix it.
+- **Already addressed or outdated:** current code resolves the concern; gather concrete file, commit, or test evidence.
+- **Not reasonable:** the suggestion conflicts with requirements, relies on a false premise, or adds unjustified scope; prepare a concise evidence-based reply instead of changing code.
+- **Ambiguous or disputed:** a behavior decision or external information is missing; ask one focused question or leave the thread open.
+
+Do not implement preference-only suggestions as correctness fixes. Do not mark a thread resolved merely to clear the review queue.
+
+## Address Reasonable Feedback
+
+1. Add the smallest regression test or failing executable check before a non-trivial code fix when practical.
+2. Fix the shared cause, then scan directly affected sibling paths for the same defect.
+3. Keep changes bounded to accepted feedback. Preserve unrelated local work.
+4. Run focused checks, then the repository's normal verification gate.
+5. Inspect the final diff and verify that it contains only intended changes.
+
+## Commit and Push
+
+1. Group changes into coherent commit boundaries. If comments require unrelated fixes, use separate focused commits.
+2. Stage only intended paths and write Conventional Commit messages grounded in each staged diff. Do not add attribution trailers.
+3. If no file change is needed, do not create an empty commit.
+4. Push the current pull-request branch to its configured upstream with a normal `git push`. Never force-push unless the user separately and explicitly requests it.
+
+## Reply and Resolve
+
+- Reply to each addressed thread with the commit ID, concise fix summary, and verification evidence.
+- For already-addressed or declined feedback, reply with concrete evidence or rationale.
+- Mark an inline thread resolved only after the fix is pushed or the concern is conclusively addressed. Leave ambiguous or genuinely disputed threads open.
+- Top-level comments and review bodies may not have a resolvable thread; acknowledge them when a response is warranted.
+
+Finally, re-query all feedback surfaces and verify:
+
+- every reasonable comment is addressed
+- every eligible thread is resolved
+- intentionally open threads are reported with the reason
+- local HEAD equals the pushed remote head
+- the worktree contains no unintended changes
+
+Report the pull-request URL, commits pushed, resolved and remaining thread counts, checks run, and any feedback deliberately not implemented.

--- a/skills/resolving-pr-review-comments/SKILL.md
+++ b/skills/resolving-pr-review-comments/SKILL.md
@@ -5,18 +5,27 @@ description: Inspect all feedback on a pull request, assess whether each comment
 
 # Resolving PR Review Comments
 
-Use this skill only after explicit invocation. Treat review comments as claims to verify, not instructions to apply blindly. External actions covered by the invocation are review replies, thread resolution, commits, and a normal push to the current pull-request branch.
+Use this skill only after explicit invocation. Treat review comments as claims to verify, not instructions to apply blindly. External actions covered by the invocation are review replies, thread resolution, commits, and an explicit push of the current pull-request branch.
 
 ## Establish Scope
 
-1. Inspect the worktree and current branch. Preserve unrelated staged, unstaged, and untracked changes; never blanket-stage them.
-2. Resolve the pull request, repository, head branch, base branch, number, URL, and current state from the hosting provider. For GitHub, start with:
+1. Inspect the worktree, index, and current branch:
 
    ```bash
-   gh pr view --json number,url,state,baseRefName,headRefName
+   git status --short --branch
+   git diff --cached --name-only
+   git symbolic-ref --quiet --short HEAD
    ```
 
-3. Confirm that the checked-out branch is the pull request head. Stop rather than editing or pushing another branch accidentally.
+   Stop before editing if any pre-existing staged change exists; a normal commit would include the entire index. Report those paths and do not unstage, commit, or hide them. Preserve unrelated unstaged and untracked changes, and stop if they overlap files that accepted feedback requires changing.
+
+2. Resolve the pull request, repository, head repository, head branch, base branch, number, URL, and current state from the hosting provider. For GitHub, start with:
+
+   ```bash
+   gh pr view --json number,url,state,baseRefName,headRefName,headRepository,headRepositoryOwner,isCrossRepository
+   ```
+
+3. Confirm that HEAD is attached and that the checked-out branch is the pull-request head. Stop rather than editing or pushing another or detached branch accidentally.
 4. Compare the pull request against the merge base of its reported base branch. Do not assume the base is `main`.
 
 ## Read All Feedback
@@ -56,9 +65,17 @@ Do not implement preference-only suggestions as correctness fixes. Do not mark a
 ## Commit and Push
 
 1. Group changes into coherent commit boundaries. If comments require unrelated fixes, use separate focused commits.
-2. Stage only intended paths and write Conventional Commit messages grounded in each staged diff. Do not add attribution trailers.
-3. If no file change is needed, do not create an empty commit.
-4. Push the current pull-request branch to its configured upstream with a normal `git push`. Never force-push unless the user separately and explicitly requests it.
+2. Stage only intended paths. Before each commit, verify that every path in `git diff --cached --name-only` belongs to that commit; stop if the index contains anything else.
+3. Write Conventional Commit messages grounded in each staged diff. Do not add attribution trailers. If no file change is needed, do not create an empty commit.
+4. Resolve a single push remote whose push URL matches the pull request's head repository, and validate the reported head branch with `git check-ref-format --branch`. Confirm any configured upstream with `git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}'`; stop if the remote or destination is missing, mismatched, or ambiguous.
+5. Push only HEAD to the verified pull-request branch with an explicit refspec:
+
+   ```bash
+   git push "$verified_remote" "HEAD:refs/heads/$verified_pr_head"
+   ```
+
+   Never use a no-refspec push, rely on `push.default` or `remote.*.push`, or force-push unless the user separately and explicitly requests it.
+6. Compare local HEAD with `git ls-remote --exit-code "$verified_remote" "refs/heads/$verified_pr_head"` before replying or resolving threads.
 
 ## Reply and Resolve
 
@@ -72,7 +89,7 @@ Finally, re-query all feedback surfaces and verify:
 - every reasonable comment is addressed
 - every eligible thread is resolved
 - intentionally open threads are reported with the reason
-- local HEAD equals the pushed remote head
+- local HEAD equals the verified pull-request remote head
 - the worktree contains no unintended changes
 
 Report the pull-request URL, commits pushed, resolved and remaining thread counts, checks run, and any feedback deliberately not implemented.

--- a/skills/resolving-pr-review-comments/agents/openai.yaml
+++ b/skills/resolving-pr-review-comments/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Resolve PR Review Comments"
+  short_description: "Assess and address pull request review feedback."
+  default_prompt: "Use $resolving-pr-review-comments to inspect all review feedback on the current pull request, address reasonable comments, verify the fixes, commit them, and push the branch."
+policy:
+  allow_implicit_invocation: false

--- a/skills/syncing-main-branch/SKILL.md
+++ b/skills/syncing-main-branch/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: syncing-main-branch
+description: Switch a clean Git worktree to the local main branch and fast-forward it from its configured upstream. Use only when the user explicitly invokes $syncing-main-branch or names syncing-main-branch; never auto-activate from ordinary requests to switch branches, return after a merge, pull, update, or sync a repository.
+---
+
+# Syncing Main Branch
+
+Use this skill only after explicit invocation. Switch to `main`, update it without creating a merge commit, and preserve the branch and worktree being left.
+
+## Workflow
+
+1. Inspect before mutating:
+
+   ```bash
+   git status --porcelain=v1 --untracked-files=all
+   git status --short --branch
+   git branch --show-current
+   ```
+
+   Stop if tracked or untracked changes exist. Report them; do not stash, commit, discard, or carry them onto `main` automatically.
+
+2. Resolve `main`.
+   - If `refs/heads/main` exists locally, use it.
+   - If local `main` is absent and exactly one intended remote-tracking `main` is clear from repository context, create the tracking branch with `git switch --track -c main <remote>/main`.
+   - If the remote is ambiguous, `main` does not exist, or another worktree already has it checked out, stop and report the specific blocker. Do not substitute `master`, bypass worktree protection, or invent a remote.
+
+3. Switch when not already on `main`:
+
+   ```bash
+   git switch main
+   ```
+
+4. Verify that `main` has a configured upstream, then update without an implicit merge commit:
+
+   ```bash
+   git rev-parse --abbrev-ref 'main@{upstream}'
+   git pull --ff-only
+   ```
+
+   If the branch has diverged, the upstream is missing, authentication fails, or the pull cannot fast-forward, stop. Do not rebase, reset, force, or change upstream configuration without a separate request.
+
+5. Verify and report:
+
+   ```bash
+   git status --short --branch
+   git log -1 --oneline --decorate
+   ```
+
+   Confirm the active branch, whether it advanced, and whether it matches its upstream. Do not delete the previous feature branch.
+
+## Safety Rules
+
+- Operate on the current repository only.
+- Keep the worktree clean throughout the switch and pull.
+- Never use interactive Git commands or a pager.
+- Never use `--force`, automatic stashing, hard reset, or branch deletion.
+- If `git pull --ff-only` reports no changes, treat that as success and do not create a commit.

--- a/skills/syncing-main-branch/SKILL.md
+++ b/skills/syncing-main-branch/SKILL.md
@@ -5,7 +5,7 @@ description: Switch a clean Git worktree to the local main branch and fast-forwa
 
 # Syncing Main Branch
 
-Use this skill only after explicit invocation. Switch to `main`, update it without creating a merge commit, and preserve the branch and worktree being left.
+Use this skill only after explicit invocation. Switch to `main`, update it without creating a merge commit, and preserve the branch, commits, and local files being left.
 
 ## Workflow
 
@@ -14,30 +14,34 @@ Use this skill only after explicit invocation. Switch to `main`, update it witho
    ```bash
    git status --porcelain=v1 --untracked-files=all
    git status --short --branch
-   git branch --show-current
+   git symbolic-ref --quiet --short HEAD
    ```
 
    Stop if tracked or untracked changes exist. Report them; do not stash, commit, discard, or carry them onto `main` automatically.
 
+   If the symbolic-ref check fails, record `git rev-parse HEAD` and inspect containing refs with `git for-each-ref --format='%(refname)' --contains=HEAD refs/heads refs/tags refs/remotes`, then stop. Do not leave a detached commit reachable only through reflog; ask whether to preserve it with a branch or tag before switching.
+
 2. Resolve `main`.
    - If `refs/heads/main` exists locally, use it.
-   - If local `main` is absent and exactly one intended remote-tracking `main` is clear from repository context, create the tracking branch with `git switch --track -c main <remote>/main`.
+   - If local `main` is absent and exactly one intended remote-tracking `main` is clear from repository context, create it with `git switch --no-overwrite-ignore --track -c main <remote>/main`.
    - If the remote is ambiguous, `main` does not exist, or another worktree already has it checked out, stop and report the specific blocker. Do not substitute `master`, bypass worktree protection, or invent a remote.
 
-3. Switch when not already on `main`:
+3. Switch when not already on `main`, protecting ignored local files from branch collisions:
 
    ```bash
-   git switch main
+   git switch --no-overwrite-ignore main
    ```
 
-4. Verify that `main` has a configured upstream, then update without an implicit merge commit:
+4. Verify that `main` tracks the intended `<remote>/main`. Fetch that remote without updating the worktree, then fast-forward with ignored-file overwrite protection:
 
    ```bash
+   upstream_remote=$(git config --get branch.main.remote)
    git rev-parse --abbrev-ref 'main@{upstream}'
-   git pull --ff-only
+   git fetch "$upstream_remote"
+   git merge --ff-only --no-overwrite-ignore 'main@{upstream}'
    ```
 
-   If the branch has diverged, the upstream is missing, authentication fails, or the pull cannot fast-forward, stop. Do not rebase, reset, force, or change upstream configuration without a separate request.
+   If the branch has diverged, the upstream is missing or unexpected, authentication fails, an ignored path would be overwritten, or the update cannot fast-forward, stop. Do not rebase, reset, force, delete ignored files, or change upstream configuration without a separate request.
 
 5. Verify and report:
 
@@ -51,7 +55,7 @@ Use this skill only after explicit invocation. Switch to `main`, update it witho
 ## Safety Rules
 
 - Operate on the current repository only.
-- Keep the worktree clean throughout the switch and pull.
+- Require tracked and untracked state to be clean; leave ignored files untouched and use overwrite-protected switch and merge commands.
 - Never use interactive Git commands or a pager.
 - Never use `--force`, automatic stashing, hard reset, or branch deletion.
-- If `git pull --ff-only` reports no changes, treat that as success and do not create a commit.
+- If the protected fast-forward reports no changes, treat that as success and do not create a commit.

--- a/skills/syncing-main-branch/agents/openai.yaml
+++ b/skills/syncing-main-branch/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Sync Main Branch"
+  short_description: "Switch to main and fast-forward from its upstream."
+  default_prompt: "Use $syncing-main-branch to switch this repository to main and safely pull the latest upstream changes."
+policy:
+  allow_implicit_invocation: false

--- a/skills/syncing-main-branch/agents/openai.yaml
+++ b/skills/syncing-main-branch/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "Sync Main Branch"
   short_description: "Switch to main and fast-forward from its upstream."
-  default_prompt: "Use $syncing-main-branch to switch this repository to main and safely pull the latest upstream changes."
+  default_prompt: "Use $syncing-main-branch to switch this repository to main and safely fast-forward it from its upstream."
 policy:
   allow_implicit_invocation: false


### PR DESCRIPTION
## Summary

- add `syncing-main-branch` for clean, protected fast-forward main branch updates
- protect ignored files and detached commits during branch switching and upstream integration
- add `resolving-pr-review-comments` for evidence-based review feedback resolution, commits, and explicit branch pushes
- stop before committing over pre-staged work and avoid ambient push-default behavior
- require explicit user invocation for both skills through metadata descriptions and `allow_implicit_invocation: false`
- add both skills to the README catalog

## Affected paths

- `README.md`
- `skills/syncing-main-branch/`
- `skills/resolving-pr-review-comments/`

## Verification

- `prek run -a`
- `quick_validate.py skills/syncing-main-branch`
- `quick_validate.py skills/resolving-pr-review-comments`
- forward-tested ignored-file collision protection during fast-forward integration
- forward-tested detached-HEAD detection
- forward-tested explicit PR branch push with `push.default=matching` without updating an unrelated branch
- forward-tested read-only PR feedback discovery across GitHub review surfaces