### PR TITLE
fix(skills): retain deprecated interface redesign skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,5 +114,6 @@ Deprecated skills remain in `deprecated/<skill-name>/` for reference and are exc
 | `cleaning-atuin-history` | Legacy Atuin audit and exact-approval cleanup preparation. |
 | `building-codex-hooks` | Version-sensitive legacy Codex CLI hook reference. |
 | `writing-work-logs` | Legacy explicit-only Git-evidence work logs. |
+| `redesigning-user-interfaces` | Replaced by `designing-user-experiences`; retained as a compatibility reference. |
 | `naming-agent-skills` | Merged into `creating-agent-skills`; retained as a compatibility reference. |
 | `researching-gourmet-venues` | Rarely used city dining workflow retained as a compatibility reference. |

--- a/deprecated/redesigning-user-interfaces/SKILL.md
+++ b/deprecated/redesigning-user-interfaces/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: redesigning-user-interfaces
+description: Deprecated compatibility reference for approval-gated redesigns of existing interfaces. Use the active designing-user-experiences workflow for current UX design and redesign work.
+metadata:
+  internal: true
+---
+
+# Redesigning User Interfaces (Deprecated Reference)
+
+Use `designing-user-experiences` for the maintained workflow. This reference preserves the former `$redesigning-user-interfaces` name for explicit local use.
+
+For an existing product, follow the active skill's **Existing Product** path. Preserve compatibility, stored data, accessibility, cancellation, recovery, tests, and documentation, and wait for explicit proposal approval before implementation.

--- a/deprecated/redesigning-user-interfaces/agents/openai.yaml
+++ b/deprecated/redesigning-user-interfaces/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Redesigning User Interfaces (Deprecated)"
+  short_description: "Use the replacement UX design workflow."
+  default_prompt: "Use $redesigning-user-interfaces as a deprecated compatibility reference; follow $designing-user-experiences for current approval-gated redesign work."

--- a/tests/test_skill_repository.py
+++ b/tests/test_skill_repository.py
@@ -30,7 +30,7 @@ def load_module(path: Path, name: str) -> ModuleType:
 
 def test_deprecated_skills_are_hidden_from_standard_discovery() -> None:
     deprecated = sorted(DEPRECATED.glob("*/SKILL.md"))
-    assert len(deprecated) == 6
+    assert len(deprecated) == 7
     for skill_md in deprecated:
         frontmatter = skill_md.read_text().split("---", 2)[1]
         assert "\nmetadata:\n  internal: true\n" in f"\n{frontmatter}\n", skill_md
@@ -38,7 +38,7 @@ def test_deprecated_skills_are_hidden_from_standard_discovery() -> None:
 
 def test_every_skill_name_metadata_and_catalog_inventory_is_complete() -> None:
     skill_markdown = all_skill_markdown()
-    assert len(skill_markdown) == 34
+    assert len(skill_markdown) == 35
     readme = (ROOT / "README.md").read_text()
 
     for skill_md in skill_markdown:
@@ -222,12 +222,23 @@ def test_material_trigger_surfaces_are_semantically_aligned() -> None:
 
 def test_designing_user_experiences_supports_new_and_existing_products() -> None:
     experience_dir = SKILLS / "ui-ux-design/designing-user-experiences"
+    deprecated_redesign_dir = DEPRECATED / "redesigning-user-interfaces"
     skill = (experience_dir / "SKILL.md").read_text()
     metadata = (experience_dir / "agents/openai.yaml").read_text()
+    deprecated_skill = (deprecated_redesign_dir / "SKILL.md").read_text()
+    deprecated_metadata = (deprecated_redesign_dir / "agents/openai.yaml").read_text()
     readme = (ROOT / "README.md").read_text()
+    active_catalog, deprecated_catalog = readme.split("## 🗄️ Deprecated Skills", 1)
     proposal, implementation = skill.split("## Implement After Approval", 1)
 
     assert not (SKILLS / "ui-ux-design/redesigning-user-interfaces").exists()
+    assert deprecated_redesign_dir.is_dir()
+    assert "metadata:\n  internal: true" in deprecated_skill
+    assert "designing-user-experiences" in deprecated_skill
+    assert "Deprecated" in deprecated_metadata
+    assert "$redesigning-user-interfaces" in deprecated_metadata
+    assert "| `redesigning-user-interfaces` |" not in active_catalog
+    assert "| `redesigning-user-interfaces` |" in deprecated_catalog
     assert "new or existing digital products" in skill
     assert "### New Product" in skill
     assert "### Existing Product" in skill


### PR DESCRIPTION
## Summary

- retain `redesigning-user-interfaces` as a deprecated compatibility reference after its replacement by `designing-user-experiences`
- catalog the deprecated name and keep it excluded from standard discovery
- add regression coverage for the compatibility path

This follows up on the review feedback from #102.

## Affected paths

- `deprecated/redesigning-user-interfaces/`
- `README.md`
- `tests/test_skill_repository.py`

## Verification

- `UV_CACHE_DIR=/tmp/uv-cache uv run --no-project --with pytest pytest` — 91 passed
- `prek run -a` — passed
- `git diff --check main...HEAD` — passed