### PR TITLE
chore: remove local Codex install flows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,16 +10,14 @@ Follow global defaults; this file defines only repo-specific additions and overr
 
 ## Repository Layout
 
-- Active skills live in `skills/<category>/<skill-name>/SKILL.md`; category directories are organizational only, and installed skills remain flat by skill name.
-- Deprecated skills live in `deprecated/<skill-name>/SKILL.md`, outside the active `skills/` tree, and are excluded from default install and clean flows.
+- Active skills live in `skills/<category>/<skill-name>/SKILL.md`; category directories are organizational only.
+- Deprecated skills live in `deprecated/<skill-name>/SKILL.md`, outside the active `skills/` tree, and are excluded from standard discovery.
 - Optional supporting material stays inside the skill directory under `references/`, `scripts/`, `assets/`, or `agents/`.
 - Slides and visual examples live under `examples/`.
 
 ## Commands
 
 - `just` is non-mutating by default and only lists available recipes.
-- Local Codex copy/rm flows use `just install-all`, `just install <skill>`, `just clean-all`, and `just clean <skill>`.
-- Those flows remove the legacy installed name `resolving-edge-cases` when operating on all skills or its replacement, `hardening-code-paths`; do not restore it as an active alias.
 - `prek run -a` is the default repository-wide verification gate before a PR.
 - Rebuild slide outputs after changing content under `examples/slides/`.
 

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -5,9 +5,8 @@
 - `skill-creator`'s `init_skill.py` creates the target skill directory and `SKILL.md` before it validates `agents/openai.yaml` metadata, so a bad `--interface short_description` can leave a partially initialized skill directory behind.
 - In this sandbox, `~/.cache/uv` may be read-only; when running one-off `uv run --with ...` tools, set `UV_CACHE_DIR=/tmp/uv-cache` first for more reliable behavior.
 - In this sandbox, the first run of skill metadata tools like `uv run --with pyyaml` may still need temporary network access if the local cache does not already contain the package, so `uv` can fetch `PyYAML`.
-- Codex CLI is unreliable with symlinks when loading local skills; this repo's `just` install flow now uses copy/rm instead of `stow`.
 - IMRaD now only lives under `skills/writing-research/applying-imrad/`; there are no remaining `imrad-*` legacy skill names in the repo to update.
-- Root document ownership is now fixed as `README.md` for external-facing docs and `AGENTS.md` for maintainer-facing docs; treat `justfile` as the source of truth for install recipes, with `install-all`/`install <skill>` and `clean-all`/`clean <skill>` as the supported commands.
+- Root document ownership is fixed as `README.md` for external-facing docs and `AGENTS.md` for maintainer-facing docs; standard skill installation uses `npx skills add`, while `justfile` contains repository maintenance recipes only.
 - `atuin search --delete` deletes every history row matching the query under the active search semantics; do not treat preview uniqueness or local substring counts as proof of single-row safety.
 - `atuin search -i` can panic inside Codex's filesystem sandbox because Atuin fails to create its log file on a read-only path; run interactive inspector deletions with escalated permissions.
 - For Atuin cleanup automation, snapshot `history.db` with SQLite's backup API instead of a raw file copy so live-database state and WAL pages stay consistent.

--- a/README.md
+++ b/README.md
@@ -14,9 +14,7 @@ Then open Codex and run `/skills` to inspect what was installed. Invoke a skill 
 
 ## 📦 Install
 
-Choose the path that matches how you want to use the skills.
-
-### 1. Standard install with `npx`
+### Standard install with `npx skills`
 
 Use this when you want the collection without linking a local checkout:
 
