### PR TITLE
feat: add Google GenAI grounding skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Repository path: `skills/writing-research/`
 | `applying-imrad` | Evidence-traceable IMRaD fit checks, reviews, transformations, and drafts. |
 | `researching-gourmet-venues` | Auditable city dining research with scope-checked evidence and scores. |
 | `creating-telegraph-pages` | Preparing and publishing one explicitly authorized Telegra.ph article. |
+| `grounding-with-google-genai` | Grounded Google Search, Maps, and specific-URL research with Gemini. |
 
 ### Learning & Explanation
 

--- a/docs/plans/archived/2026-07-22_google-genai-grounding-skill-plan.md
+++ b/docs/plans/archived/2026-07-22_google-genai-grounding-skill-plan.md
@@ -1,0 +1,34 @@
+# Google GenAI Grounding Skill Plan
+
+## Goal
+
+Create a discoverable, executable skill for one-shot Google GenAI research with Google Search, Google Maps, and URL Context grounding, defaulting to `gemini-3.5-flash` and preserving citation evidence.
+
+## Assumptions
+
+- Place the skill under `skills/writing-research/` because all three workflows retrieve evidence for grounded answers.
+- Use the generally available Interactions API and a standalone PEP 723 script run with `uv run --script`.
+- Keep requests stateless with `store=false`; accept `GEMINI_API_KEY` only from the environment.
+
+## Plan
+
+- [x] Scaffold `grounding-with-google-genai` with the official initializer; verified the generated skill and metadata paths exist.
+- [x] Add focused failing pytest coverage for the default model, tool routing, Maps coordinates, URL validation, stateless requests, and normalized evidence output; captured 9 expected failures before implementation and one serializer regression failure during refinement.
+- [x] Implement the standalone CLI and concise skill instructions; focused tests pass and `uv run --script ... --help` executes successfully.
+- [x] Update `README.md` and repository inventory expectations; the full repository suite passes with 85 tests.
+- [x] Run live Search, Maps, and URL Context requests with the local `.env` key without exposing it; Search and Maps returned citations, and URL Context returned a successful retrieval plus citation after one source-specific retry.
+- [x] Run `quick_validate.py`, `prek run -a`, and a clean diff review; all checks pass.
+- [x] Forward-test realistic skill usage in a fresh agent thread; the agent selected URL Context, verified the retrieval, cited Python.org, and made no repository edits.
+
+## Risks
+
+- Grounded requests can incur API charges and may be unavailable by region or quota; keep live checks minimal and bounded to one call per mode.
+- Google Maps grounding currently supports English prompts and responses only; state that limitation in the skill.
+- SDK response step schemas can evolve; normalize through Pydantic serialization and retain tool-step metadata rather than depending on undocumented object internals.
+
+## Completion Checklist
+
+- [x] Skill frontmatter, UI metadata, README catalog, CLI defaults, and tests agree on scope and model.
+- [x] All three grounding modes are exercised without leaking the API key.
+- [x] Focused tests, full pytest, validator, and lint gate pass.
+- [x] Completed plan is archived under `docs/plans/archived/`.

