### PR TITLE
feat(skills): add iterative UI improvement workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Repository path: `skills/ui-ux-design/`
 | --- | --- |
 | `designing-user-interfaces` | Design and review clear, accessible, platform-adapted user interfaces. |
 | `designing-user-experiences` | Plan new and existing digital workflows through an approval-gated UX process. |
+| `iterating-ui-improvements` | Run autonomous DevTools audit-fix-commit loops for evidence-backed UI improvements. |
 
 ### Slides & Visuals
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Repository path: `skills/ui-ux-design/`
 | --- | --- |
 | `designing-user-interfaces` | Design and review clear, accessible, platform-adapted user interfaces. |
 | `designing-user-experiences` | Plan new and existing digital workflows through an approval-gated UX process. |
-| `iterating-ui-improvements` | Run autonomous DevTools audit-fix-commit loops for evidence-backed UI improvements. |
+| `iterating-ui-improvements` | Explicitly invoked DevTools audit-fix-commit loops for evidence-backed UI improvements. |
 
 ### Slides & Visuals
 

--- a/skills/ui-ux-design/iterating-ui-improvements/SKILL.md
+++ b/skills/ui-ux-design/iterating-ui-improvements/SKILL.md
@@ -20,6 +20,8 @@ Require all of the following before changing files:
 
 Stop and report the blocker when a prerequisite fails. Do not substitute another browser tool silently, guess credentials or product intent, or alter data to gain access.
 
+Determine whether the target is already running. If this run starts it, record process or job ownership needed to stop its server and child watchers later; do not claim ownership of a pre-existing target.
+
 ## Choose the Finding Threshold and Limit
 
 - **`substantial` (default threshold):** continue while there is an evidence-backed, medium- or high-value problem affecting task completion, usability, or accessibility. Stop rather than pursue low-impact polish or subjective taste.
@@ -35,7 +37,9 @@ There is no iteration limit by default. A user may set a positive limit with eit
 3. Record the iteration plan in the execution log: observed evidence, user impact, exact change boundary, and acceptance checks. Do not add a plan file to the product repository.
 4. Implement the smallest coherent improvement. Preserve unknown behavior, content and data semantics, permissions, cancellation and recovery, and unrelated features. Stop before a product decision or material scope expansion.
 5. Run the repository's focused checks for the affected behavior. Re-verify the same flow and representative viewports in Chrome DevTools, confirming the improvement and checking for related interaction, responsive, accessibility, console, and network regressions.
-6. Only after verification passes, stage only the paths changed for this iteration, inspect the staged diff, and create one focused Conventional Commit grounded in that diff. Verify the commit ID and a clean worktree before beginning another iteration.
+6. Only after verification passes, stage only the paths changed for this iteration, inspect the staged diff, and record the staged tree identity. Create one focused Conventional Commit grounded in that diff, then compare the committed tree with the recorded staged tree before accepting the commit. Verify the commit ID and a clean worktree before beginning another iteration.
+
+If successful hooks changed the tree, treat their committed result as unverified and rerun affected checks and Chrome DevTools verification against the committed content. Accept it only if those checks pass. If they fail, restore the recorded validated tree, revalidate it, and create a clearly labeled recovery commit without rewriting history; verify that recovery commit's tree, then stop and report both commit IDs. If restoration or the recovery commit cannot be completed safely, stop and report the exact branch, index, and worktree state.
 
 If commit creation fails, preserve the hook or error output and re-inspect the index and worktree. Do not bypass hooks with `--no-verify`. Correct only an in-scope cause, rerun affected checks and Chrome DevTools verification when files changed, then retry. If a valid commit still cannot be created safely, unstage the exact iteration paths and apply the failure recovery below.
 
@@ -47,4 +51,6 @@ If implementation cannot pass its checks within the current coherent scope, or a
 
 Stop when the active finding threshold is empty, a fixed or explicit limit is reached, Chrome DevTools or tests are blocked, commit creation fails without a safe in-scope correction, a required product decision is missing, safe work would expand scope, or restoration fails. Do not push, open a pull request, deploy, mutate remote services, perform destructive data operations, or broaden the target without separate explicit authorization.
 
-Report each iteration's plan, commit ID, and validation evidence, followed by the stopping reason and any known unaddressed findings. Distinguish verified outcomes from untested states or assumptions.
+Before every exit, including success and blocked or failed paths, terminate and wait only for target processes started by this run and their child watchers. Preserve a target that was already running. If owned-process cleanup fails, report the remaining process and port evidence rather than stopping unrelated processes.
+
+Report each iteration's plan, commit ID, and validation evidence, followed by the stopping reason, cleanup result, and any known unaddressed findings. Distinguish verified outcomes from untested states or assumptions.

