### PR TITLE
feat(skills): add interface redesign workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Repository path: `skills/ui-ux-design/`
 | Skill | Use it for |
 | --- | --- |
 | `designing-user-interfaces` | Apple-derived, platform-adapted UI work without false simplicity. |
+| `redesigning-user-interfaces` | Evidence-backed, approval-gated redesigns of existing interfaces. |
 
 ### Slides & Visuals
 

--- a/skills/ui-ux-design/redesigning-user-interfaces/SKILL.md
+++ b/skills/ui-ux-design/redesigning-user-interfaces/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: redesigning-user-interfaces
+description: Redesign the user experience of an existing interface through an approval-gated analysis, proposal, and implementation workflow. Use for substantial reorganizations of current screens, navigation, workflows, settings, or interaction behavior that must preserve compatibility, data, accessibility, and recovery paths.
+---
+
+# Redesigning User Interfaces
+
+Ground the redesign in the product's actual users, workflows, platform, design system, and constraints. Do not transplant another product's labels, visual patterns, or information architecture. Treat unsupported claims about users, frequency, risk, or platform behavior as assumptions rather than facts.
+
+## Analyze the Existing Experience
+
+1. Inspect the relevant interface, code, tests, user-facing documentation, stored formats, supported screen sizes and inputs, and accessibility conventions.
+2. Identify the primary user groups, the jobs they are trying to complete, and the current paths to those outcomes.
+3. Inventory features and classify them as primary, secondary, advanced, destructive, or compatibility-only. Preserve unknown capabilities until their ownership and use are understood.
+4. Evaluate affected flows by evidence-backed frequency, importance, complexity, risk, and reversibility.
+5. Map current state, transitions, dependencies, cancellation and recovery paths, then identify avoidable steps, inconsistent behavior, unclear state, and usability failures.
+
+Label assumptions, unknowns, and product decisions that require confirmation. Preserve current behavior where evidence is incomplete.
+
+## Shape the Proposal
+
+Organize the revised experience around user goals rather than internal settings or data structures. Prioritize a small set of frequent and important actions while applying these constraints:
+
+- Keep consequential current state visible where it informs a decision.
+- Place secondary, advanced, and risky controls behind labeled, predictable progressive disclosure without hiding critical information or the only route to a capability.
+- Keep navigation shallow with clear return, cancel, and exit paths.
+- Offer a small set of meaningful defaults or presets when supported, while retaining expert customization.
+- Preview the concrete effect of consequential choices. Distinguish previewing, confirming, cancelling, saving, and applying through labels, state, and feedback.
+- Reduce steps without removing safeguards for destructive or hard-to-reverse actions.
+- Maintain consistent terminology, navigation, confirmations, and cancellation behavior.
+- Adapt hierarchy and interaction to supported widths, content sizes, localization, inputs, and assistive technology. Avoid ambiguous truncation, inaccessible overflow, hidden critical information, and disruptive layout shifts.
+
+Present:
+
+1. The evidence-backed usability findings and feature classification.
+2. The revised information architecture and primary, secondary, advanced, destructive, and recovery flows.
+3. Intended loading, empty, success, error, disabled, and partial states, including where status and actionable feedback appear.
+4. Concrete acceptance criteria for behavior, responsiveness, keyboard and focus operation, screen readers, contrast, compatibility, tests, and documentation.
+5. The main decisions, trade-offs, compatibility risks, migration needs, and unresolved questions.
+
+Do not edit product files, tests, stored data, or user-facing documentation during this proposal phase. Wait for explicit approval of the proposal before implementation; requested revisions update the proposal and do not imply approval.
+
+## Implement After Approval
+
+Implement only the approved scope and preserve unrelated behavior.
+
+- Keep backward compatibility, existing workflows, stored user data, and unknown configuration fields unless the approved proposal includes a verified migration path.
+- Apply confirmed changes atomically and provide immediate success feedback. Cancellation must have no side effects.
+- On failure, retain the previous valid state and show an actionable error that explains what failed and how to recover or retry.
+- Keep primary actions, consequential status, validation, unsaved-work risk, and recovery paths visible at the relevant time.
+- Preserve capability through stable progressive disclosure rather than deletion or ambiguous hiding.
+- Verify responsive layouts without overflow or harmful shifts across supported sizes, inputs, content extremes, and text scaling.
+- Support keyboard navigation, logical focus order and restoration, screen-reader semantics and announcements, non-color cues, appropriate contrast, and reduced motion where relevant.
+- Add or update tests for affected primary flows, previews, confirmations, cancellations, navigation, failures, responsive behavior, accessibility, and compatibility. Test only states and environments the product supports.
+- Update user-facing documentation to describe the final behavior and any approved migration.
+
+Exercise the affected loading, empty, success, error, disabled, and partial states. Report what changed, validation evidence, preserved compatibility, approved deviations, and any scenarios that could not be verified.

