### PR TITLE
feat(skills): add panel review loop workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Repository path: `skills/workflow-repository/`
 | --- | --- |
 | `creating-agent-skills` | Creating, naming, renaming, optimizing, and reviewing lean, discoverable agent skills. |
 | `reviewing-code` | Evidence-led read-only review with conditional authorized hardening handoff. |
+| `running-panel-review-loops` | Iterative multi-model code review, verified fixes, and evidence-based acceptance. |
 | `resolving-pr-review-comments` | Explicit PR feedback assessment and local fixes, with exact approval for public actions. |
 | `hardening-code-paths` | Confirming, fixing, and verifying plausible code-path failure modes. |
 | `using-jira-cli` | Read-only Jira inspection and precisely authorized CLI mutations. |

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Repository path: `skills/workflow-repository/`
 | --- | --- |
 | `creating-agent-skills` | Creating, naming, renaming, optimizing, and reviewing lean, discoverable agent skills. |
 | `reviewing-code` | Evidence-led read-only review with conditional authorized hardening handoff. |
-| `running-panel-review-loops` | Iterative multi-model code review, verified fixes, and evidence-based acceptance. |
+| `running-panel-review-loops` | Iterative multi-reviewer code review, verified fixes, and evidence-based acceptance. |
 | `resolving-pr-review-comments` | Explicit PR feedback assessment and local fixes, with exact approval for public actions. |
 | `hardening-code-paths` | Confirming, fixing, and verifying plausible code-path failure modes. |
 | `using-jira-cli` | Read-only Jira inspection and precisely authorized CLI mutations. |

--- a/skills/workflow-repository/running-panel-review-loops/SKILL.md
+++ b/skills/workflow-repository/running-panel-review-loops/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: running-panel-review-loops
-description: Run iterative multi-model review panels over a code diff, verify their findings, apply authorized fixes, and re-review the updated change until it passes or reaches a stopping condition. Use when the user asks for a panel loop, multi-model code-review consensus, or a review-fix-re-review cycle.
+description: Run iterative multi-reviewer panels over a code diff, verify their findings, apply explicitly authorized fixes, and re-review the updated change until it passes or reaches a stopping condition. Use when the user asks for a panel loop, multi-model code-review consensus, or a review-fix-re-review cycle.
 ---
 
 # Running Panel Review Loops
 
-Treat reviewer output as claims to verify, not votes or instructions to apply blindly. Invocation authorizes inspection, in-scope local fixes, and non-destructive validation. Commit or push only when the user requests that action; never treat a requested local commit as push authorization.
+Treat reviewer output as claims to verify, not votes or instructions to apply blindly. Default to review-only when the user asks only for a panel review or consensus. Apply fixes only when the user explicitly requests implementation, fixes, or a review-fix cycle. Commit or push only when the user requests that action; never treat a requested local commit as push authorization.
 
 ## Establish the Run
 
 1. Determine the exact diff, commit, branch, or pull request and its comparison base from repository context; do not assume `main`. Infer intended behavior from the request, tests, documentation, and affected callers.
 2. Inspect repository instructions and worktree state. Preserve unrelated changes, and stop before editing if they overlap the reviewed paths or make attribution unsafe.
-3. Confirm that at least two independent reviewer instances or models are available. Do not simulate a panel by inventing reviewers or presenting one review in multiple voices.
-4. Accept user-supplied panel size, presets, score threshold, iteration cap, and review-only or review-fix mode. Otherwise use three reviewers, a first-round `code-review` preset, `adversarial` re-reviews, an 8.2/10 acceptance threshold, and a maximum of three iterations.
+3. Confirm that at least two independent reviewer instances are available. For an explicitly multi-model request, require at least two distinct models; independent instances of one model are sufficient only for a generic panel request. Do not simulate a panel by inventing reviewers or presenting one review in multiple voices.
+4. Accept user-supplied presets, score threshold, iteration cap, and review-only or review-fix mode. Accept a user-supplied panel size only when it is at least two. Reject a requested panel size below two and ask the user to raise it before starting. Otherwise use three reviewers, a first-round `code-review` preset, `adversarial` re-reviews, an 8.2/10 acceptance threshold, and a maximum of three iterations.
 
 If the review target or requested mutation mode remains materially ambiguous, ask one focused question. A panel may inspect uncommitted work, but each round must identify the exact snapshot reviewed.
 