--- a/skills/ui-ux-design/iterating-ui-improvements/SKILL.md
+++ b/skills/ui-ux-design/iterating-ui-improvements/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: iterating-ui-improvements
+description: Iteratively audit and improve an existing web interface with Chrome DevTools by planning, implementing, validating, and locally committing one evidence-backed UI/UX improvement at a time. Use when the user wants an autonomous audit-fix-commit loop rather than a review or proposal alone.
+---
+
+# Iterating UI Improvements
+
+Run a Chrome DevTools-driven audit-fix-commit loop against an existing web product. An explicit invocation authorizes in-scope local edits, validation, and local commits; it does not authorize remote or destructive actions.
+
+## Establish the Run
+
+Accept an optional URL, user flow, page scope, stopping mode, and iteration limit. Prefer invocation details. Otherwise inspect repository instructions, application documentation, configuration, existing start commands, tests, and design-system conventions to infer one local site and primary flow. Ask one question only when multiple targets remain plausible.
+
+Require all of the following before changing files:
+
+- a clean Git worktree, including no staged, unstaged, or untracked changes;
+- an available Chrome DevTools capability and a reachable target that can be started through established non-interactive project commands;
+- any required test, account, or authentication context already available without bypassing controls; and
+- enough product evidence to preserve existing behavior, data meaning, permissions, recovery paths, and unrelated capability.
+
+Stop and report the blocker when a prerequisite fails. Do not substitute another browser tool silently, guess credentials or product intent, or alter data to gain access.
+
+## Choose the Stopping Mode
+
+- **`substantial` (default):** continue while there is an evidence-backed, medium- or high-value problem affecting task completion, usability, or accessibility. Stop rather than pursue low-impact polish or subjective taste.
+- **`exhaustive`:** also address low-impact UI problems when they are concrete, evidence-backed, and verifiable. Do not pursue unsupported subjective preferences.
+- **`fixed N`:** run at most the specified positive number of successful iterations, stopping earlier when no substantial issue remains. Report known remaining findings when the limit is reached.
+
+There is no iteration limit by default. A user may set a positive limit with any mode. Never interpret an omitted limit as five or another implicit cap.
+
+## Run One Iteration
+
+1. Use Chrome DevTools to reproduce the primary task and collect baseline evidence. As relevant to the target, inspect visual hierarchy, critical interactions, representative wide and narrow viewports, keyboard operation, semantic accessibility, and related console or network failures.
+2. Rank findings by user impact, confidence, scope, and reversibility. Select one highest-value, coherent improvement theme that meets the active stopping mode. If none qualifies, stop without creating an empty commit.
+3. Record the iteration plan in the execution log: observed evidence, user impact, exact change boundary, and acceptance checks. Do not add a plan file to the product repository.
+4. Implement the smallest coherent improvement. Preserve unknown behavior, content and data semantics, permissions, cancellation and recovery, and unrelated features. Stop before a product decision or material scope expansion.
+5. Run the repository's focused checks for the affected behavior. Re-verify the same flow and representative viewports in Chrome DevTools, confirming the improvement and checking for related interaction, responsive, accessibility, console, and network regressions.
+6. Only after verification passes, stage only the paths changed for this iteration, inspect the staged diff, and create one focused Conventional Commit grounded in that diff. Verify the commit ID and a clean worktree before beginning another iteration.
+
+Repeat from the observed post-commit interface rather than reusing stale findings.
+
+## Handle Failure and Stop
+
+If implementation cannot pass its checks within the current coherent scope, restore only the current iteration's uncommitted tracked changes and remove only files created during that iteration. Preserve every earlier successful commit. Do not reset, amend, rebase, or otherwise rewrite prior commits. If safe restoration cannot be proved or completed, stop and report the exact worktree state.
+
+Stop when the active finding threshold is empty, a fixed or explicit limit is reached, Chrome DevTools or tests are blocked, a required product decision is missing, safe work would expand scope, or restoration fails. Do not push, open a pull request, deploy, mutate remote services, perform destructive data operations, or broaden the target without separate explicit authorization.
+
+Report each iteration's plan, commit ID, and validation evidence, followed by the stopping reason and any known unaddressed findings. Distinguish verified outcomes from untested states or assumptions.

