### PR TITLE
fix(skills): address GPT-5.6 review findings

### DIFF
--- a/deprecated/cleaning-atuin-history/SKILL.md
+++ b/deprecated/cleaning-atuin-history/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cleaning-atuin-history
-description: Audit Atuin history for duplicate pressure and high-confidence typo/retry pairs, then prepare exact preview-first cleanup steps without direct SQLite deletion. This is a deprecated internal workflow; destructive and remote operations require separate exact approval.
+description: Audit Atuin history for duplicate pressure and high-confidence typo/retry pairs, then prepare fixed-scope deduplication or user-run inspector steps without direct SQLite deletion. This deprecated internal workflow keeps cleanup-typos disabled.
 metadata:
   internal: true
 ---
@@ -17,7 +17,7 @@ Audit first. Do not treat a preview, uniqueness estimate, or skill invocation as
 - `atuin search --delete` deletes every match under active search semantics; do not use it manually for a single row.
 - The transactional typo command snapshots the database but also runs `atuin store push`, recomputes and deletes candidates, may drive a TUI, and finishes with `atuin sync`. Its current interface cannot bind execution to approved candidate IDs or guarantee non-interactive operation.
 - Do not invoke `cleanup-typos` through this skill. Keep it disabled until it gains a plan-only output plus approved-ID and non-interactive execution checks; its source and recovery artifacts remain historical reference material.
-- Re-run the audit immediately before any user-run mutation. If candidates, scope, or counts differ from the reviewed set, stop for a new decision.
+- Re-run the audit and matching dry run immediately before every mutation, whether user- or agent-executed. Use a fixed cutoff instead of a relative value such as `now`; if candidates, scope, or counts differ from the approved set, stop for renewed approval.
 - Do not auto-restore a full live database after failure; preserve live state, snapshot, and verification artifacts for recovery.
 - The interactive inspector is user-run. An agent must not open or drive its TUI.
 
@@ -39,7 +39,7 @@ The audit reads selected history columns, groups duplicates by command/cwd/host,
 
 ### Duplicates
 
-Run the reported `atuin history dedup --dry-run ...`. Present the exact window, keep count, groups, and potential deletion count. Run the matching non-dry command only after that exact scope and loss are approved.
+Resolve the audit's `--before` value to a fixed cutoff, then run the reported `atuin history dedup --dry-run ...` and present the exact window, keep count, groups, and potential deletion count. Immediately before applying, repeat the audit and matching dry run with that same fixed cutoff. Run the identical non-dry command only when the results still match the approved scope and loss; otherwise obtain renewed approval.
 
 ### Typos
 

--- a/deprecated/cleaning-atuin-history/agents/openai.yaml
+++ b/deprecated/cleaning-atuin-history/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Atuin Cleanup (Deprecated)"
-  short_description: "Audit Atuin history and prepare exact cleanup steps."
-  default_prompt: "Use $cleaning-atuin-history to audit duplicate and typo candidates, then prepare exact destructive and remote operations for separate approval."
+  short_description: "Audit Atuin history with transactional cleanup disabled."
+  default_prompt: "Use $cleaning-atuin-history to audit duplicates and typo candidates, keep cleanup-typos disabled, and prepare only fixed-scope dedup or user-run inspector steps."

--- a/deprecated/cleaning-atuin-history/references/atuin-cli.md
+++ b/deprecated/cleaning-atuin-history/references/atuin-cli.md
@@ -1,27 +1,26 @@
 # Atuin CLI Notes
 
-## Single-entry delete in the TUI
+## Transactional Automation Is Disabled
 
-- Run `atuin search -i --search-mode prefix <query>` to open the interactive search view.
-- Add `--cwd <cwd>` when you know the original working directory and want a narrower review.
-- Open the entry inspector with `Ctrl+O`.
-- After confirming the exact row, press `Ctrl+D` to delete that one history item.
+The bundled `cleanup-typos` automation is disabled. Its current interface can recompute candidates, issue query-wide deletion, drive a TUI, and perform remote synchronization without binding execution to approved candidate IDs. Do not offer or execute it until those boundaries are implemented and verified.
 
-## Why manual typo cleanup avoids `search --delete`
+## User-Run Single-Entry Deletion
 
-- `atuin search --help` defines `--delete` as deleting anything that matches the query.
-- Matching behavior depends on the selected `--search-mode` or your configured default.
-- Even under `--search-mode prefix`, `search --delete` still deletes every matching row, not one chosen id.
-- For manual typo cleanup, stay in the interactive inspector and delete the confirmed row with `Ctrl+D`.
-- The transactional `cleanup-typos` command may use `search --delete`, but only after adding strict filter gates such as cwd, exit code, and a narrow timestamp window, and only when that filtered match set is provably unique.
+- Give the user `atuin search -i --search-mode prefix <query>` to open the interactive search view.
+- Add `--cwd <cwd>` when the original working directory is known.
+- The user opens the entry inspector with `Ctrl+O`, confirms the exact row, then presses `Ctrl+D`.
+- An agent must not open or drive this TUI.
 
-## Global duplicate cleanup
+Avoid manual `atuin search --delete`: it deletes every match under the selected or configured search mode, not one chosen ID.
 
-- Preview with `atuin history dedup --dry-run --before "<before>" --dupkeep <n>`.
-- If the dry run matches expectations, rerun the same command without `--dry-run`.
-- `history dedup` is global across the selected history window, not a single-command delete.
+## Global Duplicate Cleanup
 
-## Retroactive filter cleanup
+- Use a fixed `--before` cutoff; do not carry a relative value such as `now` from approval to later execution.
+- Immediately before every mutation, rerun the audit and `atuin history dedup --dry-run --before "<fixed-cutoff>" --dupkeep <n>`.
+- Compare the exact window, groups, and deletion count with the approved result. Obtain renewed approval if any differ.
+- Only then run the identical command without `--dry-run`.
+- `history dedup` is global across the selected history window, not a single-command deletion.
 
-- Use `atuin history prune` only when you already have `history_filter` or `cwd_filter` rules and need to retroactively remove matching entries.
-- Do not use `history prune` as a general typo or duplicate cleanup substitute.
+## Retroactive Filter Cleanup
+
+Use `atuin history prune` only for already-approved `history_filter` or `cwd_filter` rules and an exact reviewed scope. Do not use it as a typo or duplicate cleanup substitute.

--- a/deprecated/cleaning-atuin-history/scripts/atuin_history_cleanup.py
+++ b/deprecated/cleaning-atuin-history/scripts/atuin_history_cleanup.py
@@ -155,15 +155,6 @@ def parse_cli_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Output format.",
     )
 
-    cleanup = subparsers.add_parser(
-        "cleanup-typos",
-        help="Transactionally delete high-confidence typo entries with backup and recovery artifacts.",
-    )
-    add_shared_history_scope_args(cleanup)
-    cleanup.add_argument(
-        "--backup-dir",
-        help="Directory for history.db snapshots and cleanup reports.",
-    )
     return parser.parse_args(argv)
 
 
@@ -669,7 +660,7 @@ def audit_history(
             "max_typos": max_typos,
         },
         "stats": stats,
-        "duplicates": analyze_duplicates(entries, before, dupkeep),
+        "duplicates": analyze_duplicates(entries, before_cutoff.isoformat(), dupkeep),
         "typos": analyze_typos(entries, typo_window_seconds, max_typos),
     }
     return report
@@ -856,34 +847,23 @@ def main(argv: list[str] | None = None) -> int:
     """CLI entrypoint."""
     args = parse_cli_args(argv)
     try:
-        if args.command == "audit":
-            report = audit_history(
-                args.db_path,
-                dupkeep=args.dupkeep,
-                before=args.before,
-                typo_window_seconds=args.typo_window_seconds,
-                max_typos=args.max_typos,
-            )
-        elif args.command == "cleanup-typos":
-            report = cleanup_typos(
-                args.db_path,
-                before=args.before,
-                typo_window_seconds=args.typo_window_seconds,
-                max_typos=args.max_typos,
-                backup_dir=args.backup_dir,
-            )
-        else:
+        if args.command != "audit":
             raise AuditError(f"Unsupported command: {args.command}")
+        report = audit_history(
+            args.db_path,
+            dupkeep=args.dupkeep,
+            before=args.before,
+            typo_window_seconds=args.typo_window_seconds,
+            max_typos=args.max_typos,
+        )
     except AuditError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
 
-    if args.command == "audit" and args.format == "json":
+    if args.format == "json":
         print(json.dumps(report, indent=2, sort_keys=True))
-    elif args.command == "audit":
-        print(render_text_report(report))
     else:
-        print(render_cleanup_report(report))
+        print(render_text_report(report))
     return 0
 
 

--- a/deprecated/cleaning-atuin-history/tests/test_atuin_history_cleanup.py
+++ b/deprecated/cleaning-atuin-history/tests/test_atuin_history_cleanup.py
@@ -206,30 +206,88 @@ def test_duplicates_section_keeps_dedup_apply_command() -> None:
         for index in range(4)
     ]
 
-    duplicates = MODULE.analyze_duplicates(entries, before_value="now", dupkeep=3)
+    cutoff = "2026-01-02T03:04:05+00:00"
+    duplicates = MODULE.analyze_duplicates(entries, before_value=cutoff, dupkeep=3)
     lines = MODULE.format_duplicates_section(duplicates)
 
-    assert "- Preview: atuin history dedup --dry-run --before now --dupkeep 3" in lines
-    assert "- Apply: atuin history dedup --before now --dupkeep 3" in lines
-
-
-def test_parse_cli_args_supports_cleanup_typos() -> None:
-    args = MODULE.parse_cli_args(
-        [
-            "cleanup-typos",
-            "--before",
-            "now",
-            "--max-typos",
-            "5",
-            "--backup-dir",
-            "/tmp/backup",
-        ]
+    assert (
+        "- Preview: atuin history dedup --dry-run "
+        "--before 2026-01-02T03:04:05+00:00 --dupkeep 3" in lines
+    )
+    assert (
+        "- Apply: atuin history dedup "
+        "--before 2026-01-02T03:04:05+00:00 --dupkeep 3" in lines
     )
 
-    assert args.command == "cleanup-typos"
-    assert args.before == "now"
-    assert args.max_typos == 5
-    assert args.backup_dir == "/tmp/backup"
+
+def test_audit_resolves_now_before_building_dedup_commands(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixed_cutoff = datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC)
+    entries = [
+        make_entry(
+            str(index),
+            offset_seconds=index,
+            exit_code=0,
+            command="gst",
+            cwd="/tmp/repo",
+            session=f"session-{index}",
+        )
+        for index in range(4)
+    ]
+    stats = {
+        "rows_total": 4,
+        "rows_analyzed": 4,
+        "rows_skipped_unparsed_timestamp": 0,
+        "rows_excluded_after_before": 0,
+    }
+    monkeypatch.setattr(MODULE, "parse_before", lambda value: fixed_cutoff)
+    monkeypatch.setattr(
+        MODULE, "resolve_db_path", lambda value: Path("/tmp/history.db")
+    )
+    monkeypatch.setattr(
+        MODULE,
+        "load_history_entries",
+        lambda path, cutoff: (entries, stats),
+    )
+
+    report = MODULE.audit_history(
+        None,
+        dupkeep=3,
+        before="now",
+        typo_window_seconds=300,
+        max_typos=10,
+    )
+
+    preview = report["duplicates"]["preview_command"]
+    apply = report["duplicates"]["apply_command"]
+    assert "--before 2026-01-02T03:04:05+00:00" in preview
+    assert "--before 2026-01-02T03:04:05+00:00" in apply
+    assert "--before now" not in preview
+    assert "--before now" not in apply
+
+
+def test_cli_rejects_disabled_cleanup_typos_before_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        MODULE,
+        "cleanup_typos",
+        lambda *args, **kwargs: pytest.fail("disabled cleanup must not execute"),
+    )
+
+    with pytest.raises(SystemExit):
+        MODULE.main(
+            [
+                "cleanup-typos",
+                "--before",
+                "now",
+                "--max-typos",
+                "5",
+                "--backup-dir",
+                "/tmp/backup",
+            ]
+        )
 
 
 def test_cleanup_plan_uses_fast_path_for_unique_match() -> None:

--- a/docs/plans/archived/2026-07-22_fix-gpt-5-6-skill-review-plan.md
+++ b/docs/plans/archived/2026-07-22_fix-gpt-5-6-skill-review-plan.md
@@ -1,0 +1,32 @@
+## Goal
+
+Resolve every confirmed finding from the review of PR #95 with regression evidence, then prepare a new stacked pull request targeting `agent/optimize-skills-for-gpt-5-6` so merging it updates the original PR.
+
+## Assumptions
+
+- “New PR” means a focused stacked fix PR rather than a duplicate replacement PR against `main`.
+- Local edits, tests, branching, and commits are authorized; pushing the branch and creating the public PR require approval of the exact ref, title, and body.
+
+## Plan
+
+- [x] Add focused failing checks for the Peewee connection lifecycle, Marp structural-check claims, SVG host accessibility, palette candidate language, Jira authorization, Atuin disabled automation/fixed cutoffs, Telegraph byline defaults, gourmet source minimum, and chat-only plan archival; verified 12 focused repository assertions and the Atuin fixed-cutoff test failed for the reviewed reasons, while the Telegraph request-field test proved empty author fields are already transmitted.
+- [x] Fix Peewee and Marp guidance/scripts at their lifecycle and validation boundaries; verified a file-backed two-context Peewee example passed, the renamed structural precheck accepted malformed YAML without claiming syntax validity, and focused repository tests passed.
+- [x] Fix SVG accessibility and palette output claims; verified host-level alt/adjacent semantic alternatives are documented and representative terminal, data-viz, high-contrast, and accessibility generator output uses candidate/verification language.
+- [x] Fix Jira, Atuin, and Telegraph authorization/destructive/publication boundaries; verified exact-operation authorization text, disabled transactional cleanup across all prompt surfaces, fixed dedup command cutoffs, and explicit empty author fields in Telegraph request data.
+- [x] Restore gourmet evidence minimum and scope plan archival to saved plans; verified targeted repository assertions in `tests/test_skill_repository.py`.
+- [x] Run skill validation, focused tests, the full repository suite, representative scripts, `prek run -a`, and final diff review; verified `just`, 32/32 skill validation, 76/76 tests, live Peewee/Marp/palette checks, all `prek` hooks, `git diff --check`, zero broken links, and an independent nine-finding re-review.
+- [x] Create a focused local commit and prepare the exact stacked push/PR payload for user approval; verified `agent/fix-gpt-5-6-skill-review` is clean and one commit ahead of `agent/optimize-skills-for-gpt-5-6`, with the exact base, head, title, body, and push ref prepared.
+
+## Risks
+
+- Mitigated: deprecated Atuin automation is removed from the CLI parser, disabled on every prompt surface, and covered by no-mutation and fixed-cutoff tests.
+- Mitigated: the Marp structural checker rename has no stale references, all relative links resolve, and malformed-YAML behavior is tested without a false syntax claim.
+- Controlled: the new PR payload targets the PR #95 branch, not `main`, so it will contain only the focused fixes.
+
+## Completion Checklist
+
+- [x] All nine reviewed issue groups are resolved, verified by targeted regressions and an independent PASS re-review.
+- [x] No destructive or public action can be inferred from supplied content alone, verified by Jira, Atuin, and Telegraph boundary tests.
+- [x] All affected skill trigger, metadata, reference, script, and README surfaces remain aligned, verified by skill validation, searches, and link checks.
+- [x] All repository gates pass on the final files, verified by 76 tests and all `prek` hooks.
+- [x] The completed plan is archived and the exact external PR action is ready for explicit approval.

