### PR TITLE
refactor(skills): merge naming workflow

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -14,5 +14,6 @@
 ## TASTE
 - Prefer applying Apple-derived design philosophy across platforms while translating platform-specific metrics and controls to target conventions; minimize cognitive load without sacrificing functional completeness, keep critical actions and state visible, and use predictable progressive disclosure for secondary complexity.
 - Prefer preserving a skill's original user intent when naming or renaming skills; do not force `<verb-ing>-<object>` if it changes the meaning.
+- Prefer retaining explicit-invocation skills that act as useful mode shortcuts even when the model can infer the behavior; specifically keep `explaining-step-by-step` for requesting progressive explanations.
 - `writing-git-commits` should rely on the repo-level `AGENTS.md` for the Git baseline; `SKILL.md` should keep only the flow and judgment from diff to commit message, while less common Conventional Commits details belong in `references/`.
 - `maintaining-memory-md` should check at conversation start without creating `MEMORY.md` merely because it is missing; when the first qualifying `GOTCHA` or durable `TASTE` emerges, it should create the repository-root file without extra confirmation and revise stale or similar entries in place.

--- a/README.md
+++ b/README.md
@@ -92,11 +92,10 @@ Repository path: `skills/workflow-repository/`
 
 | Skill | Use it for |
 | --- | --- |
-| `creating-agent-skills` | Creating, optimizing, and reviewing lean, discoverable agent skills. |
+| `creating-agent-skills` | Creating, naming, renaming, optimizing, and reviewing lean, discoverable agent skills. |
 | `reviewing-code` | Evidence-led read-only review with conditional authorized hardening handoff. |
 | `resolving-pr-review-comments` | Explicit PR feedback assessment and local fixes, with exact approval for public actions. |
 | `hardening-code-paths` | Confirming, fixing, and verifying plausible code-path failure modes. |
-| `naming-agent-skills` | Choosing, reviewing, standardizing, or safely applying skill names. |
 | `using-jira-cli` | Read-only Jira inspection and precisely authorized CLI mutations. |
 | `applying-tdd` | Practical red-green-refactor for non-trivial behavior changes. |
 | `writing-git-commits` | Drafting, validating, or creating focused Conventional Commits from diffs. |
@@ -115,3 +114,4 @@ Deprecated skills remain in `deprecated/<skill-name>/` for reference and are exc
 | `cleaning-atuin-history` | Legacy Atuin audit and exact-approval cleanup preparation. |
 | `building-codex-hooks` | Version-sensitive legacy Codex CLI hook reference. |
 | `writing-work-logs` | Legacy explicit-only Git-evidence work logs. |
+| `naming-agent-skills` | Merged into `creating-agent-skills`; retained as a compatibility reference. |

--- a/deprecated/naming-agent-skills/SKILL.md
+++ b/deprecated/naming-agent-skills/SKILL.md
@@ -1,9 +1,13 @@
 ---
 name: naming-agent-skills
-description: Choose, review, rename, or standardize agent skill names for predictable triggering, searchability, and low overlap. Use for naming a new skill, evaluating an existing name, normalizing a skill library, or performing an authorized repository rename.
+description: Deprecated compatibility reference for choosing, reviewing, renaming, or standardizing agent skill names. Use the active creating-agent-skills workflow for current naming and authorized repository rename work.
+metadata:
+  internal: true
 ---
 
-# Naming Agent Skills
+# Naming Agent Skills (Deprecated Reference)
+
+Use `creating-agent-skills` for the maintained workflow. This reference preserves the former `$naming-agent-skills` behavior for explicit local use.
 
 Name the task and trigger the skill represents, not its implementation.
 

--- a/deprecated/naming-agent-skills/agents/openai.yaml
+++ b/deprecated/naming-agent-skills/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Naming Agent Skills (Deprecated)"
+  short_description: "Use the merged skill-naming reference."
+  default_prompt: "Use $naming-agent-skills as a deprecated compatibility reference; prefer $creating-agent-skills for current naming, review, and authorized rename work."