--- a/skills/writing-research/grounding-with-google-genai/SKILL.md
+++ b/skills/writing-research/grounding-with-google-genai/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: grounding-with-google-genai
+description: Run one-shot Google Gemini research through the official Google GenAI Interactions API with Google Search, Google Maps, or URL Context grounding and inspect citation evidence. Use when Codex needs current web grounding, place or local recommendations, answers about specific public HTTP(S) URLs, or an explicit Gemini/Google GenAI grounded response.
+---
+
+# Grounding With Google GenAI
+
+Use the bundled `scripts/google_genai_grounding.py` by absolute path. Default to `gemini-3.5-flash`; pass `--model` only when the user requests another compatible model. The script sends stateless requests with `store=false` and emits JSON containing the answer, citations, bounded tool evidence, and usage.
+
+## Select Grounding
+
+- Use `search` for current or open-web facts that benefit from Google Search citations.
+- Use `maps` for places, local recommendations, addresses, reviews, or proximity. Supply both coordinates when the user's relevant location is known; omit both otherwise. Google Maps grounding currently requires English prompts and responses, so query in English and translate the cited answer afterward when needed.
+- Use `url` to read or compare one to 20 specific public `http://` or `https://` pages. Prefer direct content URLs. Do not use it for localhost, private networks, login-only or paywalled pages, Google Workspace files, YouTube, or audio/video URLs.
+
+## Run One Request
+
+Resolve `SKILL_DIR` to this skill directory and require `GEMINI_API_KEY` in the environment. Never print, log, place in arguments, or write the key to repository files.
+
+Run Google Search grounding:
+
+```shell
+uv run --script "$SKILL_DIR/scripts/google_genai_grounding.py" search \
+  'What changed in the current release? Cite primary sources.'
+```
+
+Run Google Maps grounding, adding coordinates only when relevant:
+
+```shell
+uv run --script "$SKILL_DIR/scripts/google_genai_grounding.py" maps \
+  'Find a well-reviewed coffee shop within a 15-minute walk.' \
+  --latitude 25.033 --longitude 121.5654
+```
+
+Run URL Context with one `--url` per source:
+
+```shell
+uv run --script "$SKILL_DIR/scripts/google_genai_grounding.py" url \
+  'Compare the documented behavior and identify material differences.' \
+  --url 'https://example.com/one' \
+  --url 'https://example.com/two'
+```
+
+A request to use this skill authorizes one bounded grounding call. Grounded calls can consume quota or incur charges; retry once only for a clear transient failure or a corrected deterministic input, and do not fan out into extra calls without need.
+
+## Verify and Answer
+
+Inspect `citations`, `tool_steps`, and `usage` before relying on `text`:
+
+- Require a matching call/result step and relevant `url_citation` or `place_citation` evidence for grounded claims.
+- For URL Context, require each needed URL retrieval to report `status: success`. Treat `error` or `unsafe` as failed retrieval even if the model produced plausible text.
+- If grounding was not used, a required source failed, or citations are absent, disclose that the answer was not verified; do not present model text as grounded evidence.
+- Preserve citation names and links in the final answer. Attribute Maps-derived claims to Google Maps and keep place links intact.
+- Report the selected model and any unavailable check when it matters. An empty `interaction_id` is expected for stateless requests.
+
+Stop after the grounded answer and its material caveats are complete. Do not broaden a specific URL request into general web research unless the user asks for both.

--- a/skills/writing-research/grounding-with-google-genai/SKILL.md
+++ b/skills/writing-research/grounding-with-google-genai/SKILL.md
@@ -15,7 +15,7 @@ Use the bundled `scripts/google_genai_grounding.py` by absolute path. Default to
 
 ## Run One Request
 
-Resolve `SKILL_DIR` to this skill directory and require `GEMINI_API_KEY` in the environment. Never print, log, place in arguments, or write the key to repository files.
+Resolve `SKILL_DIR` to this skill directory and require `GEMINI_API_KEY` in the process environment or a discoverable `.env` file. The script loads `.env` with `python-dotenv` without overriding an existing environment value. Never print, log, place in arguments, or write the key to repository files.
 
 Run Google Search grounding:
 

--- a/skills/writing-research/grounding-with-google-genai/agents/openai.yaml
+++ b/skills/writing-research/grounding-with-google-genai/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Google GenAI Grounding"
+  short_description: "Grounded research with Google GenAI tools"
+  default_prompt: "Use $grounding-with-google-genai to answer this request with Google Search, Google Maps, or URL Context grounding."

--- a/skills/writing-research/grounding-with-google-genai/scripts/google_genai_grounding.py
+++ b/skills/writing-research/grounding-with-google-genai/scripts/google_genai_grounding.py
@@ -2,6 +2,7 @@
 # requires-python = ">=3.11"
 # dependencies = [
 #   "google-genai>=2.3.0",
+#   "python-dotenv>=1.0.0",
 # ]
 # ///
 """Run one stateless Google GenAI grounding request and emit evidence as JSON."""
@@ -19,6 +20,14 @@ from urllib.parse import urlsplit
 
 DEFAULT_MODEL = "gemini-3.5-flash"
 MAX_URLS = 20