--- a/skills/python/using-peewee-orm/SKILL.md
+++ b/skills/python/using-peewee-orm/SKILL.md
@@ -56,21 +56,21 @@ MODELS = [User]
 
 
 @pytest.fixture
-def test_db():
-    db = SqliteDatabase(":memory:", pragmas={"foreign_keys": 1})
+def test_db(tmp_path):
+    db = SqliteDatabase(
+        str(tmp_path / "test.db"),
+        pragmas={"foreign_keys": 1},
+    )
     db_proxy.initialize(db)
     try:
-        db.connect()
-        db.create_tables(MODELS)
+        with db.connection_context():
+            db.create_tables(MODELS)
         yield db
     finally:
-        if not db.is_closed():
-            try:
-                db.drop_tables(MODELS, safe=True)
-            finally:
-                db.close()
+        with db.connection_context():
+            db.drop_tables(MODELS, safe=True)
 ```
 
-The fixture owns one open connection across the test, so test transactions may use `test_db.atomic()` inside that lifetime. Test successful commits and rollback behavior for multi-statement invariants. Do not reuse an application database or depend on table state from another test.
+A temporary file-backed database preserves its schema when tested code owns and closes scoped connections. Exercise at least two sequential `connection_context()` blocks—such as a write followed by a read—and test rollback behavior for multi-statement invariants. Do not reuse an application database or depend on table state from another test.
 
 Finish by reporting the binding boundary, connection and transaction ownership, schema-test lifecycle, and checks run.

--- a/skills/slides-visuals/authoring-marp-slides/SKILL.md
+++ b/skills/slides-visuals/authoring-marp-slides/SKILL.md
@@ -14,8 +14,8 @@ Load only the authoring detail the deck needs.
 | Complex layouts | `references/advanced-layouts.md` |
 | Theme behavior | `references/themes.md` |
 | Content and QA guidance | `references/best-practices.md` |
-| Source validation | `scripts/validate_marpit.sh <deck.md>` |
-| Render and visual checks | `references/preview-workflow.md` |
+| Structural precheck | `scripts/check_marpit_structure.sh <deck.md>` |
+| Syntax, render, and visual checks | `references/preview-workflow.md` |
 | Starting point | `assets/templates/` |
 | Known-good patterns | `assets/examples/` |
 
@@ -25,7 +25,7 @@ Load only the authoring detail the deck needs.
 2. Start from the nearest template or preserve the current structure. Define valid Marp frontmatter and repository-relative asset paths.
 3. Author a clear slide sequence with consistent hierarchy and layouts. Use `bg` syntax for full-slide or split-layout visuals; keep logos, icons, and other small visuals inline.
 4. Load color or SVG guidance only when the task requires new palette or illustration work.
-5. Resolve this skill directory and validate exactly one deck with `bash "$SKILL_DIR/scripts/validate_marpit.sh" path/to/deck.md`. Then follow `references/preview-workflow.md` when rendering is available and inspect the title, densest slide, and every image/SVG slide.
+5. Resolve this skill directory and run the limited structural precheck with `bash "$SKILL_DIR/scripts/check_marpit_structure.sh" path/to/deck.md`. It checks delimiters and `marp: true` but does not parse YAML or Marp syntax. Then follow `references/preview-workflow.md` to export with the actual Marp renderer; inspect whether directives took effect, plus the title, densest slide, and every image/SVG slide. Report structural, strict-YAML, renderer, and visual evidence separately; never infer one from another.
 6. Return the deck artifact first, followed by checks performed and any rendering, font, asset, or environment caveat.
 
 Do not claim visual validation from Markdown inspection alone. Do not commit, publish, or convert formats unless requested.

--- a/skills/slides-visuals/authoring-marp-slides/assets/examples/with-bg-syntax.md
+++ b/skills/slides-visuals/authoring-marp-slides/assets/examples/with-bg-syntax.md
@@ -23,6 +23,8 @@ Tech Presentation · 2026-01-13
 
 # System Architecture
 
+**Diagram summary:** Requests pass from clients through the gateway to application services and storage.
+
 *Full-page background with overlay title*
 
 ---
@@ -32,6 +34,8 @@ Tech Presentation · 2026-01-13
 ![bg right fit](diagrams/workflow.svg)
 
 # Process Workflow
+
+**Diagram summary:** The request moves through validation and processing before a result returns to the user.
 
 **Key Steps:**
 1. User initiates request
@@ -50,7 +54,7 @@ Tech Presentation · 2026-01-13
 
 # Component Diagram
 
-The diagram on the left shows our microservices architecture with three main components:
+**Diagram summary:** The microservices architecture contains three main components:
 
 - API Gateway
 - Service Mesh
@@ -63,6 +67,8 @@ The diagram on the left shows our microservices architecture with three main com
 ![bg right:40% fit](diagrams/detail.svg)
 
 # Detailed View
+
+**Diagram summary:** The detailed view expands the selected component into its inputs, processing stage, and outputs.
 
 When you need more space for text, use a custom ratio.
 
@@ -81,15 +87,17 @@ When you need more space for text, use a custom ratio.
 
 # Before → After
 
+**Comparison summary:** The revised flow removes the intermediate handoff and reduces the path from four steps to three.
+
 ---
 
 ## With Small Icon (Exception)
 
-![width:60px](../icons/check.svg) Feature completed
+<img src="../icons/check.svg" width="60" alt="" aria-hidden="true"> Feature completed
 
-![width:60px](../icons/warning.svg) Needs attention
+<img src="../icons/warning.svg" width="60" alt="" aria-hidden="true"> Needs attention
 
-![width:60px](../icons/info.svg) Additional info
+<img src="../icons/info.svg" width="60" alt="" aria-hidden="true"> Additional info
 
 *Only use regular syntax for tiny inline icons*
 
@@ -101,11 +109,11 @@ When you need more space for text, use a custom ratio.
 
 # Key Takeaway
 
-Always use `![bg fit]` syntax for diagrams
-- No manual sizing needed
-- Consistent appearance
-- Auto-scales perfectly
-- Better split layouts
+Use `bg fit` for full-slide or split-layout diagrams
+- Provide an adjacent semantic equivalent for meaningful backgrounds
+- Keep descriptive host-level alt text for inline images
+- Let Marp control background sizing
+- Verify the exported accessibility tree
 
 ---
 

--- a/skills/slides-visuals/authoring-marp-slides/assets/templates/minimal-keynote.md
+++ b/skills/slides-visuals/authoring-marp-slides/assets/templates/minimal-keynote.md
@@ -42,7 +42,7 @@ Impact and implications
 
 <!-- _class: lead -->
 
-![width:800px](diagrams/impact.svg)
+![Visual evidence of transformation width:800px](diagrams/impact.svg)
 
 **Visual evidence** of transformation
 

--- a/skills/slides-visuals/authoring-marp-slides/assets/templates/minimal.md
+++ b/skills/slides-visuals/authoring-marp-slides/assets/templates/minimal.md
@@ -32,9 +32,9 @@ def example():
 
 ## Image or Diagram
 
-![width:600px](diagrams/example.svg)
+![Description of the diagram width:600px](diagrams/example.svg)
 
-**Caption**: Description of visual
+**Caption**: Visible semantic equivalent for the visual
 
 ---
 

--- a/skills/slides-visuals/authoring-marp-slides/assets/templates/with-bg-images.md
+++ b/skills/slides-visuals/authoring-marp-slides/assets/templates/with-bg-images.md
@@ -39,6 +39,8 @@ Your Name · Date
 
 # Optional Overlay Title
 
+**Diagram summary:** Describe the relationships or sequence shown in the background.
+
 ---
 
 ## Diagram with Explanation
@@ -46,6 +48,8 @@ Your Name · Date
 ![bg right fit](diagrams/architecture.svg)
 
 # System Design
+
+**Diagram summary:** Describe how the listed components connect and exchange data.
 
 **Components:**
 - Component A
@@ -89,6 +93,8 @@ def process_data(input_data):
 
 # Detailed Analysis
 
+**Diagram summary:** Describe the detail shown in the left-side visual.
+
 More space for text when you need to explain complex concepts.
 
 The diagram takes 60% on the left, leaving 40% for your explanation.
@@ -102,14 +108,16 @@ The diagram takes 60% on the left, leaving 40% for your explanation.
 
 # Transformation
 
+**Comparison summary:** Describe the material change between the left and right visuals.
+
 ---
 
 ## Key Takeaways
 
-1. **Always use bg syntax** for diagrams and large images
-2. **Use fit modifier** to auto-size images
-3. **Regular syntax** only for tiny inline icons
-4. **Split layouts** work great with bg syntax
+1. **Use bg syntax** for full-slide and split-layout visuals
+2. **Add an adjacent semantic equivalent** for meaningful backgrounds
+3. **Use descriptive alt text** for meaningful inline images
+4. **Verify the exported accessibility tree**
 
 ---
 

--- a/skills/slides-visuals/authoring-marp-slides/references/best-practices.md
+++ b/skills/slides-visuals/authoring-marp-slides/references/best-practices.md
@@ -10,8 +10,8 @@
 ## Design
 
 - Reuse one palette, one spacing unit, and one heading hierarchy.
-- Prefer background image syntax for diagrams and photos.
-- Use high contrast for projected decks.
+- Prefer background image syntax for diagrams and photos when layout requires it; give meaningful backgrounds an adjacent semantic equivalent.
+- Measure actual text/background contrast and inspect the exported deck on the target projector before claiming venue suitability.
 - Keep diagrams, tables, and text aligned to a simple grid.
 
 ## HTML Policy
@@ -25,13 +25,13 @@ Use Markdown first. Use inline HTML only when Marp Markdown cannot express the l
 - Avoid tiny captions and overcrowded diagrams.
 - Avoid emoji when predictable rendering matters.
 
-## Pre-Commit Check
+## Handoff Check
 
-Before handing off a deck, resolve `scripts/validate_marpit.sh` against the `authoring-marp-slides` skill directory, then run it by absolute path:
+Resolve `scripts/check_marpit_structure.sh` against the `authoring-marp-slides` skill directory and run its limited delimiter/directive precheck:
 
 ```shell
 AUTHORING_MARP_SLIDES_SKILL_DIR="/absolute/path/to/authoring-marp-slides"
