### PR TITLE
feat(reviewing-code): delegate authorized hardening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ Follow global defaults; this file defines only repo-specific additions and overr
 
 - `just` is non-mutating by default and only lists available recipes.
 - Local Codex copy/rm flows use `just install-all`, `just install <skill>`, `just clean-all`, and `just clean <skill>`.
+- Those flows remove the legacy installed name `resolving-edge-cases` when operating on all skills or its replacement, `hardening-code-paths`; do not restore it as an active alias.
 - `prek run -a` is the default repository-wide verification gate before a PR.
 - Rebuild slide outputs after changing content under `examples/slides/`.
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ just install managing-python-with-uv
 
 Each install replaces the target skill directory before copying. Active skills are grouped under `skills/<category>/<skill-name>/`; `just install-all` discovers those directories recursively and copies each skill directly into `~/.codex/skills/`. Deprecated skills live outside the active tree.
 
+`hardening-code-paths` replaces the former `resolving-edge-cases` name. Installing or cleaning all skills—or installing or cleaning `hardening-code-paths` individually—removes that legacy local copy.
+
 Remove copied skills when finished:
 
 ```shell
@@ -130,9 +132,9 @@ Repository path: `skills/workflow-repository/`
 | Skill | Use it for |
 | --- | --- |
 | `creating-agent-skills` | Creating concise, valid, discoverable agent skills. |
-| `reviewing-code` | Code review for correctness, edge cases, tests, security, and integration risk. |
+| `reviewing-code` | Read-only code review with conditional handoff for authorized code-path hardening. |
 | `resolving-pr-review-comments` | Explicitly invoked PR feedback assessment, fixes, replies, commits, and pushes. |
-| `resolving-edge-cases` | Iteratively finding, fixing, and verifying plausible edge cases in code flows. |
+| `hardening-code-paths` | Finding, fixing, and verifying plausible edge cases and failure modes in code paths. |
 | `naming-agent-skills` | Predictable, searchable skill names. |
 | `using-jira-cli` | Jira setup, queries, mutations, epics, sprints, releases, projects, and boards. |
 | `applying-tdd` | TDD red-green-refactor workflow for non-trivial code changes. |

--- a/justfile
+++ b/justfile
@@ -1,5 +1,6 @@
 target := env('HOME') + "/.codex/skills"
 active_skills := "find skills -mindepth 3 -maxdepth 3 -type f -name SKILL.md -printf '%h\\n' | sort"
+legacy_hardening_skill := "resolving-edge-cases"
 
 # Default behavior: show available recipes instead of mutating state.
 [default]
@@ -9,19 +10,20 @@ list:
 # Install all local skills into ~/.codex/skills by copying directories.
 install-all:
     mkdir -p {{ target }}
+    rm -rf "{{ target }}/{{ legacy_hardening_skill }}"
     {{ active_skills }} | while read -r dir; do name=${dir##*/}; rm -rf "{{ target }}/$name"; cp -R "$dir" "{{ target }}/$name"; done
 
 # Install a single categorized skill into ~/.codex/skills/<skill> by copying it.
 install skill:
-    set -- skills/*/{{ skill }}; test "$#" -eq 1; dir=$1; test -f "$dir/SKILL.md"; mkdir -p {{ target }}; rm -rf "{{ target }}/{{ skill }}"; cp -R "$dir" "{{ target }}/{{ skill }}"
+    set -- skills/*/{{ skill }}; test "$#" -eq 1; dir=$1; test -f "$dir/SKILL.md"; mkdir -p {{ target }}; if [ "{{ skill }}" = "hardening-code-paths" ]; then rm -rf "{{ target }}/{{ legacy_hardening_skill }}"; fi; rm -rf "{{ target }}/{{ skill }}"; cp -R "$dir" "{{ target }}/{{ skill }}"
 
 # Clean all local skill copies managed by this repo when target exists.
 clean-all:
-    if [ -d {{ target }} ]; then {{ active_skills }} | while read -r dir; do name=${dir##*/}; if [ -e "{{ target }}/$name" ] || [ -L "{{ target }}/$name" ]; then rm -rf "{{ target }}/$name"; else echo "skip clean: {{ target }}/$name does not exist"; fi; done; else echo "skip clean: {{ target }} does not exist"; fi
+    if [ -d {{ target }} ]; then rm -rf "{{ target }}/{{ legacy_hardening_skill }}"; {{ active_skills }} | while read -r dir; do name=${dir##*/}; if [ -e "{{ target }}/$name" ] || [ -L "{{ target }}/$name" ]; then rm -rf "{{ target }}/$name"; else echo "skip clean: {{ target }}/$name does not exist"; fi; done; else echo "skip clean: {{ target }} does not exist"; fi
 
 # Clean a single local skill copy only when its source and target exist.
 clean skill:
-    set -- skills/*/{{ skill }}; test "$#" -eq 1; test -f "$1/SKILL.md"; if [ -e "{{ target }}/{{ skill }}" ] || [ -L "{{ target }}/{{ skill }}" ]; then rm -rf "{{ target }}/{{ skill }}"; else echo "skip clean: {{ target }}/{{ skill }} does not exist"; fi
+    set -- skills/*/{{ skill }}; test "$#" -eq 1; test -f "$1/SKILL.md"; if [ "{{ skill }}" = "hardening-code-paths" ]; then rm -rf "{{ target }}/{{ legacy_hardening_skill }}"; fi; if [ -e "{{ target }}/{{ skill }}" ] || [ -L "{{ target }}/{{ skill }}" ]; then rm -rf "{{ target }}/{{ skill }}"; else echo "skip clean: {{ target }}/{{ skill }} does not exist"; fi
 
 # Create the next semantic version tag from the latest major.minor.patch tag.
 bump-version bump="patch":

--- a/skills/workflow-repository/hardening-code-paths/SKILL.md
+++ b/skills/workflow-repository/hardening-code-paths/SKILL.md
@@ -1,11 +1,11 @@
 ---
-name: resolving-edge-cases
-description: Use when asked to proactively find, fix, or harden edge-case bugs in a specific code flow, or when a concrete bug fix suggests nearby same-pattern regression risks that should be inspected.
+name: hardening-code-paths
+description: Use when asked to proactively harden a specific code path by finding and fixing plausible edge-case, boundary, failure-mode, or lifecycle bugs, or when a concrete bug fix suggests nearby same-pattern regression risks.
 ---
 
-# Resolving Edge Cases
+# Hardening Code Paths
 
-Use this to actively inspect relevant code, find plausible edge-case bugs, and fix or harden them. Do not wait for the user to enumerate edge cases.
+Actively inspect the relevant code path, confirm plausible edge-case and failure-mode bugs, and fix or harden them. Do not wait for the user to enumerate cases.
 
 ## Default Scope
 

--- a/skills/workflow-repository/hardening-code-paths/agents/openai.yaml
+++ b/skills/workflow-repository/hardening-code-paths/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Harden Code Paths"
+  short_description: "Find and fix plausible failure modes in code paths."
+  default_prompt: "Use $hardening-code-paths to harden this code path by confirming plausible failures, fixing the shared root cause, and verifying each fix."

--- a/skills/workflow-repository/resolving-edge-cases/agents/openai.yaml
+++ b/skills/workflow-repository/resolving-edge-cases/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Resolving Edge Cases"
-  short_description: "Find and fix plausible edge cases in code flows."
-  default_prompt: "Use $resolving-edge-cases to harden this code path by confirming plausible edge-case failures, fixing the shared root cause, and verifying each fix."

--- a/skills/workflow-repository/reviewing-code/SKILL.md
+++ b/skills/workflow-repository/reviewing-code/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reviewing-code
-description: Use when reviewing code changes for correctness, maintainability, readability, security, performance, test coverage, and integration risk; especially when the user asks to inspect a diff, pull request, merge request, commit, patch, or source files.
+description: Review code changes for correctness, maintainability, readability, security, performance, test coverage, and integration risk. Use when asked to inspect a diff, pull request, merge request, commit, patch, or source files; when fixes are also requested, hand confirmed edge-case and failure-mode findings to hardening-code-paths when available.
 ---
 
 # Reviewing Code
@@ -20,6 +20,19 @@ Review the requested change, not the entire codebase. Prioritize correctness and
 6. Clearly separate confirmed problems, inferred risks, and anything you could not verify.
 
 Report findings introduced by the reviewed change or made materially worse or newly reachable by it. Keep unrelated pre-existing problems out of the main findings unless the user requested a broader audit; mention a directly relevant pre-existing problem separately and label it clearly.
+
+## Hardening Handoff
+
+Keep the review read-only unless the user explicitly asks to fix findings, harden the implementation, or review and improve the code.
+
+When changes are authorized:
+
+1. Follow this review workflow until the triggering edge-case or failure-mode finding is confirmed.
+2. For each confirmed finding that needs bounded code-path hardening, load and follow the available `hardening-code-paths` skill for the affected flow.
+3. Do not hand off speculative risks, preference-only comments, or unrelated findings.
+4. Return to this workflow after hardening, inspect the resulting change, and report what was fixed, how it was verified, and any residual risk.
+
+If `hardening-code-paths` is unavailable, keep the review read-only, report the confirmed finding and missing companion skill, and do not recreate its workflow here.
 
 ## Review Workflow
 

--- a/skills/workflow-repository/reviewing-code/agents/openai.yaml
+++ b/skills/workflow-repository/reviewing-code/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Code Review"
   short_description: "Review code changes for correctness, risk, and maintainability."
-  default_prompt: "Use $reviewing-code to review the provided diff, pull request, patch, commit, or source files and return actionable findings."
+  default_prompt: "Use $reviewing-code to review the provided diff, pull request, patch, commit, or source files, return actionable findings, and hand confirmed code-path hardening work off when fixes are requested."


### PR DESCRIPTION
## Summary

- rename `resolving-edge-cases` to `hardening-code-paths` to clarify its active remediation role
- let `reviewing-code` hand confirmed edge-case and failure-mode fixes to the hardening skill only when changes are explicitly authorized
- remove legacy local skill copies through the supported `just` install and clean flows

## Affected paths

- `skills/workflow-repository/reviewing-code/`
- `skills/workflow-repository/hardening-code-paths/`
- `README.md`
- `AGENTS.md`
- `justfile`

## Verification

- both affected skills passed `quick_validate.py`
- `just --dry-run install hardening-code-paths`
- `just --dry-run clean hardening-code-paths`
- `just --dry-run install-all`
- `just --dry-run clean-all`
- `prek run -a`