### PR TITLE
feat(skills): strengthen Typer CLI guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Repository path: `skills/python/`
 | Skill | Use it for |
 | --- | --- |
 | `managing-python-with-uv` | uv projects, scripts, dependencies, checks, builds, and authorized publishing. |
-| `building-typer-clis` | Building, wiring, extending, and testing thin Typer CLIs. |
+| `building-typer-clis` | Typer command grammar, typed parameters, callbacks, packaging, completion, and current tests. |
 | `configuring-python-logging` | Python logging backend, boundary, sink, context, and exception choices. |
 | `using-peewee-orm` | Peewee binding, connection, transaction, and isolated test lifecycles. |
 

--- a/docs/plans/archived/2026-07-23_strengthen-typer-skill-plan.md
+++ b/docs/plans/archived/2026-07-23_strengthen-typer-skill-plan.md
@@ -1,0 +1,31 @@
+## Goal
+
+Strengthen `building-typer-clis` with current, official Typer guidance that protects command grammar, modern parameter declarations, callbacks and completion, runtime exits, testing behavior, and installed entry points without bloating the core skill.
+
+## Context
+
+- The existing trigger is useful, but the body mainly provides a basic greeting example and generic CLI advice.
+- Official Typer documentation and release notes currently show Typer 0.27.0, recommend `Annotated`, require explicit `add_typer(..., name=...)` group names, dropped `typer-slim`/`typer-cli`, vendored Click in 0.26.0, and changed current testing compatibility surfaces.
+- The official Typer repository also ships an agent skill whose current rules corroborate the installation, `Annotated`, explicit app, and vendored-Click guidance.
+
+## Plan
+
+- [x] Create branch `feat/strengthen-typer-skill` from clean, fast-forwarded `main`; verified at `f22e9e8` after PR #99 merged.
+- [x] Research the official Typer tutorial, API reference, release notes, and official agent skill; verified current command-shape, parameter, callback/completion, packaging, testing, and compatibility behavior against `https://typer.tiangolo.com/` and `fastapi/typer`.
+- [x] Add focused regression expectations for the strengthened trigger, lean routing workflow, command-grammar and modern-API safeguards, justified references, and aligned metadata/catalog; verified the focused test failed because the current basic skill had no Typer reference set.
+- [x] Rewrite the core skill around Typer-specific decisions and add focused architecture, parameter/runtime, testing, and packaging/completion references with official source links; verified command shape, `Annotated`, `BadParameter`, current `CliRunner`, `[project.scripts]`, installed execution, help, and wheel build against Typer 0.27.0.
+- [x] Run all repository validation gates, inspect the final diff and branch state, obtain independent review, and archive this completed plan with evidence; verified the changed skill passed `quick_validate.py`, 89/89 tests passed, all `prek run -a` hooks passed, `git diff --check` passed, and final independent re-review found no issue after its three correctness findings were fixed.
+
+## Risks
+
+- Typer evolves quickly; keep version-sensitive details in references, require inspection of the declared version, and link release notes rather than hard-coding latest behavior as universally compatible.
+- Adding commands or callbacks can silently change `PROGRAM ...` into `PROGRAM COMMAND ...`; make public invocation grammar an explicit invariant and regression assertion.
+- Typer 0.26 vendored Click and simplified `CliRunner`; avoid stale Click extension, `mix_stderr`, and filesystem-runner guidance.
+- More documentation can recreate the prompt bloat this repository removed; keep only routing and invariants in `SKILL.md` and load detailed references on demand.
+
+## Completion Checklist
+
+- [x] `building-typer-clis` provides substantial Typer-specific value beyond a basic framework example while remaining lean and trigger-aligned; verified a 37-line routed core replaces the generic minimal pattern and aligns frontmatter, metadata, and README.
+- [x] References cover application shape, typed parameters/runtime, current testing, and packaging/completion with official source URLs and no obsolete package/API advice; verified by focused assertions, link checks, and independent review.
+- [x] Representative current-Typer examples and regression assertions prove the highest-risk guidance; verified live against Typer 0.27.0 for command promotion, `add_typer`, callbacks, `Annotated`, `default_factory`, `BadParameter`, no-command modes, current `CliRunner`, installed scripts, help, and wheel builds.
+- [x] Skill validation, full pytest, `prek run -a`, and `git diff --check` pass on `feat/strengthen-typer-skill`; verified one valid changed skill, 89 passing tests, all hooks passing, and a clean diff check.