-bash "$AUTHORING_MARP_SLIDES_SKILL_DIR/scripts/validate_marpit.sh" deck.md
+bash "$AUTHORING_MARP_SLIDES_SKILL_DIR/scripts/check_marpit_structure.sh" deck.md
 ```
 
-Then preview or export the deck and inspect at least title, densest content slide, and every slide with an SVG/background image.
+This does not parse YAML or Marp syntax. Follow with the actual preview/export workflow and inspect at least the title, densest content slide, every SVG/background image, and the exported accessibility tree when meaningful visuals are present.

--- a/skills/slides-visuals/authoring-marp-slides/references/output-examples.md
+++ b/skills/slides-visuals/authoring-marp-slides/references/output-examples.md
@@ -81,7 +81,7 @@ Engineering Team · 2026-01-09
 - **Service Mesh**: Inter-service communication
 - **Data Layer**: PostgreSQL + Redis caching
 
-![width:900px](diagrams/architecture.svg)
+![System architecture width:900px](diagrams/architecture.svg)
 
 ---
 

--- a/skills/slides-visuals/authoring-marp-slides/references/preview-workflow.md
+++ b/skills/slides-visuals/authoring-marp-slides/references/preview-workflow.md
@@ -21,13 +21,13 @@ http://localhost:8080/<deck>.md
 
 Jump to a slide with `#N`, for example `deck.md#5`.
 
-## Export Check
+## Renderer and Export Check
 
 ```bash
 marp examples/slides/deck.md -o /tmp/deck.html
 ```
 
-Inspect the title slide, the densest slide, and every slide that uses images or SVGs.
+Unlike the bundled structural precheck, this invokes the Marp renderer and confirms whether it accepted the source and produced output. It does not prove strict YAML validity: malformed or ignored directives may still export. Inspect whether frontmatter directives took effect, plus the title slide, densest slide, every image/SVG slide, and the accessibility tree or equivalent when meaningful visuals are present.
 
 ## Common Fixes
 

--- a/skills/slides-visuals/authoring-marp-slides/references/syntax-guide.md
+++ b/skills/slides-visuals/authoring-marp-slides/references/syntax-guide.md
@@ -44,15 +44,15 @@ Common directives: `theme`, `paginate`, `size`, `class`, `backgroundColor`, `col
 Prefer background image syntax; it avoids manual resizing.
 
 ```markdown
-![bg fit](assets/diagram.svg)
+## Request flow: client → gateway → service
+
 ![bg right:45% fit](assets/architecture.svg)
-![bg left:40% fit](assets/photo.jpg)
 ```
 
-Use regular image sizing only for small inline images:
+A meaningful background needs an adjacent semantic equivalent because CSS backgrounds do not expose reliable alt text. Use descriptive host-level alt text for inline images:
 
 ```markdown
-![w:600](assets/logo.svg)
+![Company logo w:600](assets/logo.svg)
 ```
 
 ## Code
@@ -76,9 +76,11 @@ Use Markdown tables only for small comparisons. For dense data, simplify or use 
 
 ## Validation
 
-Resolve `scripts/validate_marpit.sh` against the `authoring-marp-slides` skill directory, then run the local syntax check by absolute path:
+Resolve `scripts/check_marpit_structure.sh` against the `authoring-marp-slides` skill directory and run its limited structural precheck:
 
 ```shell
 AUTHORING_MARP_SLIDES_SKILL_DIR="/absolute/path/to/authoring-marp-slides"
-bash "$AUTHORING_MARP_SLIDES_SKILL_DIR/scripts/validate_marpit.sh" deck.md
+bash "$AUTHORING_MARP_SLIDES_SKILL_DIR/scripts/check_marpit_structure.sh" deck.md
 ```
+
+The precheck does not parse YAML or Marp syntax. Export with the actual Marp renderer as described in `preview-workflow.md`, verify directives took effect, and report strict-YAML, renderer, and visual evidence separately.

--- a/skills/slides-visuals/authoring-marp-slides/scripts/check_marpit_structure.sh
+++ b/skills/slides-visuals/authoring-marp-slides/scripts/check_marpit_structure.sh
@@ -1,15 +1,17 @@
 #!/bin/bash
-# Validate Marpit Markdown syntax
+# Check basic Marpit Markdown structure without parsing YAML or rendering slides.
 
 set -e
 
 if [ $# -ne 1 ]; then
-    echo "Usage: validate_marpit.sh <file.md>"
+    echo "Usage: check_marpit_structure.sh <file.md>"
     echo ""
-    echo "Validates Marpit Markdown files for:"
-    echo "  - Frontmatter presence and format"
-    echo "  - Required 'marp: true' directive"
-    echo "  - Slide separators"
+    echo "Checks only:"
+    echo "  - Frontmatter opening and closing delimiters"
+    echo "  - A literal 'marp: true' directive in frontmatter"
+    echo "  - Structural slide-separator count"
+    echo ""
+    echo "This does not parse YAML or validate rendered Marp output."
     exit 1
 fi
 
@@ -55,13 +57,14 @@ else
     SLIDE_COUNT=0
 fi
 
-if [ $ERRORS -eq 0 ]; then
-    echo "✅ Marpit syntax valid"
+if [ "$ERRORS" -eq 0 ]; then
+    echo "✅ Structural precheck passed"
     echo "   File: $FILE"
     echo "   Slides: $SLIDE_COUNT"
+    echo "   Note: YAML and rendered Marp output were not validated"
     exit 0
-else
-    echo ""
-    echo "❌ Found $ERRORS error(s) in Marpit syntax"
-    exit 1
 fi
+
+echo ""
+echo "❌ Found $ERRORS structural issue(s)"
+exit 1

--- a/skills/slides-visuals/creating-slide-decks/references/troubleshooting-common.md
+++ b/skills/slides-visuals/creating-slide-decks/references/troubleshooting-common.md
@@ -15,7 +15,7 @@
 4. Embed and export once; a standalone browser preview may not match the deck renderer.
 
 ```markdown