+
+
+def load_api_key() -> str | None:
+    """Load a local .env file without overriding the process environment."""
+    from dotenv import load_dotenv
+
+    load_dotenv(override=False)
+    return os.environ.get("GEMINI_API_KEY")
 
 
 def _validate_url(url: str) -> str:
@@ -222,7 +231,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     except ValueError as exc:
         parser.error(str(exc))
 
-    api_key = os.environ.get("GEMINI_API_KEY")
+    api_key = load_api_key()
     if not api_key:
         parser.error("GEMINI_API_KEY must be set in the environment")
 

--- a/skills/writing-research/grounding-with-google-genai/scripts/google_genai_grounding.py
+++ b/skills/writing-research/grounding-with-google-genai/scripts/google_genai_grounding.py
@@ -1,0 +1,249 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "google-genai>=2.3.0",
+# ]
+# ///
+"""Run one stateless Google GenAI grounding request and emit evidence as JSON."""
+
+from __future__ import annotations
+
+import argparse
+import ipaddress
+import json
+import os
+import sys
+from collections.abc import Sequence
+from typing import Any
+from urllib.parse import urlsplit
+
+DEFAULT_MODEL = "gemini-3.5-flash"
+MAX_URLS = 20
+
+
+def _validate_url(url: str) -> str:
+    parsed = urlsplit(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise ValueError(f"URL must be a complete http:// or https:// URL: {url}")
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError(f"URL must not contain credentials: {url}")
+
+    hostname = parsed.hostname.lower().rstrip(".")
+    if hostname == "localhost" or hostname.endswith(".localhost"):
+        raise ValueError(f"URL must be publicly accessible, not localhost: {url}")
+    try:
+        address = ipaddress.ip_address(hostname)
+    except ValueError:
+        return url
+    if not address.is_global:
+        raise ValueError(f"URL must not target a private or local address: {url}")
+    return url
+
+
+def build_interaction_request(
+    *,
+    mode: str,
+    prompt: str,
+    model: str = DEFAULT_MODEL,
+    urls: Sequence[str] | None = None,
+    latitude: float | None = None,
+    longitude: float | None = None,
+) -> dict[str, Any]:
+    """Build validated keyword arguments for ``client.interactions.create``."""
+    prompt = prompt.strip()
+    if not prompt:
+        raise ValueError("Prompt must be non-empty")
+    if not model.strip():
+        raise ValueError("Model must be non-empty")
+
+    if mode == "search":
+        tools = [{"type": "google_search"}]
+        input_text = prompt
+    elif mode == "maps":
+        if (latitude is None) != (longitude is None):
+            raise ValueError("Maps latitude and longitude must be provided together")
+        tool: dict[str, Any] = {"type": "google_maps"}
+        if latitude is not None and longitude is not None:
+            if not -90 <= latitude <= 90:
+                raise ValueError("Maps latitude must be between -90 and 90")
+            if not -180 <= longitude <= 180:
+                raise ValueError("Maps longitude must be between -180 and 180")
+            tool.update(latitude=latitude, longitude=longitude)
+        tools = [tool]
+        input_text = prompt
+    elif mode == "url":
+        supplied_urls = list(urls or ())
+        if not supplied_urls:
+            raise ValueError("URL Context requires at least one URL")
+        if len(supplied_urls) > MAX_URLS:
+            raise ValueError(f"URL Context accepts at most {MAX_URLS} URLs")
+        validated_urls = [_validate_url(url) for url in supplied_urls]
+        url_list = "\n".join(f"- {url}" for url in validated_urls)
+        input_text = f"{prompt}\n\nURLs to retrieve:\n{url_list}"
+        tools = [{"type": "url_context"}]
+    else:
+        raise ValueError(f"Unsupported grounding mode: {mode}")
+
+    return {
+        "model": model,
+        "input": input_text,
+        "tools": tools,
+        "store": False,
+    }
+
+
+def _summarize_tool_step(step: dict[str, Any]) -> dict[str, Any]:
+    summary: dict[str, Any] = {"type": step.get("type")}
+    for key in ("is_error", "search_type", "queries", "latitude", "longitude"):
+        if key in step:
+            summary[key] = step[key]
+
+    arguments = step.get("arguments")
+    if isinstance(arguments, dict):
+        kept_arguments = {
+            key: arguments[key]
+            for key in ("queries", "latitude", "longitude", "urls")
+            if key in arguments
+        }
+        if kept_arguments:
+            summary["arguments"] = kept_arguments
+
+    retrievals: list[dict[str, Any]] = []
+
+    def collect(value: Any) -> None:
+        if isinstance(value, dict):
+            retrieval = {
+                key: value[key]
+                for key in (
+                    "retrieved_url",
+                    "url",
+                    "status",
+                    "url_retrieval_status",
+                    "title",
+                    "name",
+                    "place_id",
+                )
+                if key in value and isinstance(value[key], (str, int, float, bool))
+            }
+            if retrieval and any(
+                key in retrieval
+                for key in ("retrieved_url", "url", "status", "url_retrieval_status")
+            ):
+                retrievals.append(retrieval)
+            for child in value.values():
+                collect(child)
+        elif isinstance(value, list):
+            for child in value:
+                collect(child)
+
+    collect(step.get("result"))
+    if retrievals:
+        summary["retrievals"] = retrievals
+    return summary
+
+
+def normalize_interaction(
+    interaction: Any,
+    *,
+    mode: str,
+    model: str,
+) -> dict[str, Any]:
+    """Return answer text, citations, tool evidence, and usage as JSON data."""
+    raw = interaction.model_dump(mode="json", exclude_none=True)
+    steps = raw.get("steps") or []
+    citations: list[dict[str, Any]] = []
+    tool_steps: list[dict[str, Any]] = []
+
+    for step in steps:
+        if not isinstance(step, dict):
+            continue
+        step_type = str(step.get("type", ""))
+        if step_type == "model_output":
+            for block in step.get("content") or []:
+                if not isinstance(block, dict) or block.get("type") != "text":
+                    continue
+                citations.extend(
+                    annotation
+                    for annotation in block.get("annotations") or []
+                    if isinstance(annotation, dict)
+                )
+        elif any(
+            marker in step_type
+            for marker in ("google_search", "google_maps", "url_context")
+        ):
+            tool_steps.append(_summarize_tool_step(step))
+
+    return {
+        "interaction_id": raw.get("id"),
+        "mode": mode,
+        "model": model,
+        "text": interaction.output_text or "",
+        "citations": citations,
+        "tool_steps": tool_steps,
+        "usage": raw.get("usage"),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Query Google GenAI with Search, Maps, or URL Context grounding."
+    )
+    subparsers = parser.add_subparsers(dest="mode", required=True)
+
+    search = subparsers.add_parser("search", help="Ground with Google Search")
+    search.add_argument("prompt")
+    search.add_argument("--model", default=DEFAULT_MODEL)
+
+    maps = subparsers.add_parser("maps", help="Ground with Google Maps")
+    maps.add_argument("prompt")
+    maps.add_argument("--latitude", type=float)
+    maps.add_argument("--longitude", type=float)
+    maps.add_argument("--model", default=DEFAULT_MODEL)
+
+    url = subparsers.add_parser("url", help="Ground with specific public URLs")
+    url.add_argument("prompt")
+    url.add_argument("--url", action="append", required=True, dest="urls")
+    url.add_argument("--model", default=DEFAULT_MODEL)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        request = build_interaction_request(
+            mode=args.mode,
+            prompt=args.prompt,
+            model=args.model,
+            urls=getattr(args, "urls", None),
+            latitude=getattr(args, "latitude", None),
+            longitude=getattr(args, "longitude", None),
+        )
+    except ValueError as exc:
+        parser.error(str(exc))
+
+    api_key = os.environ.get("GEMINI_API_KEY")
+    if not api_key:
+        parser.error("GEMINI_API_KEY must be set in the environment")
+
+    try:
+        from google import genai
+
+        with genai.Client(api_key=api_key) as client:
+            interaction = client.interactions.create(**request)
+    except Exception as exc:
+        message = str(exc).replace(api_key, "[REDACTED]")
+        print(f"Google GenAI request failed: {message}", file=sys.stderr)
+        return 1
+
+    result = normalize_interaction(
+        interaction,
+        mode=args.mode,
+        model=args.model,
+    )
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/writing-research/grounding-with-google-genai/scripts/test_google_genai_grounding.py
+++ b/skills/writing-research/grounding-with-google-genai/scripts/test_google_genai_grounding.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).with_name("google_genai_grounding.py")
+
+
+def load_script():
+    spec = importlib.util.spec_from_file_location("google_genai_grounding", SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeInteraction:
+    output_text = "Grounded answer."
+
+    def model_dump(self, **_kwargs):
+        return {
+            "id": "interaction-123",
+            "steps": [
+                {
+                    "type": "google_search_call",
+                    "queries": ["grounded test query"],
+                    "signature": "opaque-and-large",
+                },
+                {
+                    "type": "google_search_result",
+                    "is_error": False,
+                    "result": [{"search_suggestions": "large HTML payload"}],
+                },
+                {
+                    "type": "thought",
+                    "content": "not evidence",
+                },
+                {
+                    "type": "model_output",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Grounded answer.",
+                            "annotations": [
+                                {
+                                    "type": "url_citation",
+                                    "title": "Primary source",
+                                    "url": "https://example.com/source",
+                                    "start_index": 0,
+                                    "end_index": 16,
+                                }
+                            ],
+                        }
+                    ],
+                },
+            ],
+            "usage": {"total_tokens": 42},
+        }
+
+
+def test_search_request_uses_required_default_model_and_is_stateless():
+    grounding = load_script()
+
+    request = grounding.build_interaction_request(
+        mode="search",
+        prompt="What changed today?",
+    )
+
+    assert grounding.DEFAULT_MODEL == "gemini-3.5-flash"
+    assert request == {
+        "model": "gemini-3.5-flash",
+        "input": "What changed today?",
+        "tools": [{"type": "google_search"}],
+        "store": False,
+    }
+
+
+def test_maps_request_includes_location_only_when_both_coordinates_are_valid():
+    grounding = load_script()
+
+    request = grounding.build_interaction_request(
+        mode="maps",
+        prompt="Find a nearby coffee shop.",
+        latitude=25.033,
+        longitude=121.5654,
+    )
+
+    assert request["tools"] == [
+        {
+            "type": "google_maps",
+            "latitude": 25.033,
+            "longitude": 121.5654,
+        }
+    ]
+
+    with pytest.raises(ValueError, match="together"):
+        grounding.build_interaction_request(
+            mode="maps",
+            prompt="Find a nearby coffee shop.",
+            latitude=25.033,
+        )
+    with pytest.raises(ValueError, match="latitude"):
+        grounding.build_interaction_request(
+            mode="maps",
+            prompt="Find a nearby coffee shop.",
+            latitude=91,
+            longitude=121.5654,
+        )
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "ftp://example.com/report",
+        "https://localhost/report",
+        "http://127.0.0.1/report",
+        "https://user:secret@example.com/report",
+        "https:///missing-host",
+    ],
+)
+def test_url_context_rejects_unsupported_or_nonpublic_urls(url):
+    grounding = load_script()
+
+    with pytest.raises(ValueError, match="URL"):
+        grounding.build_interaction_request(
+            mode="url",
+            prompt="Summarize this source.",
+            urls=[url],
+        )
+
+
+def test_url_context_adds_validated_urls_to_the_prompt_and_caps_count():
+    grounding = load_script()
+    urls = ["https://example.com/one", "http://example.org/two"]
+
+    request = grounding.build_interaction_request(
+        mode="url",
+        prompt="Compare the sources.",
+        urls=urls,
+    )
+
+    assert request["tools"] == [{"type": "url_context"}]
+    assert request["input"] == (
+        "Compare the sources.\n\nURLs to retrieve:\n"
+        "- https://example.com/one\n"
+        "- http://example.org/two"
+    )
+    with pytest.raises(ValueError, match="20 URLs"):
+        grounding.build_interaction_request(
+            mode="url",
+            prompt="Compare all sources.",
+            urls=[f"https://example.com/{index}" for index in range(21)],
+        )
+
+
+def test_normalized_output_preserves_citations_and_tool_evidence_only():
+    grounding = load_script()
+
+    result = grounding.normalize_interaction(
+        FakeInteraction(),
+        mode="search",
+        model="gemini-3.5-flash",
+    )
+
+    assert result == {
+        "interaction_id": "interaction-123",
+        "mode": "search",
+        "model": "gemini-3.5-flash",
+        "text": "Grounded answer.",
+        "citations": [
+            {
+                "type": "url_citation",
+                "title": "Primary source",
+                "url": "https://example.com/source",
+                "start_index": 0,
+                "end_index": 16,
+            }
+        ],
+        "tool_steps": [
+            {
+                "type": "google_search_call",
+                "queries": ["grounded test query"],
+            },
+            {
+                "type": "google_search_result",
+                "is_error": False,
+            },
+        ],
+        "usage": {"total_tokens": 42},
+    }