--- a/skills/ui-ux-design/iterating-ui-improvements/SKILL.md
+++ b/skills/ui-ux-design/iterating-ui-improvements/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: iterating-ui-improvements
-description: Iteratively audit and improve an existing web interface with Chrome DevTools by planning, implementing, validating, and locally committing one evidence-backed UI/UX improvement at a time. Use when the user wants an autonomous audit-fix-commit loop rather than a review or proposal alone.
+description: Iteratively audit and improve an existing web interface with Chrome DevTools by planning, implementing, validating, and locally committing one evidence-backed UI/UX improvement at a time. Use only when the user explicitly invokes `$iterating-ui-improvements` or names it to request an autonomous audit-fix-commit loop.
 ---
 
 # Iterating UI Improvements
 
-Run a Chrome DevTools-driven audit-fix-commit loop against an existing web product. An explicit invocation authorizes in-scope local edits, validation, and local commits; it does not authorize remote or destructive actions.
+Use only after explicit invocation. That invocation authorizes an audit-fix-commit loop with in-scope local edits, validation, and local commits; it does not authorize remote or destructive actions.
 
 ## Establish the Run
 
@@ -13,20 +13,20 @@ Accept an optional URL, user flow, page scope, stopping mode, and iteration limi
 
 Require all of the following before changing files:
 
-- a clean Git worktree, including no staged, unstaged, or untracked changes;
+- a clean Git worktree, including no staged, unstaged, or untracked changes, and an attached symbolic branch that will retain each commit; detached HEAD is a blocker, and do not create or switch branches without authorization;
 - an available Chrome DevTools capability and a reachable target that can be started through established non-interactive project commands;
 - any required test, account, or authentication context already available without bypassing controls; and
 - enough product evidence to preserve existing behavior, data meaning, permissions, recovery paths, and unrelated capability.
 
 Stop and report the blocker when a prerequisite fails. Do not substitute another browser tool silently, guess credentials or product intent, or alter data to gain access.
 
-## Choose the Stopping Mode
+## Choose the Finding Threshold and Limit
 
-- **`substantial` (default):** continue while there is an evidence-backed, medium- or high-value problem affecting task completion, usability, or accessibility. Stop rather than pursue low-impact polish or subjective taste.
+- **`substantial` (default threshold):** continue while there is an evidence-backed, medium- or high-value problem affecting task completion, usability, or accessibility. Stop rather than pursue low-impact polish or subjective taste.
 - **`exhaustive`:** also address low-impact UI problems when they are concrete, evidence-backed, and verifiable. Do not pursue unsupported subjective preferences.
-- **`fixed N`:** run at most the specified positive number of successful iterations, stopping earlier when no substantial issue remains. Report known remaining findings when the limit is reached.
+- **`fixed N`:** apply the specified positive iteration cap to the active finding threshold. If no threshold is named, use `substantial`. Stop earlier only when no finding meets the active threshold, and report known remaining findings when the cap is reached.
 
-There is no iteration limit by default. A user may set a positive limit with any mode. Never interpret an omitted limit as five or another implicit cap.
+There is no iteration limit by default. A user may set a positive limit with either threshold; the limit applies to the active finding threshold. Never interpret an omitted limit as five or another implicit cap.
 
 ## Run One Iteration
 
@@ -37,12 +37,14 @@ There is no iteration limit by default. A user may set a positive limit with any
 5. Run the repository's focused checks for the affected behavior. Re-verify the same flow and representative viewports in Chrome DevTools, confirming the improvement and checking for related interaction, responsive, accessibility, console, and network regressions.
 6. Only after verification passes, stage only the paths changed for this iteration, inspect the staged diff, and create one focused Conventional Commit grounded in that diff. Verify the commit ID and a clean worktree before beginning another iteration.
 
+If commit creation fails, preserve the hook or error output and re-inspect the index and worktree. Do not bypass hooks with `--no-verify`. Correct only an in-scope cause, rerun affected checks and Chrome DevTools verification when files changed, then retry. If a valid commit still cannot be created safely, unstage the exact iteration paths and apply the failure recovery below.
+
 Repeat from the observed post-commit interface rather than reusing stale findings.
 
 ## Handle Failure and Stop
 
-If implementation cannot pass its checks within the current coherent scope, restore only the current iteration's uncommitted tracked changes and remove only files created during that iteration. Preserve every earlier successful commit. Do not reset, amend, rebase, or otherwise rewrite prior commits. If safe restoration cannot be proved or completed, stop and report the exact worktree state.
+If implementation cannot pass its checks within the current coherent scope, or a valid commit cannot be created, unstage the exact iteration paths, restore only the current iteration's uncommitted tracked changes, and remove only files created during that iteration. Preserve every earlier successful commit. Do not reset, amend, rebase, or otherwise rewrite prior commits. If safe restoration cannot be proved or completed, stop and report the exact index and worktree state.
 