-![width:800px](diagrams/flow.svg)
+![Request flow diagram width:800px](diagrams/flow.svg)
 ```
 
 ## Exported Text Loses Contrast

--- a/skills/slides-visuals/creating-svg-illustrations/SKILL.md
+++ b/skills/slides-visuals/creating-svg-illustrations/SKILL.md
@@ -18,7 +18,7 @@ Start with `references/core-rules.md`; load only the extra detail the artifact n
 ## Workflow
 
 1. Inspect the target slide or document, required dimensions, surrounding palette, and renderer.
-2. Create the smallest editable SVG that communicates the idea. Use a correct `viewBox`, explicit text styles, consistent geometry, and accessible title/description where the visual carries meaning.
+2. Create the smallest editable SVG that communicates the idea. Use a correct `viewBox`, explicit text styles, consistent geometry, and SVG title/description where the visual carries meaning. When embedding, also provide descriptive host-level alt text or an adjacent semantic equivalent as required by `references/embedding.md`; internal SVG metadata alone is not sufficient.
 3. Keep assets portable: avoid embedded fonts, unexplained emoji, unnecessary filters, and base64 content unless the output must be self-contained.
 4. Validate with `svglint` when available, then open or embed the SVG in the target artifact and inspect clipping, scaling, contrast, text, and relative paths.
 5. Return the SVG artifact first, followed by validation performed and any renderer or font caveat.

--- a/skills/slides-visuals/creating-svg-illustrations/assets/examples/with-diagrams.md
+++ b/skills/slides-visuals/creating-svg-illustrations/assets/examples/with-diagrams.md
@@ -32,7 +32,9 @@ Tech Talk · 2026-01-09
 
 ## Data Flow
 
-<svg viewBox="0 0 600 200" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 600 200" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="data-flow-title data-flow-desc">
+  <title id="data-flow-title">Request data flow</title>
+  <desc id="data-flow-desc">A request travels from the user through the API and service to the database.</desc>
   <!-- User -->
   <rect x="20" y="70" width="100" height="60" fill="#252526" stroke="#569CD6" stroke-width="2" rx="4"/>
   <text x="70" y="105" font-size="14" fill="#D4D4D4" text-anchor="middle">User</text>

--- a/skills/slides-visuals/creating-svg-illustrations/references/embedding.md
+++ b/skills/slides-visuals/creating-svg-illustrations/references/embedding.md
@@ -1,35 +1,37 @@
 # Embedding SVG in Marp/Marpit
 
-## Preferred: Background Image Syntax
+Accessibility belongs to the host document as well as the SVG. Internal `<title>` and `<desc>` help when SVG is opened directly, but do not reliably replace host-level alternatives for external images or CSS backgrounds.
+
+## Inline Images
+
+Give meaningful inline images descriptive host-level alt text. Marp directives can share the alt field:
 
 ```markdown
-![bg fit](assets/diagram.svg)
+![System architecture w:800](assets/architecture.svg)
+![Company logo w:160](assets/logo.svg)
+```
+
+Use empty alt text only for a truly decorative image whose meaning is already present in nearby content.
+
+## Background Images
+
+Marp background syntax is useful for full-slide and split layouts, but a CSS background has no reliable image alternative:
+
+```markdown
 ![bg right:45% fit](assets/architecture.svg)