--- a/docs/plans/archived/2026-07-23_merge-naming-agent-skills-plan.md
+++ b/docs/plans/archived/2026-07-23_merge-naming-agent-skills-plan.md
@@ -1,0 +1,24 @@
+## Goal
+
+Merge the naming and rename-selection behavior from `naming-agent-skills` into `creating-agent-skills`, retire the standalone skill from active discovery, and preserve it as a deprecated compatibility reference on a dedicated branch.
+
+## Plan
+
+- [x] Create and verify branch `refactor/merge-naming-agent-skills`; verified by `git switch -c` and `git status --short --branch` showing that branch with a clean starting worktree.
+- [x] Add focused repository regression assertions for the merged naming trigger, naming/rename constraints, active/deprecated inventories, and catalog placement; verified the three focused tests failed against the pre-merge layout because the active/deprecated counts and naming directory had not changed.
+- [x] Expand `creating-agent-skills` and its OpenAI metadata with the standalone skill's discriminating naming, candidate-selection, collision, user-intent, and authorized-rename behavior; verified by the focused merged-skill and metadata assertions.
+- [x] Move `naming-agent-skills` to `deprecated/` as an internal compatibility reference and align the README active/deprecated catalog entries and durable repository memory; verified 28 active, 5 deprecated, and 33 total skills, with exact-name references limited to the deprecated catalog, regression test, replacement UI label, and historical archived plan.
+- [x] Run all repository validation gates, inspect the final diff and branch state, and archive this completed plan with command evidence; verified 33/33 skill directories passed `quick_validate.py`, 87/87 tests passed, every `prek run -a` hook passed after its one formatting fix, `git diff --check` passed, `just` listed non-mutating recipes, and final review's only minor test-coverage finding was addressed.
+
+## Risks
+
+- Naming guidance could be shortened enough to lose the user's preference for preserving original intent; retain that rule explicitly and add a regression assertion.
+- A directory move without aligned metadata/catalog changes could keep the old skill discoverable or break inventory tests; assert both active absence and deprecated internal metadata.
+- Historical archived plans legitimately mention the old active skill; leave those records unchanged rather than rewriting past evidence.
+
+## Completion Checklist
+
+- [x] `creating-agent-skills` handles creating, naming, reviewing, and authorized renaming with aligned frontmatter, UI metadata, and README wording; verified by focused regression assertions and manual surface review.
+- [x] `naming-agent-skills` is absent from active discovery and retained under `deprecated/` with `metadata.internal: true` and deprecated UI labeling; verified by inventory tests and 28-active/5-deprecated counts.
+- [x] The user's durable shortcut preference is recorded without changing the decision to keep `explaining-step-by-step` active; verified in `MEMORY.md` and the unchanged active skill inventory.
+- [x] The full pytest suite, `prek run -a`, skill metadata validation, and `git diff --check` pass on `refactor/merge-naming-agent-skills`; verified by 87 passing tests, all hooks passing, 33 valid skill directories, and a clean diff check.

--- a/skills/workflow-repository/creating-agent-skills/SKILL.md
+++ b/skills/workflow-repository/creating-agent-skills/SKILL.md
@@ -1,16 +1,30 @@
 ---
 name: creating-agent-skills
-description: Create, revise, or review agent skills for reliable triggering, lean instructions, justified resources, aligned UI metadata, repository discovery, and validation. Use for new skills, skill scaffolding, workflow-to-skill conversion, prompt optimization, or skill audits.
+description: Create, name, rename, revise, or review agent skills for reliable triggering, lean instructions, justified resources, aligned UI metadata, repository discovery, and validation. Use for new skills, naming decisions, authorized repository renames, skill scaffolding, workflow-to-skill conversion, prompt optimization, or skill audits.
 ---
 
 # Creating Agent Skills
 
 Create a skill another agent can select and apply without unnecessary context.
 