--- a/skills/python/building-typer-clis/SKILL.md
+++ b/skills/python/building-typer-clis/SKILL.md
@@ -1,52 +1,37 @@
 ---
 name: building-typer-clis
-description: Build, extend, wire, or test Python CLIs with Typer, including commands, arguments, options, prompts, entry points, and multi-command apps. Use when Typer is the chosen framework or an existing Typer CLI needs changes.
+description: Build, extend, package, migrate, or test Python CLIs with Typer, including command grammar, typed arguments and options, callbacks and context, command groups, prompts, completion, entry points, and current CliRunner behavior. Use when Typer is chosen or an existing Typer CLI needs changes.
 ---
 
-# Python CLI with Typer
+# Building Typer CLIs
 
-Keep Typer commands as thin adapters between parsed terminal input and ordinary Python functions.
+Preserve the public invocation grammar while keeping Typer commands as thin adapters between typed terminal input and ordinary Python functions.
+
+## Load Focused Guidance
+
+| Need | Read |
+| --- | --- |
+| Single versus multiple commands, callbacks, context, groups, or help | `references/application-architecture.md` |
+| `typing.Annotated`, defaults, parameter types, prompts, validation, exits, or value completion | `references/parameters-and-runtime.md` |
+| `CliRunner`, input, streams, files, errors, help, or entry-point tests | `references/testing.md` |
+| Dependency choice, installed commands, `python -m`, wheels, shell completion, or Typer migration | `references/packaging-and-completion.md` |
 
 ## Workflow
 
-1. Inspect `pyproject.toml`, the existing entry point, command conventions, and tests before changing the CLI.
-2. Add Typer with `uv add typer` only when the project does not already provide it.
-3. Define one `typer.Typer()` app and model input with typed arguments and options. Use Typer prompts or confirmations instead of custom shell parsing.
-4. Validate CLI-specific input at the boundary, call business logic, render the result, and map expected failures to deliberate messages and exit codes.
-5. Wire the supported entry point:
-   - `if __name__ == "__main__": app()` for direct script or module execution.
-   - A `[project.scripts]` entry for an installed command.
-6. Run `--help` and representative success and failure paths through the repository's uv workflow.
-7. Test parsing, output, and exit behavior with `typer.testing.CliRunner`; test business logic directly with normal unit tests.
+1. Inspect `pyproject.toml`, the declared Typer version and Python range, existing invocation examples, entry points, app/callback structure, tests, and repository commands. Do not silently upgrade Typer or redesign the CLI.
+2. Preserve command shape deliberately. Typer promotes one registered command to the root grammar, `PROGRAM [ARGS]...`; adding a second command, registering a sub-app with `app.add_typer(...)`, or adding an application callback changes it to `PROGRAM COMMAND [ARGS]...`. Treat that transition, command renames, option renames, and moved root options as public-interface changes.
+3. Use one explicit root `typer.Typer()` app. Compose domain groups with explicit `app.add_typer(sub_app, name="...")` names and use an application callback only for genuine root options, initialization, documentation, or a deliberate default action.
+4. Prefer `typing.Annotated` with `typer.Argument()` and `typer.Option()`. Put static defaults in Python assignments, use `default_factory=` for dynamic defaults, and let Typer perform supported type conversion and boundary validation.
+5. Keep command bodies thin. Use `typer.BadParameter` for parameter-specific validation, `typer.Exit` for deliberate termination and exit status, and `typer.Abort` for an aborted interaction. Translate domain failures at the CLI boundary without exposing tracebacks by default.
+6. Keep parameter callbacks and autocompletion fast, side-effect-free, and silent on stdout. When callback work must be skipped during completion, check `ctx.resilient_parsing` before validation or output.
+7. Wire only the invocation modes the project supports: a guarded `app()` for direct scripts, `[project.scripts]` for installed commands, and package `__main__.py` for `python -m package`. Exercise the actual installed command when packaging or shell completion is in scope.
+8. Test the current public grammar, typed parsing, success, validation failure, deliberate exits, prompts, stable help fragments, and any filesystem or environment boundary with `typer.testing.CliRunner`; test business logic directly.
 