-![bg left:40% fit](assets/process.svg)
 ```
 
-Use this for full-slide or split-layout diagrams. It keeps sizing in Marp instead of hard-coding it in SVG.
+When a background diagram carries meaning, provide an adjacent semantic equivalent in the slide's heading, body, caption, speaker notes included in the accessible deliverable, or another documented text alternative. Do not rely on the `bg`, `fit`, or sizing directives as alt text.
 
-## Inline Image
+## Verification
 
-Use only for small logos or icons.
+- Inspect the exported accessibility tree or equivalent output, not only the source Markdown.
+- Confirm meaningful inline images expose their descriptive alt text.
+- Confirm every meaningful background diagram has an adjacent semantic equivalent.
+- Check that decorative images do not create redundant announcements.
 
-```markdown
-![w:320](assets/logo.svg)
-```
+## Paths and Sizing
 
-## Path Rules
-
-- Paths are relative to the slide Markdown file.
-- Do not use absolute local paths.
-- Keep SVG assets near the deck, for example `examples/slides/assets/system-map.svg`.
-
-## Sizing Rules
-
-- Let `viewBox` define the SVG's internal bounds.
-- Let Marp control displayed size with `bg`, `fit`, `cover`, or `w:`.
-- If content appears tiny, shrink the SVG `viewBox` to the actual content.
-
-## Production Option
-
-Inline base64 only when the deck must be a single self-contained Markdown file. Otherwise keep SVG as a normal file.
+- Resolve paths relative to the slide Markdown file; do not use absolute local paths.
+- Let `viewBox` define SVG content bounds and Marp control display size with `bg`, `fit`, `cover`, or `w:`.
+- Keep SVG assets near the deck. Use base64 only when a self-contained artifact is required.

--- a/skills/slides-visuals/designing-slide-colors/scripts/generate_palette.py
+++ b/skills/slides-visuals/designing-slide-colors/scripts/generate_palette.py
@@ -223,8 +223,8 @@ SVG_PALETTES = {
         "example": '<rect fill="#BFDBFE" stroke="#374151" stroke-width="3"/>\n<text fill="#374151">Soft, friendly label</text>',
     },
     "high-contrast": {
-        "name": "High Contrast",
-        "best_for": "Accessibility, large venue presentations",
+        "name": "High Contrast Candidate",
+        "best_for": "Starting point for diagrams that need strong color separation",
         "colors": {
             "Black": "#000000",
             "White": "#FFFFFF",
@@ -232,7 +232,7 @@ SVG_PALETTES = {
             "Cyan": "#22D3EE",
             "Magenta": "#F472B6",
         },
-        "notes": "Ensure text-to-background contrast ratio ≥ 7:1 for AAA compliance",
+        "notes": "Calculate each actual pairing and test the exported artifact in its target environment",
     },
 }
 
@@ -247,8 +247,8 @@ PALETTE_METADATA = {
     "terminal-dark": {
         "name": "Terminal Dark",
         "category": "Dark Technical",
-        "best_for": "Terminal commands, CLI tools, DevOps presentations",
-        "notes": "High contrast for projectors; three-color semantic system",
+        "best_for": "Candidate for terminal, CLI, and DevOps presentations",
+        "notes": "Verify every assigned pairing and the exported deck on the target projector",
     },
     "midnight-professional": {
         "name": "Midnight Professional",
@@ -287,16 +287,16 @@ PALETTE_METADATA = {
         "notes": "Red accent should be reserved for 1-2 key elements per slide",
     },
     "data-viz": {
-        "name": "Data Visualization (Categorical)",
+        "name": "Data Visualization Candidate (Categorical)",
         "category": "Specialized",
-        "best_for": "Charts, graphs, multi-category data",
-        "notes": "Tableau-inspired; colorblind-friendly; maximizes distinction",
+        "best_for": "Starting point for charts, graphs, and multi-category data",
+        "notes": "Verify series distinguishability with target charts, labels, and color-vision simulation",
     },
     "accessibility": {
-        "name": "Accessibility First (High Contrast)",
+        "name": "High Contrast Candidate",
         "category": "Specialized",
-        "best_for": "Accessibility requirements, large audiences, recorded content",
-        "notes": "Validate each foreground/background role pairing before use",
+        "best_for": "Starting point for slides with strong contrast requirements",
+        "notes": "Validate each actual pairing, noncolor cue, export, and assistive path before use",
     },
 }
 

--- a/skills/workflow-repository/using-jira-cli/SKILL.md
+++ b/skills/workflow-repository/using-jira-cli/SKILL.md
@@ -5,7 +5,7 @@ description: Inspect Jira or prepare and perform precisely authorized Jira mutat
 
 # Using Jira CLI
 
-Use read-only discovery freely. Jira creates, edits, transitions, assignments, comments, worklogs, links, sprint/epic changes, and deletes are external writes and require approval for the exact target and content unless already supplied.
+Use read-only discovery freely. Jira creates, edits, transitions, assignments, comments, worklogs, links, sprint/epic changes, and deletes are external writes and require authorization for the exact operation, target, and content. Supplying values for a draft does not authorize execution.
 
 ## Establish Context
 
@@ -27,7 +27,7 @@ Read `references/commands.md` only for the relevant resource's common command sh
 
 1. Read the current target and discover valid field/status values.
 2. Prepare the exact Jira instance/config, issue or container IDs, operation, summary/body/comment/worklog text, transition, assignment, and other changed fields. Do not impose a project-name summary prefix or description template unless the user or repository requires it.
-3. If any target or content is not already authorized, show the exact mutation and ask for approval. Always require exact approval for deletion.
+3. If the exact operation, target, and content have not already been explicitly authorized for execution, show the complete mutation and ask for approval. Treat requests to draft, explain, review, or prepare Jira content as read-only. Always require exact approval for deletion.
 4. After approval, use non-interactive flags only when every required parameter is known. Quote values and provide long content through a template or stdin rather than unsafe shell interpolation.
 5. Re-read the affected issue or resource and report its resulting key, status, assignee, fields, or comment/worklog evidence. A zero exit code alone is not sufficient verification.
 

--- a/skills/writing-research/creating-telegraph-pages/SKILL.md
+++ b/skills/writing-research/creating-telegraph-pages/SKILL.md
@@ -12,7 +12,7 @@ Use the bundled `scripts/telegraph.py` by absolute path. A page is a public exte
 1. Preserve the user's language and wording unless editing was requested. Reject secrets, private data, and local-only asset links.
 2. Convert the body to a temporary JSON array of Telegraph nodes. Text may be a string; elements use `tag`, optional `attrs`, and optional `children`.
 3. Allow only `a`, `aside`, `b`, `blockquote`, `br`, `code`, `em`, `figcaption`, `figure`, `h3`, `h4`, `hr`, `i`, `iframe`, `img`, `li`, `ol`, `p`, `pre`, `s`, `strong`, `u`, `ul`, or `video`. Attributes are string-valued `href` or `src`. Convert larger Markdown headings to `h3`/`h4` and keep encoded content at or below 64 KB.
-4. Verify the final title, byline, links, node structure, and one-page publication scope.
+4. Record an explicit byline decision along with the final title, links, node structure, and one-page publication scope. Approve either exact author values or no public byline; do not infer omission from missing fields.
 
 ## Credentials and Account Boundary
 
@@ -35,11 +35,12 @@ With exact publication authorization and `SKILL_DIR` resolved to this skill dire
 ```shell
 uv run --no-project python "$SKILL_DIR/scripts/telegraph.py" create-page \
   --title '<approved-title>' \
-  --author-name '<approved-author>' \
+  --author-name '<approved-author-or-empty>' \
+  --author-url '<approved-author-url-or-empty>' \
   /tmp/telegraph-content.json
 ```
 
-Omit optional author fields unless approved. Inject the token through the execution environment; if loading an approved token file, do so without printing it.
+Pass the approved byline values explicitly. To suppress account-default identity, include `--author-name '' --author-url ''`; omitting these fields can publish the account's default author name or URL. Inject the token through the execution environment and load an approved token file without printing it.
 
 Require an `https://telegra.ph/...` result, then fetch or open the public page and verify title, byline, links, and content structure. Report the URL and any unavailable check. Remove sensitive temporary drafts after successful publication.
 

--- a/skills/writing-research/creating-telegraph-pages/scripts/telegraph.py
+++ b/skills/writing-research/creating-telegraph-pages/scripts/telegraph.py
@@ -230,8 +230,16 @@ def build_parser():
     page = commands.add_parser("create-page", help="Publish a Telegraph page")
     page.add_argument("content", type=Path, help="JSON file containing Telegraph nodes")
     page.add_argument("--title", required=True)
-    page.add_argument("--author-name")
-    page.add_argument("--author-url")
+    page.add_argument(
+        "--author-name",
+        required=True,
+        help="Approved author name, or an empty string to suppress the account default",
+    )
+    page.add_argument(
+        "--author-url",
+        required=True,
+        help="Approved author URL, or an empty string to suppress the account default",
+    )
     return parser
 
 

--- a/skills/writing-research/creating-telegraph-pages/scripts/test_telegraph.py
+++ b/skills/writing-research/creating-telegraph-pages/scripts/test_telegraph.py
@@ -2,6 +2,7 @@ import json
 import os
 import sys
 from unittest.mock import patch
+from urllib.parse import parse_qs
 
 import pytest
 
@@ -31,7 +32,7 @@ def test_create_page_posts_validated_content_and_returns_page():
     )
 
     with patch("telegraph.urlopen", return_value=response) as urlopen:
-        page = telegraph.create_page("token", "Hello", content, "Author", None)
+        page = telegraph.create_page("token", "Hello", content, "Author", "")
 
     request = urlopen.call_args.args[0]
     form = request.data.decode()
@@ -39,6 +40,43 @@ def test_create_page_posts_validated_content_and_returns_page():
     assert "access_token=token" in form
     assert "title=Hello" in form
     assert "content=%5B" in form
+
+
+def test_create_page_cli_can_clear_account_author_defaults(tmp_path):
+    content_file = tmp_path / "content.json"
+    content_file.write_text('["Text"]')
+    response = FakeResponse(
+        {"ok": True, "result": {"url": "https://telegra.ph/Anonymous-01-01"}}
+    )
+
+    with (
+        patch.dict(os.environ, {"TELEGRAPH_ACCESS_TOKEN": "token"}, clear=True),
+        patch("telegraph.urlopen", return_value=response) as urlopen,
+    ):
+        telegraph.main(
+            [
+                "create-page",
+                "--title",
+                "Anonymous",
+                "--author-name",
+                "",
+                "--author-url",
+                "",
+                str(content_file),
+            ]
+        )
+
+    request = urlopen.call_args.args[0]
+    form = parse_qs(request.data.decode(), keep_blank_values=True)
+    assert form["author_name"] == [""]
+    assert form["author_url"] == [""]
+
+
+def test_create_page_cli_requires_explicit_byline_fields():
+    with pytest.raises(SystemExit):
+        telegraph.build_parser().parse_args(
+            ["create-page", "--title", "Hello", "content.json"]
+        )
 
 
 def test_rejects_unsupported_tags_before_request():