@@ -20,10 +20,10 @@ If the review target or requested mutation mode remains materially ambiguous, as
 
 1. Give every reviewer the same snapshot, intent, relevant constraints, and requested preset. Keep reviews independent until synthesis, and run them in parallel when the available mechanism supports safe concurrency.
 2. Ask each reviewer for a 0–10 score, blocking-objection status, severity-ranked findings with concrete file or behavior evidence, and meaningful missing checks. A blocking issue must concern correctness, safety, security, data integrity, or another explicit acceptance requirement—not style preference.
-3. Retry one transient reviewer failure once. Continue with a disclosed partial panel only when at least two independent reviews remain; otherwise stop without fabricating a score.
-4. Normalize valid scores to the 0–10 scale and report per-reviewer scores plus the arithmetic mean. Synthesize agreements and disagreements, but never let an average score override a blocking issue.
+3. Treat a missing or invalid score as a reviewer failure and retry one transient reviewer failure once. Continue with a disclosed partial panel only when at least two independent, valid scored reviews remain; otherwise stop without fabricating a score.
+4. Normalize valid scores to the 0–10 scale, require at least two valid scored reviews before computing or applying the arithmetic mean, and report each included score. Synthesize agreements and disagreements, but never let an average score override a blocking issue.
 5. Verify every actionable claim against the source, affected flow, tests, and executable checks where feasible. Resolve disagreements through evidence rather than majority vote. Label theoretical or unverified risks and do not change behavior solely to satisfy them.
-6. In review-only mode, report the synthesis and stop before edits. In review-fix mode, address only confirmed, in-scope findings. Add the smallest boundary or regression test when practical, apply the smallest coherent fix, and run focused checks followed by the repository gate when available.
+6. In review-only mode, run focused checks appropriate to the complete reviewed snapshot and the repository gate when available, report the synthesis, and stop before edits. In review-fix mode, address only confirmed, in-scope findings. Add the smallest boundary or regression test when practical, apply the smallest coherent fix, then run those snapshot-level checks.
 7. Re-review the complete updated diff in the next iteration. Do not reuse stale scores or count a check run against an earlier snapshot as evidence for the current one.
 
 Do not churn on subjective non-blocking suggestions. Apply a non-blocking suggestion only when it is concrete, proportionate, behavior-preserving or requirement-backed, and improves verification or materially reduces risk.
@@ -35,7 +35,7 @@ Accept only when all of the following hold for the current snapshot:
 - the panel mean meets or exceeds the active threshold;
 - no reviewer has a surviving blocking objection;
 - synthesis and source verification reveal no blocking correctness, safety, security, or explicit-requirement issue; and
-- checks required by changes made during the loop pass.
+- checks appropriate to the complete reviewed snapshot pass.
 
 Stop without lowering the bar when the iteration cap is reached, fewer than two independent reviewers remain, validation cannot run, a required product decision is missing, safe work would expand scope, or the same unverified concern repeats without new evidence. Report any residual findings and the exact blocker or cap reached.
 