-## Minimal Pattern
+## Constraints
 
-```python
-import typer
+- Add plain `typer` through the repository's uv workflow only when missing; do not introduce obsolete Typer packages or extras.
+- Preserve non-interactive use when adding prompts. Keep secrets out of argv where practical, and distinguish value re-entry from affirmative consent for a destructive action.
+- Mock or inject external, destructive, costly, or nondeterministic effects in CLI tests.
+- Inspect release notes before relying on Click integration, exact Rich help rendering, runner internals, or another version-sensitive surface.
 
-app = typer.Typer()
-
-
-@app.command()
-def greet(name: str, count: int = 1) -> None:
-    for _ in range(count):
-        typer.echo(f"Hello, {name}!")
-
-
-if __name__ == "__main__":
-    app()
-```
-
-```python
-from typer.testing import CliRunner
-
-from my_package.cli import app
-
-
-def test_greet() -> None:
-    result = CliRunner().invoke(app, ["Ada", "--count", "2"])
-    assert result.exit_code == 0
-    assert result.stdout.count("Hello, Ada!") == 2
-```
-
-Mock or inject external, destructive, or costly effects in CLI tests; do not exercise them merely to verify command wiring. Finish with the entry point exercised, CLI behavior covered, and the exact validation results reported.
+Finish with the supported invocation forms exercised, behavior and exit codes covered, packaging checked when applicable, and exact validation evidence reported.

--- a/skills/python/building-typer-clis/agents/openai.yaml
+++ b/skills/python/building-typer-clis/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Python CLI with Typer"
-  short_description: "Build and test thin, well-wired Typer CLIs."
-  default_prompt: "Use $building-typer-clis to build or revise this Typer CLI with thin command adapters, correct entry points, and focused CLI tests."
+  display_name: "Building Typer CLIs"
+  short_description: "Build current Typer CLIs without grammar regressions."
+  default_prompt: "Use $building-typer-clis to preserve command grammar while building this Typer CLI with Annotated parameters, deliberate callbacks and exits, supported entry points, and current CliRunner tests."