@@ -253,7 +291,18 @@ def test_cli_rejects_deeply_nested_json_before_request(tmp_path):
         patch("telegraph.urlopen") as urlopen,
         pytest.raises(ValueError, match="nesting is too deep"),
     ):
-        telegraph.main(["create-page", "--title", "Hello", str(content_file)])
+        telegraph.main(
+            [
+                "create-page",
+                "--title",
+                "Hello",
+                "--author-name",
+                "",
+                "--author-url",
+                "",
+                str(content_file),
+            ]
+        )
 
     urlopen.assert_not_called()
 
@@ -261,4 +310,15 @@ def test_cli_rejects_deeply_nested_json_before_request(tmp_path):
 def test_cli_requires_token_from_environment():
     with patch.dict(os.environ, {}, clear=True):
         with pytest.raises(SystemExit, match="TELEGRAPH_ACCESS_TOKEN"):
-            telegraph.main(["create-page", "--title", "Hello", "content.json"])
+            telegraph.main(
+                [
+                    "create-page",
+                    "--title",
+                    "Hello",
+                    "--author-name",
+                    "",
+                    "--author-url",
+                    "",
+                    "content.json",
+                ]
+            )

--- a/skills/writing-research/researching-gourmet-venues/SKILL.md
+++ b/skills/writing-research/researching-gourmet-venues/SKILL.md
@@ -18,8 +18,8 @@ Never fabricate sources, ratings, hours, or claims. Use `unknown`. Never delete 
 ## Research and Score
 
 1. Capture raw discoveries in `inbox.md`, then move viable entries to `candidates.md` with status.
-2. Build a `notes.md` evidence block for each candidate with practical constraints. Aim for four independent source roles where available: official channel, maps/aggregator, local reviews, and guide/editorial.
-3. In an information-sparse locale, use three sources only after recording `evidence: limited`, why, and attempted sources.
+2. Build a `notes.md` evidence block for each candidate with practical constraints. Require four independent source roles by default: official channel, maps/aggregator, local reviews, and guide/editorial.
+3. In an information-sparse locale, use three sources only after recording `evidence: limited`, why, and attempted sources. Do not score or publish a recommendation with fewer sources outside this exception.
 4. When repeated service complaints, hygiene/safety concerns, tourist-trap claims, extreme queues, inconsistent ratings, or unclear access appear, add a focused negative-review section and reflect it in scoring.
 5. Score and justify each component: Taste/Quality, Value, Convenience, Consistency, and Risk (0–10 each; higher Risk score means lower practical risk).
 6. Classify totals: Top Pick ≥35, Backup 30–34, Reject <30 or a hard safety/tourist-trap exclusion.

--- a/skills/writing-research/writing-plans/SKILL.md
+++ b/skills/writing-research/writing-plans/SKILL.md
@@ -45,8 +45,8 @@ Order dependencies explicitly. Convert important unknowns into early discovery t
 - After each task's acceptance method passes, immediately change `- [ ]` to `- [x]` and add evidence when repository state does not make it obvious.
 - Leave failed or unavailable checks open. Mark an inapplicable item `- [x] Not applicable: <reason>`.
 - If later work invalidates evidence, reopen the item and reverify it.
-- Track the current plan only; do not inspect or alter unrelated plans.
+- Track the current saved plan only; do not inspect or alter unrelated plans. For a chat-only plan, show each updated checkbox and its evidence in chat.
 
 Complete only when every task and completion check is checked, important unknowns are resolved or explicitly accepted, risks are mitigated/accepted/moved to follow-up, and required handoff or release work is done. Do not infer completion from implementation alone.
 
-After a complete execution, archive the current plan under `docs/plans/archived/` and report the path. Do not archive with missing evidence or overwrite an existing archived filename; stop and report that conflict.
+After a complete execution of a saved plan, archive that plan under `docs/plans/archived/` and report the path. Do not create an archive file for a chat-only plan. Do not archive with missing evidence or overwrite an existing archived filename; stop and report that conflict.

--- a/tests/test_skill_repository.py
+++ b/tests/test_skill_repository.py
@@ -124,7 +124,7 @@ def test_bundled_script_commands_do_not_assume_source_checkout_layout() -> None:
     assert offenders == []
 
 
-def test_marp_validator_rejects_unclosed_frontmatter(tmp_path: Path) -> None:
+def test_marp_structure_check_rejects_unclosed_frontmatter(tmp_path: Path) -> None:
     deck = tmp_path / "invalid.md"
     deck.write_text("---\nmarp: true\n# Missing closing delimiter\n")
 
@@ -133,7 +133,7 @@ def test_marp_validator_rejects_unclosed_frontmatter(tmp_path: Path) -> None:
             "bash",
             str(
                 SKILLS
-                / "slides-visuals/authoring-marp-slides/scripts/validate_marpit.sh"
+                / "slides-visuals/authoring-marp-slides/scripts/check_marpit_structure.sh"
             ),
             str(deck),
         ],
@@ -146,7 +146,7 @@ def test_marp_validator_rejects_unclosed_frontmatter(tmp_path: Path) -> None:
     assert "syntax valid" not in result.stdout
 
 
-def test_marp_validator_requires_exactly_one_file(tmp_path: Path) -> None:
+def test_marp_structure_check_requires_exactly_one_file(tmp_path: Path) -> None:
     deck = tmp_path / "valid.md"
     deck.write_text("---\nmarp: true\n---\n# Slide\n")
 
@@ -155,7 +155,7 @@ def test_marp_validator_requires_exactly_one_file(tmp_path: Path) -> None:
             "bash",
             str(
                 SKILLS
-                / "slides-visuals/authoring-marp-slides/scripts/validate_marpit.sh"
+                / "slides-visuals/authoring-marp-slides/scripts/check_marpit_structure.sh"
             ),
             str(deck),
             "unexpected.md",
@@ -169,7 +169,7 @@ def test_marp_validator_requires_exactly_one_file(tmp_path: Path) -> None:
     assert "Usage:" in result.stdout
 
 