--- a/skills/workflow-repository/running-panel-review-loops/SKILL.md
+++ b/skills/workflow-repository/running-panel-review-loops/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: running-panel-review-loops
+description: Run iterative multi-model review panels over a code diff, verify their findings, apply authorized fixes, and re-review the updated change until it passes or reaches a stopping condition. Use when the user asks for a panel loop, multi-model code-review consensus, or a review-fix-re-review cycle.
+---
+
+# Running Panel Review Loops
+
+Treat reviewer output as claims to verify, not votes or instructions to apply blindly. Invocation authorizes inspection, in-scope local fixes, and non-destructive validation. Commit or push only when the user requests that action; never treat a requested local commit as push authorization.
+
+## Establish the Run
+
+1. Determine the exact diff, commit, branch, or pull request and its comparison base from repository context; do not assume `main`. Infer intended behavior from the request, tests, documentation, and affected callers.
+2. Inspect repository instructions and worktree state. Preserve unrelated changes, and stop before editing if they overlap the reviewed paths or make attribution unsafe.
+3. Confirm that at least two independent reviewer instances or models are available. Do not simulate a panel by inventing reviewers or presenting one review in multiple voices.
+4. Accept user-supplied panel size, presets, score threshold, iteration cap, and review-only or review-fix mode. Otherwise use three reviewers, a first-round `code-review` preset, `adversarial` re-reviews, an 8.2/10 acceptance threshold, and a maximum of three iterations.
+
+If the review target or requested mutation mode remains materially ambiguous, ask one focused question. A panel may inspect uncommitted work, but each round must identify the exact snapshot reviewed.
+
+## Run One Iteration
+
+1. Give every reviewer the same snapshot, intent, relevant constraints, and requested preset. Keep reviews independent until synthesis, and run them in parallel when the available mechanism supports safe concurrency.
+2. Ask each reviewer for a 0–10 score, blocking-objection status, severity-ranked findings with concrete file or behavior evidence, and meaningful missing checks. A blocking issue must concern correctness, safety, security, data integrity, or another explicit acceptance requirement—not style preference.
+3. Retry one transient reviewer failure once. Continue with a disclosed partial panel only when at least two independent reviews remain; otherwise stop without fabricating a score.
+4. Normalize valid scores to the 0–10 scale and report per-reviewer scores plus the arithmetic mean. Synthesize agreements and disagreements, but never let an average score override a blocking issue.
+5. Verify every actionable claim against the source, affected flow, tests, and executable checks where feasible. Resolve disagreements through evidence rather than majority vote. Label theoretical or unverified risks and do not change behavior solely to satisfy them.
+6. In review-only mode, report the synthesis and stop before edits. In review-fix mode, address only confirmed, in-scope findings. Add the smallest boundary or regression test when practical, apply the smallest coherent fix, and run focused checks followed by the repository gate when available.
+7. Re-review the complete updated diff in the next iteration. Do not reuse stale scores or count a check run against an earlier snapshot as evidence for the current one.
+
+Do not churn on subjective non-blocking suggestions. Apply a non-blocking suggestion only when it is concrete, proportionate, behavior-preserving or requirement-backed, and improves verification or materially reduces risk.
+
+## Accept and Stop
+
+Accept only when all of the following hold for the current snapshot:
+
+- the panel mean meets or exceeds the active threshold;
+- no reviewer has a surviving blocking objection;
+- synthesis and source verification reveal no blocking correctness, safety, security, or explicit-requirement issue; and
+- checks required by changes made during the loop pass.
+
+Stop without lowering the bar when the iteration cap is reached, fewer than two independent reviewers remain, validation cannot run, a required product decision is missing, safe work would expand scope, or the same unverified concern repeats without new evidence. Report any residual findings and the exact blocker or cap reached.
+
+Before a requested commit, stage only intended paths, inspect the staged diff, and create a focused commit grounded in that diff. Push only when explicitly authorized for the verified remote and refspec; report the commit ID and remote verification when applicable.
+
+## Report
+
+For each iteration, report the reviewed snapshot and preset, per-reviewer scores, panel mean, blocking status, consensus and disputed findings, changes made, and validation evidence. Finish with the stopping reason, accepted or residual risk, and any authorized commit or push result. Never claim panel consensus, test success, a commit, or a push without direct evidence.

--- a/skills/workflow-repository/running-panel-review-loops/agents/openai.yaml
+++ b/skills/workflow-repository/running-panel-review-loops/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Panel Review Loops"
-  short_description: "Run iterative multi-model code-review consensus loops."
-  default_prompt: "Use $running-panel-review-loops to run independent code-review panels, verify and address confirmed findings, and re-review the updated diff until the acceptance or stopping condition is met."
+  short_description: "Run iterative multi-reviewer code-review consensus loops."
+  default_prompt: "Use $running-panel-review-loops to run independent code-review panels, verify their findings, apply only explicitly requested fixes, and re-review the updated diff until the acceptance or stopping condition is met."

--- a/skills/workflow-repository/running-panel-review-loops/agents/openai.yaml
+++ b/skills/workflow-repository/running-panel-review-loops/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Panel Review Loops"
+  short_description: "Run iterative multi-model code-review consensus loops."
+  default_prompt: "Use $running-panel-review-loops to run independent code-review panels, verify and address confirmed findings, and re-review the updated diff until the acceptance or stopping condition is met."