--- a/skills/ui-ux-design/redesigning-user-interfaces/agents/openai.yaml
+++ b/skills/ui-ux-design/redesigning-user-interfaces/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Redesigning User Interfaces"
+  short_description: "Plan approval-gated redesigns of existing interfaces."
+  default_prompt: "Use $redesigning-user-interfaces to analyze this existing interface, propose an evidence-backed redesign with acceptance criteria, and wait for approval before implementation."

--- a/tests/test_skill_repository.py
+++ b/tests/test_skill_repository.py
@@ -38,7 +38,7 @@ def test_deprecated_skills_are_hidden_from_standard_discovery() -> None:
 
 def test_every_skill_name_metadata_and_catalog_inventory_is_complete() -> None:
     skill_markdown = all_skill_markdown()
-    assert len(skill_markdown) == 33
+    assert len(skill_markdown) == 34
     readme = (ROOT / "README.md").read_text()
 
     for skill_md in skill_markdown:
@@ -220,6 +220,27 @@ def test_material_trigger_surfaces_are_semantically_aligned() -> None:
     assert "Apple-derived, platform-adapted UI work" in readme
 
 
+def test_redesigning_user_interfaces_requires_approval_before_implementation() -> None:
+    redesign_dir = SKILLS / "ui-ux-design/redesigning-user-interfaces"
+    skill = (redesign_dir / "SKILL.md").read_text()
+    metadata = (redesign_dir / "agents/openai.yaml").read_text()
+    readme = (ROOT / "README.md").read_text()
+    proposal, implementation = skill.split("## Implement After Approval", 1)
+
+    assert "existing interface" in skill
+    assert "Wait for explicit approval" in proposal
+    assert "Do not edit product files" in proposal
+    assert "loading, empty, success, error, disabled, and partial" in proposal
+    assert "unknown configuration fields" in skill
+    assert "Cancellation must have no side effects" in implementation
+    assert "atomically" in implementation
+    assert "responsive" in implementation
+    assert "accessibility" in implementation
+    assert "user-facing documentation" in implementation
+    assert "$redesigning-user-interfaces" in metadata
+    assert "approval-gated redesigns of existing interfaces" in readme
+
+
 def test_skill_bodies_avoid_repeating_trigger_and_generic_cleanup_sections() -> None:
     redundant_headings = {
         "## Overview",
@@ -239,7 +260,7 @@ def test_skill_bodies_avoid_repeating_trigger_and_generic_cleanup_sections() -> 
 def test_active_skills_are_grouped_one_category_deep() -> None:
     categorized = sorted(SKILLS.glob("*/*/SKILL.md"))
     assert categorized == sorted(SKILLS.glob("**/SKILL.md"))
-    assert len(categorized) == 27
+    assert len(categorized) == 28
     assert len({skill_md.parent.name for skill_md in categorized}) == len(categorized)
 
 


### PR DESCRIPTION
## Summary

- add an approval-gated skill for redesigning existing interfaces
- cover current-flow analysis, information architecture, interface states, compatibility, accessibility, and responsive behavior
- align OpenAI metadata and README discovery, with repository regression coverage

## Verification

- `UV_CACHE_DIR=/tmp/uv-cache uv run --no-project --python 3.13 --with pyyaml python "$HOME/.codex/skills/.system/skill-creator/scripts/quick_validate.py" skills/ui-ux-design/redesigning-user-interfaces` — passed
- `uv run --no-project --with pytest pytest` — 91 passed
- `prek run -a` — passed
- `git diff --check` — passed