+## Name and Rename
+
+Name the task and trigger the skill represents, not its implementation.
+
+- Read the skill's actual description and workflow, then identify the triggering action, object or domain, and any necessary product qualifier.
+- Use lowercase kebab-case with meaningful digits and single hyphens; use no leading or trailing hyphen. Keep the directory and frontmatter `name` identical and respect the target framework's length limit.
+- Prefer two to four specific words. Avoid vague terms such as `helper`, `utils`, `tools`, `assistant`, `magic`, `smart`, or `general`, and avoid product or organization names unless the trigger is genuinely product-specific.
+- Preserve the original user intent rather than forcing `<verb-ing>-<object>` when another pattern better expresses the meaning or matches the repository's established convention.
+- Inspect sibling names and exact-name references. Compare a small candidate set for specificity, searchability, future stability, and collision risk, then lead with one recommendation and its deciding reason.
+
+A naming recommendation does not authorize a repository rename. Do not edit files when the user asked only for names or review. For an authorized rename, update the directory, frontmatter `name`, UI metadata and default prompt, catalog, links, examples, tests, and other exact-name references as one bounded change; preserve a compatibility note when external consumers depend on the old name.
+
+For naming-only output, lead with the recommendation and deciding reason. For multiple skills, use a current/recommended/reason table and include only conflicts or compatibility work that affects adoption.
+
 ## Workflow
 
 1. Inspect the target repository's instructions, skill root, sibling skills, catalog, validators, and any model-specific prompting guide. Infer the destination and ask one question only when purpose, trigger, or location is materially ambiguous.
-2. Choose a concise lowercase kebab-case name that preserves the skill's actual intent. Keep directory and frontmatter `name` identical.
+2. Choose or review the name with the naming criteria above.
 3. Keep only justified contents:
    - `SKILL.md` for trigger metadata and post-trigger workflow.
    - `agents/openai.yaml` when the target ecosystem uses UI metadata.
@@ -31,7 +45,7 @@ Create a skill another agent can select and apply without unnecessary context.
 
 ## Completion Criteria
 
-- One clear purpose and discriminating trigger.
+- One clear purpose, discriminating trigger, and specific collision-resistant name that preserves the intended meaning.
 - Body content is useful only after the skill has triggered.
 - No repeated instruction groups, generic background, decorative examples, or unjustified resources.
 - Local edits and checks proceed when requested; external, destructive, costly, or scope-expanding actions retain explicit approval boundaries.

--- a/skills/workflow-repository/creating-agent-skills/agents/openai.yaml
+++ b/skills/workflow-repository/creating-agent-skills/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Creating Agent Skills"
-  short_description: "Create, revise, and review lean agent skills."
-  default_prompt: "Use $creating-agent-skills to create, optimize, or review this skill for reliable triggering, lean instructions, aligned metadata, and validation."
+  display_name: "Creating and Naming Agent Skills"
+  short_description: "Create, name, rename, and review lean agent skills."
+  default_prompt: "Use $creating-agent-skills to create, name, rename, optimize, or review this skill for reliable triggering, low naming overlap, lean instructions, aligned metadata, and validation."

--- a/skills/workflow-repository/naming-agent-skills/agents/openai.yaml
+++ b/skills/workflow-repository/naming-agent-skills/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Naming Agent Skills"
-  short_description: "Choose, review, and safely apply skill names."
-  default_prompt: "Use $naming-agent-skills to choose, review, standardize, or apply skill names that match actual triggers and avoid repository collisions."

--- a/tests/test_skill_repository.py
+++ b/tests/test_skill_repository.py
@@ -30,7 +30,7 @@ def load_module(path: Path, name: str) -> ModuleType:
 
 def test_deprecated_skills_are_hidden_from_standard_discovery() -> None:
     deprecated = sorted(DEPRECATED.glob("*/SKILL.md"))
-    assert len(deprecated) == 4
+    assert len(deprecated) == 5
     for skill_md in deprecated:
         frontmatter = skill_md.read_text().split("---", 2)[1]
         assert "\nmetadata:\n  internal: true\n" in f"\n{frontmatter}\n", skill_md