--- a/skills/python/building-typer-clis/references/application-architecture.md
+++ b/skills/python/building-typer-clis/references/application-architecture.md
@@ -1,0 +1,90 @@
+# Typer Application Architecture
+
+Load this reference when commands, callbacks, context, nested groups, or help behavior could change the public CLI grammar.
+
+## Preserve Command Shape
+
+An explicit `typer.Typer()` app is extensible and directly testable. Prefer it to `typer.run()` for production CLIs.
+
+Typer treats these shapes differently:
+
+- With exactly one registered `@app.command()`, that function is promoted to the root: `PROGRAM [ARGS]...`. Its Python function name is not a subcommand.
+- With multiple registered commands, the grammar becomes `PROGRAM COMMAND [ARGS]...`.
+- Registering any sub-app also creates grouped grammar, even if the root previously had one promoted command.
+- Adding an application callback also makes the registered command explicit, even when only one command exists.
+
+Adding a second command, registering a sub-app, or adding a callback can therefore break scripts that previously called `PROGRAM VALUE`. Before changing shape, inventory documentation, shell scripts, CI, completion, and tests. Either preserve compatibility or report the migration explicitly.
+
+Use explicit apps even for one command when extension or installed entry points are likely:
+
+```python
+import typer
+
+app = typer.Typer()
+
+
+@app.command()
+def main(name: str) -> None:
+    print(f"Hello {name}")
+```
+
+This is invoked as `program Ada`, not `program main Ada`.
+
+## Compose Named Groups
+
+Create one root app and separate sub-apps by responsibility. Register every group with an explicit public name:
+
+```python
+import typer
+
+app = typer.Typer()
+users_app = typer.Typer()
+
+
+@users_app.command()
+def create(name: str) -> None:
+    print(f"Creating {name}")
+
+
+app.add_typer(users_app, name="users")
+```
+
+The command is `program users create Ada`. Do not infer a group's name from its callback; Typer removed that behavior. Keep nesting only when it matches a real user-facing hierarchy.
+
+## Use Callbacks Deliberately
+
+An application callback owns options that appear before the subcommand:
+
+```text
+program --verbose users create Ada
+```
+
+The same option after `users create` belongs to that command and is not a root option. A callback also runs before the selected command, so avoid expensive or side-effecting initialization when help, completion, or a narrower command does not need it.
+
+For a default root action alongside subcommands:
+
+```python
+@app.callback(invoke_without_command=True)
+def main(ctx: typer.Context) -> None:
+    if ctx.invoked_subcommand is None:
+        print("Default action")
+```
+
+For a current grouped Typer app, choose the no-command behavior explicitly: the default missing-command error rejects an omitted command, `no_args_is_help=True` shows help, and `invoke_without_command=True` runs the callback as a default action. Inspect older pinned versions before changing this behavior.
+
+A callback docstring can provide root help, but adding a callback solely for documentation still changes a one-command app into a command group. Treat that as a grammar decision, not harmless decoration.
+
+## Help and Naming
+
+- Keep public command and option names stable; Python underscores normally become CLI dashes.
+- Give `add_typer()` groups explicit names and meaningful help.
+- Use stable semantic help assertions. Rich formatting and metavar layout can change across Typer versions.
+- Keep pass-through `context_settings` such as `allow_extra_args` and `ignore_unknown_options` for deliberate wrapper CLIs; they bypass normal typed parsing.
+
+## Official Sources
+
+- [One or Multiple Commands](https://typer.tiangolo.com/tutorial/commands/one-or-multiple/)
+- [Typer Callback](https://typer.tiangolo.com/tutorial/commands/callback/)
+- [Using the Context](https://typer.tiangolo.com/tutorial/commands/context/)
+- [Add Typer](https://typer.tiangolo.com/tutorial/subcommands/add-typer/)
+- [Release notes: explicit group naming](https://typer.tiangolo.com/release-notes/#0140-2024-11-28)

--- a/skills/python/building-typer-clis/references/packaging-and-completion.md
+++ b/skills/python/building-typer-clis/references/packaging-and-completion.md
@@ -1,0 +1,86 @@
+# Typer Packaging and Completion
+
+Load this reference when adding Typer, wiring an executable, supporting `python -m`, testing a wheel, enabling completion, or migrating across Typer versions.
+
+## Use the Current Package
+
+Inspect the project's Python range, existing Typer constraint, and lockfile before changing dependencies. Add plain Typer through the repository workflow with `uv add typer`.
+
+Do not add `typer[all]`, `typer-slim`, or `typer-cli` to a current project. Plain `typer` includes Rich, shellingham, and the `typer` command; the slim and CLI distributions stopped receiving releases and now defer to `typer`.
+
+Do not silently raise the minimum Python version or upgrade a pinned Typer release. When a migration is requested, read the release notes between the current and target versions and test command grammar, help, completion, and runner behavior.
+
+## Wire Each Supported Invocation Explicitly
+
+For an installed executable, point `[project.scripts]` at the explicit app:
+
+```toml
+[project.scripts]
+my-command = "my_package.cli:app"
+```
+
+The left side is the executable users call. The right side is the importable module and `typer.Typer()` object. An installed entry point does not require an `if __name__ == "__main__"` block.
+
+For direct script execution, use a guard:
+
+```python
+if __name__ == "__main__":
+    app()
+```
+
+For optional `python -m my_package` support, add `my_package/__main__.py`:
+
+```python
+from .cli import app
+
+app()
+```
+
+These are separate public invocation modes. Test every mode the project documents instead of assuming that an importable app proves the script metadata or module path.
+
+## Build and Test the Distribution
+
+Use the repository's uv workflow. For a package, representative checks are:
+
+```bash
+uv sync
+uv run my-command --help
+uv build
+uv tool run --from path/to/dist/package-version-py3-none-any.whl my-command --help
+```
+
+Choose the actual artifact path produced by the build. `uv tool run --from` uses an isolated tool environment instead of overwriting an unrelated installed command. Publishing is a separate external action; use the dedicated uv packaging workflow and require exact publication authorization.
+
+## Preserve Completion
+
+Shell completion is tied to a stable installed executable name. It does not work through `python -m my_package`. When completion is required:
+
+- install and invoke the `[project.scripts]` command
+- exercise `--show-completion` or the relevant shell in a disposable environment before claiming it works
+- keep imports, app construction, callbacks, and custom `autocompletion` functions fast and free of stdout diagnostics or external side effects
+- remember that completion executes the program with protocol environment variables
+
+Do not install completion into the user's shell merely to test command wiring. That mutates external configuration and requires explicit authorization.
+
+## Treat Version Boundaries as Compatibility Work
+
+Typer 0.26.0 vendors Click. For current Typer, do not extract a Click application, attach Click plug-ins, subclass Click's runner, or depend on Click-specific internals. Prefer documented Typer parameters and APIs; several inherited settings are compatibility-only or deprecated.
+
+Other migration-sensitive surfaces include:
+
+- explicit names for `add_typer()` groups
+- `Annotated` parameter declarations
+- `shell_complete` versus Typer's `autocompletion`
+- `mix_stderr` and the current Typer `CliRunner`
+- exact Rich help and metavar rendering
+- Python-version support
+
+Pin versions when exact rendering is a product requirement; otherwise assert semantic help content.
+
+## Official Sources
+
+- [Install Typer](https://typer.tiangolo.com/tutorial/install/)
+- [Building a Package](https://typer.tiangolo.com/tutorial/package/)
+- [Features: shell completion](https://typer.tiangolo.com/features/)
+- [Release Notes](https://typer.tiangolo.com/release-notes/)
+- [Vendored Click](https://typer.tiangolo.com/tutorial/click/)

--- a/skills/python/building-typer-clis/references/parameters-and-runtime.md
+++ b/skills/python/building-typer-clis/references/parameters-and-runtime.md
@@ -1,0 +1,99 @@
+# Typer Parameters and Runtime Behavior
+
+Load this reference for nontrivial arguments, options, prompts, callbacks, completion, or error and exit behavior.
+
+## Declare Parameters with `Annotated`
+
+Prefer `typing.Annotated`; the older style that stores `typer.Argument(...)` or `typer.Option(...)` as the Python default is deprecated.
+
+```python
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+app = typer.Typer()
+
+
+@app.command()
+def import_data(
+    source: Annotated[Path, typer.Argument(exists=True, dir_okay=False)],
+    limit: Annotated[int, typer.Option(min=1)] = 100,
+) -> None:
+    ...
+```
+
+Parameter requiredness comes from the presence of a default value:
+
+- The absence of both a Python assignment and `default_factory=` means required, including for an option.
+- An assignment supplies a static default and makes the parameter optional.
+- `default_factory=` inside `Argument()` or `Option()` supplies a dynamic default and also makes the parameter optional.
+- Do not combine `default_factory=` with a Python assignment; Typer rejects two defaults.
+- `T | None` describes an accepted value; it does not by itself make a parameter optional.
+
+Prefer Typer's supported types and constraints before custom parsing:
+
+- `Enum` or `Literal` for choices.
+- `Path` with `exists`, `file_okay`, `dir_okay`, `readable`, `writable`, or `resolve_path` when those checks match the contract.
+- `list[T]` for repeated values; repeated options are supplied by repeating the flag.
+- Fixed tuples for fixed-arity values.
+- `datetime` with explicit `formats=` when the accepted format is part of the interface.
+- `typer.FileText` or `typer.FileBinaryRead` only when passing open file objects is preferable to a `Path` boundary.
+
+Do not assume paths expand `~`, datetimes accept every ISO-8601 form, or list and tuple parameters share the same grammar. Exercise the actual accepted forms.
+
+## Validate and Terminate at the Boundary
+
+Use a parameter callback when validation belongs to one argument or option:
+
+```python
+def positive(value: int) -> int:
+    if value <= 0:
+        raise typer.BadParameter("must be greater than zero")
+    return value
+```
+
+`typer.BadParameter` associates the failure with the originating parameter and renders usage. Use ordinary domain exceptions inside business logic and translate them once at the command boundary.
+
+Use the termination types deliberately:
+
+- `raise typer.Exit()` for an intentional successful early stop.
+- `raise typer.Exit(code=n)` for a deliberate nonzero status after rendering the intended message.
+- `raise typer.Abort()` for an aborted interaction; Typer renders `Aborted!`.
+
+Do not use `BadParameter` for an unrelated service or business failure merely to obtain formatted output.
+
+## Prompts, Secrets, and Consent
+
+`prompt=True` asks only when an option is omitted. Preserve a non-interactive flag or environment path for automation.
+
+For secrets, `hide_input=True` hides interactive typing and `confirmation_prompt=True` asks for the same value twice. They do not protect a value supplied directly in argv, which may be visible in shell history or process listings. Prefer a secure prompt, environment variable, file, or existing secret provider according to the application's threat model.
+
+`confirmation_prompt=True` confirms equality, not user intent. For an affirmative destructive-action decision, use a separate confirmation such as:
+
+```python
+typer.confirm("Delete all cached records?", abort=True)
+```
+
+Keep destructive execution outside tests or inject the effect.
+
+## Callbacks and Completion
+
+A parameter callback and an `autocompletion` function can receive typed injected values such as `typer.Context`; completion functions can also receive the incomplete `str` and raw `list[str]` arguments.
+
+- Use `autocompletion=...` for custom value completion. The inherited `shell_complete` parameter is deprecated and not fully functional.
+- Return or yield strings, or `(value, help)` tuples where the shell supports help text.
+- Filter on the incomplete value and keep completion bounded, fast, and deterministic.
+- Never print normal diagnostics to stdout during completion; completion reads stdout as its protocol.
+- Parameter callbacks may execute during completion. Check `ctx.resilient_parsing` and return before validation, output, network, or storage work when it is true.
+- Root import and app construction must also avoid side effects because completion starts the program.
+
+## Official Sources
+
+- [Parameters reference](https://typer.tiangolo.com/reference/parameters/)
+- [CLI Option Callback and Context](https://typer.tiangolo.com/tutorial/options/callback-and-context/)
+- [CLI Option autocompletion](https://typer.tiangolo.com/tutorial/options-autocompletion/)
+- [Password and Confirmation Prompt](https://typer.tiangolo.com/tutorial/options/password/)
+- [Terminating](https://typer.tiangolo.com/tutorial/terminating/)
+- [Parameter Types](https://typer.tiangolo.com/tutorial/parameter-types/)
+- [Multiple Values](https://typer.tiangolo.com/tutorial/multiple-values/)

--- a/skills/python/building-typer-clis/references/testing.md
+++ b/skills/python/building-typer-clis/references/testing.md
@@ -1,0 +1,74 @@
+# Testing Typer CLIs
+
+Load this reference when adding or revising CLI tests. Test business behavior directly and use `typer.testing.CliRunner` for the Typer boundary.
+
+## Test the Public Grammar
+
+The argument list passed to `runner.invoke()` starts after the executable name. Match the real command shape:
+
+```python
+from typer.testing import CliRunner
+
+from my_package.cli import app
+
+runner = CliRunner()
+
+
+def test_import_requires_existing_file(tmp_path) -> None:
+    source = tmp_path / "records.json"
+    source.write_text("[]")
+
+    result = runner.invoke(app, [str(source), "--limit", "10"])
+
+    assert result.exit_code == 0
+    assert "Imported 0 records" in result.stdout
+```
+
+For a one-command app, do not insert the function name. For a grouped app, include each public command or group. Add a regression test before introducing a second command or application callback because that can change the entire invocation grammar.
+
+## Cover Observable Boundaries
+
+Exercise representative cases:
+
+- success with converted values
+- missing, malformed, bounded, and callback-invalid parameters
+- deliberate zero and nonzero `typer.Exit` paths
+- aborted confirmation or interaction
+- prompt input with `input="value\n"`
+- environment fallback with `env={"NAME": "value"}`
+- filesystem effects in a pytest `tmp_path`
+- stable `--help` fragments, command names, option names, and required/default semantics
+
+Assert `result.exit_code` first. Use `result.stdout` and `result.stderr` when the stream matters; `result.output` is useful when combined terminal output is the contract. Avoid snapshots of complete Rich help or metavar spacing unless exact rendering is itself required and the Typer version is pinned.
+
+Use `catch_exceptions=False` temporarily when diagnosing an unexpected exception. Do not make a passing test depend on a traceback for an expected user error.
+
+## Respect Current Runner Boundaries
+
+Typer's testing surface changed across versions. Inspect the declared Typer version rather than copying old Click examples.
+
+For current Typer 0.26+:
+
+- `CliRunner` is Typer's runner, not the public Click runner.
+- Do not pass `mix_stderr`; current results expose stdout and stderr separately.
+- Do not assume `isolated_filesystem()` exists. Use pytest `tmp_path` and `monkeypatch.chdir(tmp_path)` when a current-working-directory boundary matters.
+- Invoke runners sequentially. Runner calls replace process-global streams and environment during execution and are not a safe concurrent-test primitive.
+- Do not rely on Click plug-ins, runner subclasses, or undocumented Click internals.
+
+For an older pinned Typer version, consult its matching release notes and runner signature. Do not silently upgrade merely to make a copied test helper work.
+
+## Separate CLI and Domain Tests
+
+A CLI test should prove parsing, help, rendering, and exit behavior. It should not need real network calls, publication, destructive mutations, wall-clock time, randomness, or persistent user configuration.
+
+Inject or mock those effects and test the ordinary function underneath directly. Keep at least one boundary test proving that the command translates a known domain result or failure into the intended message and exit code.
+
+When packaging is in scope, add a subprocess smoke test for the installed `[project.scripts]` executable or isolated wheel in addition to `CliRunner`; importing `app` does not prove distribution metadata works.
+
+## Official Sources
+
+- [Testing](https://typer.tiangolo.com/tutorial/testing/)
+- [Building a Package](https://typer.tiangolo.com/tutorial/package/)
+- [Release notes: `mix_stderr` removal](https://typer.tiangolo.com/release-notes/#0160-2025-05-26)
+- [Release notes: vendored Click](https://typer.tiangolo.com/release-notes/#0260-2026-05-26)
+- [Vendored Click](https://typer.tiangolo.com/tutorial/click/)

--- a/tests/test_skill_repository.py
+++ b/tests/test_skill_repository.py
@@ -137,6 +137,68 @@ def test_gourmet_research_is_deprecated() -> None:
     assert "| `researching-gourmet-venues` |" in deprecated_catalog
 
 
+def test_typer_skill_covers_current_framework_decisions() -> None:
+    typer_dir = SKILLS / "python/building-typer-clis"
+    skill = (typer_dir / "SKILL.md").read_text()
+    metadata = (typer_dir / "agents/openai.yaml").read_text()
+    references = {
+        path.name: path.read_text()
+        for path in sorted((typer_dir / "references").glob("*.md"))
+    }
+    readme = (ROOT / "README.md").read_text()
+
+    assert set(references) == {
+        "application-architecture.md",
+        "packaging-and-completion.md",
+        "parameters-and-runtime.md",
+        "testing.md",
+    }
+    assert "Preserve the public invocation grammar" in skill
+    assert "declared Typer version" in skill
+    assert "`PROGRAM [ARGS]...`" in skill
+    assert "`PROGRAM COMMAND [ARGS]...`" in skill
+    assert "registering a sub-app with `app.add_typer(...)`" in skill
+    assert "`typing.Annotated`" in skill
+    assert "`typer.BadParameter`" in skill
+    assert "`typer.Exit`" in skill
+    assert "`typer.Abort`" in skill
+    assert "`ctx.resilient_parsing`" in skill
+    assert "## Minimal Pattern" not in skill
+
+    architecture = references["application-architecture.md"]
+    assert 'app.add_typer(users_app, name="users")' in architecture
+    assert "Registering any sub-app also creates grouped grammar" in architecture
+    assert "default missing-command error" in architecture
+    assert "invoke_without_command=True" in architecture
+    assert "ctx.invoked_subcommand is None" in architecture
+
+    parameters = references["parameters-and-runtime.md"]
+    assert "requiredness comes from the presence of a default" in parameters
+    assert "absence of both a Python assignment and `default_factory=`" in parameters
+    assert "Do not combine `default_factory=` with a Python assignment" in parameters
+    assert "confirmation_prompt" in parameters
+    assert "`autocompletion`" in parameters
+    assert "`shell_complete`" in parameters
+
+    testing = references["testing.md"]
+    assert "sequentially" in testing
+    assert "result.stdout" in testing and "result.stderr" in testing
+    assert "`mix_stderr`" in testing
+    assert "`isolated_filesystem()`" in testing
+
+    packaging = references["packaging-and-completion.md"]
+    assert "`uv add typer`" in packaging
+    assert "`typer-slim`" in packaging and "`typer-cli`" in packaging
+    assert "`[project.scripts]`" in packaging
+    assert "Typer 0.26.0 vendors Click" in packaging
+    assert "`python -m`" in packaging and "shell completion" in packaging
+
+    assert all("https://typer.tiangolo.com/" in text for text in references.values())
+    assert "command grammar" in metadata
+    assert "Annotated" in metadata
+    assert "Typer command grammar, typed parameters" in readme
+
+
 def test_material_trigger_surfaces_are_semantically_aligned() -> None:
     readme = (ROOT / "README.md").read_text()
     svg_skill = (


### PR DESCRIPTION
## Summary

- replace the basic Typer example with a lean workflow that protects public command grammar and routes deeper decisions to focused references
- add current official guidance for application architecture, `Annotated` parameters and runtime behavior, testing, packaging, and shell completion
- align the README and OpenAI metadata, and add regression coverage for high-risk Typer 0.27 behavior

## Why

The previous skill mostly restated basic Typer usage. This revision captures framework-specific failure modes such as single-command promotion, grammar changes caused by callbacks or `add_typer()`, dynamic default semantics, vendored Click boundaries, and the current `CliRunner` API while keeping the core skill concise.

## Affected paths

- `skills/python/building-typer-clis/`
- `tests/test_skill_repository.py`
- `README.md`
- `docs/plans/archived/2026-07-23_strengthen-typer-skill-plan.md`

## Verification

- `uv run --no-project --with pytest pytest` — 89 passed
- `prek run -a` — passed
- `git diff --check` — passed
- changed skill `quick_validate.py` — valid
- Typer 0.27 smoke tests — passed for command promotion, `add_typer()` grammar, callbacks, `Annotated`, `default_factory`, `BadParameter`, current `CliRunner`, installed scripts, help, and wheel builds
- independent final review — no findings