-def test_marp_validator_accepts_relative_path_starting_with_dash(
+def test_marp_structure_check_accepts_relative_path_starting_with_dash(
     tmp_path: Path,
 ) -> None:
     deck = tmp_path / "--deck.md"
@@ -180,7 +180,7 @@ def test_marp_validator_accepts_relative_path_starting_with_dash(
             "bash",
             str(
                 SKILLS
-                / "slides-visuals/authoring-marp-slides/scripts/validate_marpit.sh"
+                / "slides-visuals/authoring-marp-slides/scripts/check_marpit_structure.sh"
             ),
             deck.name,
         ],
@@ -193,7 +193,7 @@ def test_marp_validator_accepts_relative_path_starting_with_dash(
     assert result.returncode == 0, result.stdout + result.stderr
 
 
-def test_marp_validator_accepts_crlf_and_yaml_comment(tmp_path: Path) -> None:
+def test_marp_structure_check_accepts_crlf_and_yaml_comment(tmp_path: Path) -> None:
     deck = tmp_path / "windows.md"
     deck.write_bytes(
         b"---\r\nmarp: TRUE  # enable Marp\r\ntheme: default\r\n---\r\n# Slide\r\n"
@@ -204,7 +204,7 @@ def test_marp_validator_accepts_crlf_and_yaml_comment(tmp_path: Path) -> None:
             "bash",
             str(
                 SKILLS
-                / "slides-visuals/authoring-marp-slides/scripts/validate_marpit.sh"
+                / "slides-visuals/authoring-marp-slides/scripts/check_marpit_structure.sh"
             ),
             str(deck),
         ],
@@ -215,6 +215,31 @@ def test_marp_validator_accepts_crlf_and_yaml_comment(tmp_path: Path) -> None:
 
     assert result.returncode == 0, result.stdout
     assert "Slides: 1" in result.stdout
+
+
+def test_marp_structure_check_does_not_claim_to_parse_malformed_yaml(
+    tmp_path: Path,
+) -> None:
+    deck = tmp_path / "malformed-yaml.md"
+    deck.write_text("---\nmarp: true\ntheme: [\n---\n# Slide\n")
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(
+                SKILLS
+                / "slides-visuals/authoring-marp-slides/scripts/check_marpit_structure.sh"
+            ),
+            str(deck),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Structural precheck passed" in result.stdout
+    assert "syntax valid" not in result.stdout
 
 
 def test_contrast_checker_reports_failed_large_text() -> None:
@@ -278,7 +303,23 @@ def test_generated_palette_contrast_is_calculated_from_colors() -> None:
     expected = checker.contrast_ratio(palette["Primary"], palette["Background"])
 
     assert "All combinations meet WCAG AAA" not in output
+    assert "Accessibility First" not in output
+    assert "Accessibility requirements" not in output
     assert f"Primary/Background = {expected:.2f}:1" in output
+
+    terminal_output = generator.format_palette_markdown(
+        generator.generate_preset_palette("terminal-dark"), "terminal-dark"
+    )
+    data_viz_output = generator.format_palette_markdown(
+        generator.generate_preset_palette("data-viz"), "data-viz"
+    )
+    assert "High contrast for projectors" not in terminal_output
+    assert "colorblind-friendly" not in data_viz_output
+
+    svg_output = generator.format_svg_palette("high-contrast")
+    assert "High Contrast Candidate" in svg_output
+    assert "Accessibility, large venue presentations" not in svg_output
+    assert "AAA compliance" not in svg_output
 
 
 def test_publish_examples_keep_tokens_out_of_argv() -> None:
@@ -296,10 +337,12 @@ def test_logging_context_has_a_default_for_unrelated_records() -> None:
     assert 'defaults={"user_id": "-"}' in logging_reference
 
 
-def test_plan_archival_is_scoped_to_the_current_plan() -> None:
+def test_plan_archival_is_scoped_to_saved_current_plan() -> None:
     plan_skill = (SKILLS / "writing-research/writing-plans/SKILL.md").read_text()
     assert "inspect `./docs/plans/*.md`" not in plan_skill
-    assert "current plan" in plan_skill
+    assert "current saved plan" in plan_skill
+    assert "Do not create an archive file for a chat-only plan" in plan_skill
+    assert "archive that plan under `docs/plans/archived/`" in plan_skill
 
 
 def test_generic_gourmet_ranking_is_not_hardcoded_to_okinawa() -> None:
@@ -330,11 +373,77 @@ def test_external_and_destructive_workflows_require_exact_authorization() -> Non
     assert "exact package/version, repository or index, and artifacts" in uv_skill
     assert "does not by itself authorize public replies" in pr_skill
     assert "push remote" in pr_skill and "reply text" in pr_skill
-    assert "approval for the exact target and content" in jira_skill
+    assert "authorization for the exact operation, target, and content" in jira_skill
+    assert "Supplying values for a draft does not authorize execution" in jira_skill
     assert "do not run interactive `jira init`" in jira_skill
     assert "approved candidate IDs" in atuin_skill
     assert "Do not invoke `cleanup-typos`" in atuin_skill
+    assert "before every mutation" in atuin_skill
+    assert "fixed cutoff" in atuin_skill
     assert "`atuin store push`" in atuin_skill and "`atuin sync`" in atuin_skill
+
+
+def test_peewee_fixture_survives_sequential_connection_contexts() -> None:
+    peewee = (SKILLS / "python/using-peewee-orm/SKILL.md").read_text()
+
+    assert "def test_db(tmp_path):" in peewee
+    assert 'tmp_path / "test.db"' in peewee
+    assert 'SqliteDatabase(":memory:"' not in peewee
+    assert "two sequential `connection_context()`" in peewee
+
+
+def test_svg_embedding_preserves_host_level_accessibility() -> None:
+    embedding = (
+        SKILLS / "slides-visuals/creating-svg-illustrations/references/embedding.md"
+    ).read_text()
+
+    assert "descriptive host-level alt text" in embedding
+    assert "adjacent semantic equivalent" in embedding
+    assert "![System architecture w:800]" in embedding
+    assert "![bg fit](assets/diagram.svg)" not in embedding
+
+
+def test_marp_examples_pair_visuals_with_nonredundant_semantics() -> None:
+    authoring = SKILLS / "slides-visuals/authoring-marp-slides"
+    example = (authoring / "assets/examples/with-bg-syntax.md").read_text()
+    template = (authoring / "assets/templates/with-bg-images.md").read_text()
+
+    for markdown in (example, template):
+        background_slides = [
+            slide for slide in markdown.split("\n---\n") if "![bg" in slide
+        ]
+        assert background_slides
+        for slide in background_slides:
+            assert "**Diagram summary:**" in slide or "**Comparison summary:**" in slide
+
+    assert 'alt="" aria-hidden="true"' in example
+
+
+def test_atuin_disabled_automation_is_aligned_across_surfaces() -> None:
+    atuin_dir = DEPRECATED / "cleaning-atuin-history"
+    skill = (atuin_dir / "SKILL.md").read_text()
+    reference = (atuin_dir / "references/atuin-cli.md").read_text()
+    metadata = (atuin_dir / "agents/openai.yaml").read_text()
+
+    for text in (skill, reference, metadata):
+        assert "cleanup-typos" in text
+        assert "disabled" in text
+    assert "remote operations" not in metadata
+
+
+def test_publication_and_research_boundaries_remain_explicit() -> None:
+    telegraph = (
+        SKILLS / "writing-research/creating-telegraph-pages/SKILL.md"
+    ).read_text()
+    gourmet = (
+        SKILLS / "writing-research/researching-gourmet-venues/SKILL.md"
+    ).read_text()
+
+    assert "explicit byline decision" in telegraph
+    assert "--author-name '' --author-url ''" in telegraph
+    assert "Require four independent source roles by default" in gourmet
+    assert "three sources only" in gourmet
+    assert "Do not score or publish a recommendation with fewer sources" in gourmet
 
 
 def test_slide_color_checks_never_claim_unperformed_validation() -> None:
@@ -368,8 +477,8 @@ def test_logging_and_peewee_examples_preserve_runtime_semantics() -> None:
     assert "db_proxy.obj" not in peewee
     assert "MODELS = [User]" in peewee
     assert "with db.connection_context():\n    with db.atomic():" in peewee
-    assert "try:\n                db.drop_tables" in peewee
-    assert "finally:\n                db.close()" in peewee
+    assert "finally:\n        with db.connection_context():" in peewee
+    assert "            db.drop_tables(MODELS, safe=True)" in peewee
 
 
 def test_relative_markdown_links_resolve() -> None:


### PR DESCRIPTION
## Summary

- resolve all nine findings from the review of PR #95
- fix Peewee connection lifecycle guidance and distinguish Marp structural checks from renderer evidence
- add host-level SVG accessibility guidance and remove unsupported palette validation claims
- require exact Jira authorization, disable unsafe Atuin automation, and make Telegraph byline decisions explicit
- restore the gourmet evidence minimum and limit plan archival to saved plans
- add focused regression coverage for each corrected boundary

## Relationship to PR #95

PR #95 was merged while this follow-up was being prepared. This PR targets `main` and contains only the review fixes.

## Verification

- skill validator: 32/32 passed
- `uv run --no-project --with pytest pytest`: 76 passed
- `prek run -a`: passed
- `git diff --check`: passed
- live Peewee two-context check: passed
- Marp structural-precheck and palette generator checks: passed
- independent nine-finding re-review: passed