-Stop when the active finding threshold is empty, a fixed or explicit limit is reached, Chrome DevTools or tests are blocked, a required product decision is missing, safe work would expand scope, or restoration fails. Do not push, open a pull request, deploy, mutate remote services, perform destructive data operations, or broaden the target without separate explicit authorization.
+Stop when the active finding threshold is empty, a fixed or explicit limit is reached, Chrome DevTools or tests are blocked, commit creation fails without a safe in-scope correction, a required product decision is missing, safe work would expand scope, or restoration fails. Do not push, open a pull request, deploy, mutate remote services, perform destructive data operations, or broaden the target without separate explicit authorization.
 
 Report each iteration's plan, commit ID, and validation evidence, followed by the stopping reason and any known unaddressed findings. Distinguish verified outcomes from untested states or assumptions.

--- a/skills/ui-ux-design/iterating-ui-improvements/agents/openai.yaml
+++ b/skills/ui-ux-design/iterating-ui-improvements/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Iterating UI Improvements"
-  short_description: "Run autonomous DevTools audit-fix-commit UI loops."
-  default_prompt: "Use $iterating-ui-improvements to audit the target interface with Chrome DevTools, plan and implement one evidence-backed improvement at a time, validate it, and create focused local commits until the selected stopping condition is met."
+  short_description: "Explicitly run DevTools audit-fix-commit UI loops."
+  default_prompt: "Explicitly invoke $iterating-ui-improvements to audit the target interface with Chrome DevTools, plan and implement one evidence-backed improvement at a time, validate it, and create focused local commits until the selected stopping condition is met."

--- a/skills/ui-ux-design/iterating-ui-improvements/agents/openai.yaml
+++ b/skills/ui-ux-design/iterating-ui-improvements/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Iterating UI Improvements"
+  short_description: "Run autonomous DevTools audit-fix-commit UI loops."
+  default_prompt: "Use $iterating-ui-improvements to audit the target interface with Chrome DevTools, plan and implement one evidence-backed improvement at a time, validate it, and create focused local commits until the selected stopping condition is met."

--- a/tests/test_skill_repository.py
+++ b/tests/test_skill_repository.py
@@ -226,11 +226,15 @@ def test_iterating_ui_improvements_is_a_devtools_commit_loop() -> None:
     metadata = (skill_dir / "agents/openai.yaml").read_text()
     readme = (ROOT / "README.md").read_text()
 
+    frontmatter = skill.split("---", 2)[1]
     assert "Chrome DevTools" in skill
+    assert "Use only when the user explicitly invokes" in frontmatter
     assert "Do not substitute another browser tool silently" in skill
     assert "multiple targets remain plausible" in skill
     assert "clean Git worktree" in skill
+    assert "attached symbolic branch" in skill
     assert all(mode in skill for mode in ("`substantial`", "`exhaustive`", "`fixed N`"))
+    assert "applies to the active finding threshold" in skill
     assert "no iteration limit by default" in skill
     assert "one highest-value, coherent improvement theme" in skill
     assert "stop without creating an empty commit" in skill
@@ -243,11 +247,14 @@ def test_iterating_ui_improvements_is_a_devtools_commit_loop() -> None:
         "restore only the current iteration's uncommitted tracked changes"
         in normalized_skill
     )
+    assert "Do not bypass hooks with `--no-verify`" in skill
+    assert "re-inspect the index and worktree" in skill
     assert "Do not push, open a pull request" in skill
     assert "mutate remote services" in skill
     assert "commit ID" in skill and "stopping reason" in skill
     assert "$iterating-ui-improvements" in metadata
-    assert "DevTools audit-fix-commit loops" in readme
+    assert "explicitly" in metadata.lower()
+    assert "Explicitly invoked DevTools audit-fix-commit loops" in readme
 
 
 def test_designing_user_experiences_supports_new_and_existing_products() -> None:

--- a/tests/test_skill_repository.py
+++ b/tests/test_skill_repository.py
@@ -38,7 +38,7 @@ def test_deprecated_skills_are_hidden_from_standard_discovery() -> None:
 
 def test_every_skill_name_metadata_and_catalog_inventory_is_complete() -> None:
     skill_markdown = all_skill_markdown()
-    assert len(skill_markdown) == 34
+    assert len(skill_markdown) == 35
     readme = (ROOT / "README.md").read_text()
 
     for skill_md in skill_markdown:
@@ -220,6 +220,36 @@ def test_material_trigger_surfaces_are_semantically_aligned() -> None:
     assert "Design and review clear, accessible, platform-adapted" in readme
 
 
+def test_iterating_ui_improvements_is_a_devtools_commit_loop() -> None:
+    skill_dir = SKILLS / "ui-ux-design/iterating-ui-improvements"
+    skill = (skill_dir / "SKILL.md").read_text()
+    metadata = (skill_dir / "agents/openai.yaml").read_text()
+    readme = (ROOT / "README.md").read_text()
+
+    assert "Chrome DevTools" in skill
+    assert "Do not substitute another browser tool silently" in skill
+    assert "multiple targets remain plausible" in skill
+    assert "clean Git worktree" in skill
+    assert all(mode in skill for mode in ("`substantial`", "`exhaustive`", "`fixed N`"))
+    assert "no iteration limit by default" in skill
+    assert "one highest-value, coherent improvement theme" in skill
+    assert "stop without creating an empty commit" in skill
+    assert "one focused Conventional Commit" in skill
+    normalized_skill = skill.lower()
+    assert normalized_skill.index("re-verify") < normalized_skill.index(
+        "stage only the paths"
+    )
+    assert (
+        "restore only the current iteration's uncommitted tracked changes"
+        in normalized_skill
+    )
+    assert "Do not push, open a pull request" in skill
+    assert "mutate remote services" in skill
+    assert "commit ID" in skill and "stopping reason" in skill
+    assert "$iterating-ui-improvements" in metadata
+    assert "DevTools audit-fix-commit loops" in readme
+
+
 def test_designing_user_experiences_supports_new_and_existing_products() -> None:
     experience_dir = SKILLS / "ui-ux-design/designing-user-experiences"
     skill = (experience_dir / "SKILL.md").read_text()
@@ -263,7 +293,7 @@ def test_skill_bodies_avoid_repeating_trigger_and_generic_cleanup_sections() -> 
 def test_active_skills_are_grouped_one_category_deep() -> None:
     categorized = sorted(SKILLS.glob("*/*/SKILL.md"))
     assert categorized == sorted(SKILLS.glob("**/SKILL.md"))
-    assert len(categorized) == 28
+    assert len(categorized) == 29
     assert len({skill_md.parent.name for skill_md in categorized}) == len(categorized)
 
 

--- a/tests/test_skill_repository.py
+++ b/tests/test_skill_repository.py
@@ -239,6 +239,9 @@ def test_iterating_ui_improvements_is_a_devtools_commit_loop() -> None:
     assert "one highest-value, coherent improvement theme" in skill
     assert "stop without creating an empty commit" in skill
     assert "one focused Conventional Commit" in skill
+    assert "record the staged tree" in skill
+    assert "compare the committed tree" in skill
+    assert "against the committed content" in skill
     normalized_skill = skill.lower()
     assert normalized_skill.index("re-verify") < normalized_skill.index(
         "stage only the paths"
@@ -249,6 +252,11 @@ def test_iterating_ui_improvements_is_a_devtools_commit_loop() -> None:
     )
     assert "Do not bypass hooks with `--no-verify`" in skill
     assert "re-inspect the index and worktree" in skill
+    assert "recovery commit" in skill
+    assert "Before every exit" in skill
+    assert "processes started by this run" in skill
+    assert "their child watchers" in skill
+    assert "Preserve a target that was already running" in skill
     assert "Do not push, open a pull request" in skill
     assert "mutate remote services" in skill
     assert "commit ID" in skill and "stopping reason" in skill


### PR DESCRIPTION
## Summary

- add `$iterating-ui-improvements` for autonomous Chrome DevTools audit-fix-commit loops
- support substantial, exhaustive, and fixed-iteration stopping modes with no default iteration cap
- require a clean worktree, focused per-iteration validation, safe rollback, and local-only commits
- catalog the skill and add repository regression coverage

## Affected paths

- `skills/ui-ux-design/iterating-ui-improvements/SKILL.md`
- `skills/ui-ux-design/iterating-ui-improvements/agents/openai.yaml`
- `README.md`
- `tests/test_skill_repository.py`

## Verification

- `UV_CACHE_DIR=/tmp/uv-cache uv run --no-project --python 3.13 --with pyyaml python "$HOME/.codex/skills/.system/skill-creator/scripts/quick_validate.py" skills/ui-ux-design/iterating-ui-improvements` — passed
- `uv run --no-project --with pytest pytest` — 92 passed
- `prek run -a` — passed
- `git diff --check` — passed