--- a/skills/writing-research/grounding-with-google-genai/scripts/test_google_genai_grounding.py
+++ b/skills/writing-research/grounding-with-google-genai/scripts/test_google_genai_grounding.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import importlib.util
+import sys
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
@@ -59,6 +61,23 @@ class FakeInteraction:
             ],
             "usage": {"total_tokens": 42},
         }
+
+
+def test_load_api_key_loads_dotenv_before_reading_environment(monkeypatch):
+    grounding = load_script()
+    dotenv = ModuleType("dotenv")
+    calls = []
+
+    def load_dotenv(*, override):
+        calls.append(override)
+        monkeypatch.setenv("GEMINI_API_KEY", "loaded-from-dotenv")
+
+    dotenv.load_dotenv = load_dotenv
+    monkeypatch.setitem(sys.modules, "dotenv", dotenv)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+
+    assert grounding.load_api_key() == "loaded-from-dotenv"
+    assert calls == [False]
 
 
 def test_search_request_uses_required_default_model_and_is_stateless():

--- a/tests/test_skill_repository.py
+++ b/tests/test_skill_repository.py
@@ -38,7 +38,7 @@ def test_deprecated_skills_are_hidden_from_standard_discovery() -> None:
 
 def test_every_skill_name_metadata_and_catalog_inventory_is_complete() -> None:
     skill_markdown = all_skill_markdown()