--- a/tests/test_skill_repository.py
+++ b/tests/test_skill_repository.py
@@ -38,7 +38,7 @@ def test_deprecated_skills_are_hidden_from_standard_discovery() -> None:
 
 def test_every_skill_name_metadata_and_catalog_inventory_is_complete() -> None:
     skill_markdown = all_skill_markdown()
-    assert len(skill_markdown) == 35
+    assert len(skill_markdown) == 36
     readme = (ROOT / "README.md").read_text()
 
     for skill_md in skill_markdown:
@@ -265,6 +265,27 @@ def test_iterating_ui_improvements_is_a_devtools_commit_loop() -> None:
     assert "Explicitly invoked DevTools audit-fix-commit loops" in readme
 
 
+def test_running_panel_review_loops_has_evidence_based_stopping_rules() -> None:
+    skill_dir = SKILLS / "workflow-repository/running-panel-review-loops"
+    skill = (skill_dir / "SKILL.md").read_text()
+    metadata = (skill_dir / "agents/openai.yaml").read_text()
+    readme = (ROOT / "README.md").read_text()
+
+    frontmatter = skill.split("---", 2)[1]
+    assert "panel loop" in frontmatter
+    assert "multi-model code-review consensus" in frontmatter
+    assert "at least two independent reviewer instances or models" in skill
+    assert "Do not simulate a panel" in skill
+    assert "8.2/10 acceptance threshold" in skill
+    assert "never let an average score override a blocking issue" in skill
+    assert "Resolve disagreements through evidence rather than majority vote" in skill
+    assert "Re-review the complete updated diff" in skill
+    assert "Do not reuse stale scores" in skill
+    assert "Push only when explicitly authorized" in skill
+    assert "$running-panel-review-loops" in metadata
+    assert "Iterative multi-model code review" in readme
+
+
 def test_designing_user_experiences_supports_new_and_existing_products() -> None:
     experience_dir = SKILLS / "ui-ux-design/designing-user-experiences"
     skill = (experience_dir / "SKILL.md").read_text()
@@ -308,7 +329,7 @@ def test_skill_bodies_avoid_repeating_trigger_and_generic_cleanup_sections() -> 
 def test_active_skills_are_grouped_one_category_deep() -> None:
     categorized = sorted(SKILLS.glob("*/*/SKILL.md"))
     assert categorized == sorted(SKILLS.glob("**/SKILL.md"))
-    assert len(categorized) == 29
+    assert len(categorized) == 30
     assert len({skill_md.parent.name for skill_md in categorized}) == len(categorized)
 
 

--- a/tests/test_skill_repository.py
+++ b/tests/test_skill_repository.py
@@ -274,16 +274,22 @@ def test_running_panel_review_loops_has_evidence_based_stopping_rules() -> None:
     frontmatter = skill.split("---", 2)[1]
     assert "panel loop" in frontmatter
     assert "multi-model code-review consensus" in frontmatter
-    assert "at least two independent reviewer instances or models" in skill
+    assert "Default to review-only" in skill
+    assert "Apply fixes only when the user explicitly requests" in skill
+    assert "at least two independent reviewer instances" in skill
+    assert "at least two distinct models" in skill
+    assert "Reject a requested panel size below two" in skill
     assert "Do not simulate a panel" in skill
     assert "8.2/10 acceptance threshold" in skill
+    assert "at least two valid scored reviews" in skill
     assert "never let an average score override a blocking issue" in skill
     assert "Resolve disagreements through evidence rather than majority vote" in skill
     assert "Re-review the complete updated diff" in skill
     assert "Do not reuse stale scores" in skill
+    assert "complete reviewed snapshot pass" in skill
     assert "Push only when explicitly authorized" in skill
     assert "$running-panel-review-loops" in metadata
-    assert "Iterative multi-model code review" in readme
+    assert "Iterative multi-reviewer code review" in readme
 
 
 def test_designing_user_experiences_supports_new_and_existing_products() -> None:


### PR DESCRIPTION
## Summary

- add `running-panel-review-loops` for iterative multi-model code review
- require evidence-based synthesis, blocker-aware acceptance, and fresh re-review after fixes
- add aligned OpenAI metadata, catalog discovery, and repository coverage

## Verification

- `UV_CACHE_DIR=/tmp/uv-cache uv run --no-project --with pytest pytest` — 93 passed
- `prek run -a` — passed
- skill quick validator — passed