@@ -53,6 +53,60 @@ def test_every_skill_name_metadata_and_catalog_inventory_is_complete() -> None:
         metadata = metadata_path.read_text()
         assert f"${name}" in metadata, metadata_path
         assert f"| `{name}` |" in readme, skill_md
+
+
+def test_naming_agent_skills_is_merged_into_creating_agent_skills() -> None:
+    creating_dir = SKILLS / "workflow-repository/creating-agent-skills"
+    active_naming_dir = SKILLS / "workflow-repository/naming-agent-skills"
+    deprecated_naming_dir = DEPRECATED / "naming-agent-skills"
+
+    assert not active_naming_dir.exists()
+    assert deprecated_naming_dir.is_dir()
+
+    creating = (creating_dir / "SKILL.md").read_text()
+    metadata = (creating_dir / "agents/openai.yaml").read_text()
+    deprecated = (deprecated_naming_dir / "SKILL.md").read_text()
+    readme = (ROOT / "README.md").read_text()
+    active_catalog, deprecated_catalog = readme.split("## 🗄️ Deprecated Skills", 1)
+    rename_boundary = creating.split("A naming recommendation", 1)[1].split(
+        "For naming-only output", 1
+    )[0]
+    metadata_fields = {
+        line.split(":", 1)[0].strip(): json.loads(line.split(":", 1)[1].strip())
+        for line in metadata.splitlines()
+        if line.strip().startswith(
+            ("display_name:", "short_description:", "default_prompt:")
+        )
+    }
+
+    assert "Create, name, rename, revise, or review agent skills" in creating
+    assert "Name the task and trigger the skill represents" in creating
+    assert "lowercase kebab-case" in creating
+    assert "original user intent" in creating
+    assert "Compare a small candidate set" in creating
+    assert "collision risk" in creating
+    assert "recommendation does not authorize a repository rename" in creating
+    assert "Do not edit files when the user asked only for names or review" in creating
+    for rename_surface in (
+        "directory",
+        "frontmatter `name`",
+        "UI metadata and default prompt",
+        "catalog",
+        "links",
+        "examples",
+        "tests",
+        "other exact-name references",
+        "compatibility note",
+    ):
+        assert rename_surface in rename_boundary
+    assert "Naming" in metadata_fields["display_name"]
+    assert "name, rename" in metadata_fields["short_description"]
+    assert "$creating-agent-skills" in metadata_fields["default_prompt"]
+    assert "name, rename" in metadata_fields["default_prompt"]
+    assert "metadata:\n  internal: true" in deprecated
+    assert "Creating, naming, renaming, optimizing, and reviewing" in active_catalog
+    assert "| `naming-agent-skills` |" not in active_catalog
+    assert "| `naming-agent-skills` |" in deprecated_catalog
 
 
 def test_material_trigger_surfaces_are_semantically_aligned() -> None:
@@ -95,6 +149,7 @@ def test_skill_bodies_avoid_repeating_trigger_and_generic_cleanup_sections() -> 
 def test_active_skills_are_grouped_one_category_deep() -> None:
     categorized = sorted(SKILLS.glob("*/*/SKILL.md"))
     assert categorized == sorted(SKILLS.glob("**/SKILL.md"))
+    assert len(categorized) == 28
     assert len({skill_md.parent.name for skill_md in categorized}) == len(categorized)
 
 


### PR DESCRIPTION
## Summary

- Merge naming, collision avoidance, and authorized rename guidance into `creating-agent-skills`.
- Move `naming-agent-skills` to `deprecated/` as an internal compatibility reference and align metadata and catalog entries.
- Add regression coverage and record the preference for explicit skill shortcuts.

## Affected paths

- `skills/workflow-repository/creating-agent-skills/`
- `deprecated/naming-agent-skills/`
- `README.md`
- `MEMORY.md`
- `tests/test_skill_repository.py`
- `docs/plans/archived/2026-07-23_merge-naming-agent-skills-plan.md`

## Verification

- All 33 skill directories passed `quick_validate.py`.
- `uv run --no-project --with pytest pytest` — 87 passed.
- `prek run -a` — passed.
- `git diff --check` — passed.