-    assert len(skill_markdown) == 32
+    assert len(skill_markdown) == 33
     readme = (ROOT / "README.md").read_text()
 
     for skill_md in skill_markdown:


### PR DESCRIPTION
## Summary

- add the `grounding-with-google-genai` Writing & Research skill with aligned UI metadata and catalog discovery
- bundle a PEP 723 `google-genai` CLI for stateless Google Search, Google Maps, and URL Context grounding, defaulting to `gemini-3.5-flash`
- preserve citations and bounded tool evidence, validate Maps coordinates and public URLs, and keep `GEMINI_API_KEY` out of arguments and output
- add focused pytest coverage and archive the completed implementation plan

## Why

Agents need a repeatable, evidence-aware way to use Google GenAI grounding without rewriting SDK integration code or trusting plausible model text when retrieval failed. The skill makes tool selection, credential boundaries, source verification, and stopping conditions explicit.

## Affected paths

- `skills/writing-research/grounding-with-google-genai/`
- `README.md`
- `tests/test_skill_repository.py`
- `docs/plans/archived/2026-07-22_google-genai-grounding-skill-plan.md`

## Verification

- `env UV_CACHE_DIR=/tmp/uv-cache uv run --no-project --with pytest pytest` — 85 passed
- `env UV_CACHE_DIR=/tmp/uv-cache uv run --no-project --python 3.13 --with pyyaml python /home/narumi/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/writing-research/grounding-with-google-genai` — Skill is valid
- `env UV_CACHE_DIR=/tmp/uv-cache prek run -a` — passed
- `env UV_CACHE_DIR=/tmp/uv-cache uv run --script skills/writing-research/grounding-with-google-genai/scripts/google_genai_grounding.py --help` — passed
- live Search, Maps, and URL Context calls with `gemini-3.5-flash` returned grounded citations; the API key was not printed or written
- isolated forward test selected URL Context, verified retrieval success, cited Python.org, and made no repository edits

No checks were skipped or left failing.