@@ -25,44 +23,6 @@ npx skills add narumiruna/skills
 ```
 
 Standard discovery exposes active skills only; deprecated skills live outside `skills/` and remain available solely for repository reference or explicit local use.
-
-### 2. Local Codex development with `just`
-
-Use this when you want repo-managed local copies in `~/.codex/skills`:
-
-```shell
-just install-all
-
-# or install one skill
-just install managing-python-with-uv
-```
-
-Each install replaces the target skill directory before copying. Active skills are grouped under `skills/<category>/<skill-name>/`; `just install-all` discovers those directories recursively and copies each skill directly into `~/.codex/skills/`. Deprecated skills live outside the active tree.
-
-`hardening-code-paths` replaces the former `resolving-edge-cases` name. Installing or cleaning all skills—or installing or cleaning `hardening-code-paths` individually—removes that legacy local copy.
-
-Remove copied skills when finished:
-
-```shell
-just clean-all
-
-# or clean one skill
-just clean managing-python-with-uv
-```
-
-`just` by itself only lists the available recipes.
-
-### 3. Manual copy for Codex
-
-Use this when you want a one-off local copy without `just`:
-
-```shell
-mkdir -p ~/.codex/skills
-rm -rf ~/.codex/skills/managing-python-with-uv
-cp -R ./skills/python/managing-python-with-uv ~/.codex/skills/managing-python-with-uv
-```
-
-Repeat the same pattern for other skills as needed.
 
 ## 🧭 How To Use In Codex
 
@@ -146,7 +106,7 @@ Repository path: `skills/workflow-repository/`
 
 ## 🗄️ Deprecated Skills
 
-Deprecated skills remain in `deprecated/<skill-name>/` for reference and are not included in `just install-all`.
+Deprecated skills remain in `deprecated/<skill-name>/` for reference and are excluded from standard discovery.
 
 | Skill | Notes |
 | --- | --- |

--- a/justfile
+++ b/justfile
@@ -1,29 +1,7 @@
-target := env('HOME') + "/.codex/skills"
-active_skills := "find skills -mindepth 3 -maxdepth 3 -type f -name SKILL.md -printf '%h\\n' | sort"
-legacy_hardening_skill := "resolving-edge-cases"
-
 # Default behavior: show available recipes instead of mutating state.
 [default]
 list:
     @just --list
-
-# Install all local skills into ~/.codex/skills by copying directories.
-install-all:
-    mkdir -p {{ target }}
-    rm -rf "{{ target }}/{{ legacy_hardening_skill }}"
-    {{ active_skills }} | while read -r dir; do name=${dir##*/}; rm -rf "{{ target }}/$name"; cp -R "$dir" "{{ target }}/$name"; done
-
-# Install a single categorized skill into ~/.codex/skills/<skill> by copying it.
-install skill:
-    set -- skills/*/{{ skill }}; test "$#" -eq 1; dir=$1; test -f "$dir/SKILL.md"; mkdir -p {{ target }}; if [ "{{ skill }}" = "hardening-code-paths" ]; then rm -rf "{{ target }}/{{ legacy_hardening_skill }}"; fi; rm -rf "{{ target }}/{{ skill }}"; cp -R "$dir" "{{ target }}/{{ skill }}"
-
-# Clean all local skill copies managed by this repo when target exists.
-clean-all:
-    if [ -d {{ target }} ]; then rm -rf "{{ target }}/{{ legacy_hardening_skill }}"; {{ active_skills }} | while read -r dir; do name=${dir##*/}; if [ -e "{{ target }}/$name" ] || [ -L "{{ target }}/$name" ]; then rm -rf "{{ target }}/$name"; else echo "skip clean: {{ target }}/$name does not exist"; fi; done; else echo "skip clean: {{ target }} does not exist"; fi
-
-# Clean a single local skill copy only when its source and target exist.
-clean skill:
-    set -- skills/*/{{ skill }}; test "$#" -eq 1; test -f "$1/SKILL.md"; if [ "{{ skill }}" = "hardening-code-paths" ]; then rm -rf "{{ target }}/{{ legacy_hardening_skill }}"; fi; if [ -e "{{ target }}/{{ skill }}" ] || [ -L "{{ target }}/{{ skill }}" ]; then rm -rf "{{ target }}/{{ skill }}"; else echo "skip clean: {{ target }}/{{ skill }} does not exist"; fi
 
 # Create the next semantic version tag from the latest major.minor.patch tag.
 bump-version bump="patch":


### PR DESCRIPTION
## Summary

- remove the local Codex `just` installation and cleanup recipes
- remove local and manual copy instructions from the README
- align maintainer guidance and repository memory with `npx skills` as the standard install path

## Affected paths

- `README.md`
- `AGENTS.md`
- `justfile`
- `MEMORY.md`

## Verification

- `prek run -a` — passed
- `git diff --check` — passed
- `just --list` — only `list` and `bump-version` remain