### PR TITLE
refactor(skills): consolidate edge-case hardening guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Repository path: `skills/workflow-repository/`
 | Skill | Use it for |
 | --- | --- |
 | `creating-agent-skills` | Creating, naming, renaming, optimizing, and reviewing lean, discoverable agent skills. |
-| `reviewing-code` | Evidence-led read-only review with conditional authorized hardening handoff. |
+| `reviewing-code` | Evidence-led read-only review, including edge-case audits and PR preflight, with authorized hardening handoff. |
 | `running-panel-review-loops` | Iterative multi-reviewer code review, verified fixes, and evidence-based acceptance. |
 | `resolving-pr-review-comments` | Explicit PR feedback assessment and local fixes, with exact approval for public actions. |
 | `hardening-code-paths` | Confirming, fixing, and verifying plausible code-path failure modes. |

--- a/skills/workflow-repository/hardening-code-paths/SKILL.md
+++ b/skills/workflow-repository/hardening-code-paths/SKILL.md
@@ -14,26 +14,15 @@ When the user does not provide files, a commit, or a diff, inspect `git status -
 ## Loop
 
 1. Infer intended behavior from the user request, code, tests, docs, and sibling flows; state assumptions, but only ask when the rule is ambiguous.
-2. Trace the real flow end to end, including callers, sibling routes, cleanup paths, and stored state.
-3. Proactively inspect plausible edge cases for that flow; skip generic checklists that cannot occur.
-4. Establish that each candidate violates intended behavior, then add the smallest regression test or executable check that fails before the fix when practical. If the failure cannot be verified, report the risk as unverified instead of changing behavior.
-5. Fix or harden each confirmed bug at the shared root path, not only the reported symptom.
-6. Run the narrow check, then scan sibling callers/routes for the same pattern.
-7. Repeat while each fix exposes a concrete adjacent edge case.
-8. Run the repo's normal verification gate before final response.
-
-## Edge-Case Families
-
-Consider these only when relevant:
-
-- empty, single, duplicate, huge, unsorted, missing, null, undefined, NaN, malformed, or wrong-type inputs
-- inclusive/exclusive bounds, off-by-one behavior, overflow, divide-by-zero, and precision loss
-- trust boundaries: HTTP, WebSocket, CLI args, files, environment, database rows, external APIs
-- path containment, authz/authn, tenant ownership, unsafe deserialization, and sensitive logging
-- stale state, reconnect/disconnect, cancellation, retries, idempotency, races, and partial failure
-- timeout, cleanup, file handles, sockets, locks, transactions, subscriptions, and memory growth
-- time zones, DST, clock skew, expiry windows, ordering assumptions, and eventual consistency
-- response shape, schema migration, backward compatibility, packaging/runtime/config mismatches
+2. Trace the real flow end to end, including callers, sibling routes, cleanup paths, stored state, and representation changes.
+3. Load [the edge-case checklist](references/edge-case-checklist.md) and select only domains reachable in this flow.
+4. Build a bounded risk matrix across the few dimensions most likely to interact: representative inputs, operations, before/during/after states, lifecycle events, and representations. Prioritize security, data loss, corruption, hangs, and broken core behavior; avoid exhaustive Cartesian products and unsupported platform speculation.
+5. Establish that each candidate violates intended behavior, then add the smallest regression test or executable check that fails before the fix when practical. If the failure cannot be verified, report the risk as unverified instead of changing behavior.
+6. Fix or harden each confirmed bug at the shared root path, not only the reported symptom.
+7. Run the narrow check, then scan sibling callers/routes for the same pattern.
+8. Perform one fresh pass over the resulting diff for opposite bounds, equivalent encodings, stale or cancelled state at asynchronous boundaries, cleanup, and whether the regression test would fail if the bug returned.
+9. Repeat only while the fix exposes a concrete adjacent case in the same failure class; stop before materially different behavior or scope.
+10. Run the repo's normal verification gate before final response.
 
 ## Fix Rules
 

--- a/skills/workflow-repository/hardening-code-paths/references/edge-case-checklist.md
+++ b/skills/workflow-repository/hardening-code-paths/references/edge-case-checklist.md
@@ -1,0 +1,75 @@
+# Edge-case checklist
+
+Use this as a prompt library, not a requirement to test every item. Select domains supported by the change.
+
+## Inputs and representation
+
+- Empty, singleton, maximum-size, malformed, duplicate, unsorted, missing, null, undefined, NaN, wrong-type, and partially valid input
+- Leading/trailing whitespace, blank lines, mixed newline forms, and embedded NUL/control bytes
+- Equivalent delimiter forms, nesting, escaping, quoting, casing, and normalization
+- UTF-8 byte limits versus code units, code points, grapheme clusters, and display cells
+- Combining marks, variation selectors, emoji modifiers, ZWJ sequences, CJK, and invalid byte sequences
+- Lossy parse/serialize/parse or normalize/store/read round trips
+
+## Ranges and collections
+
+- Start/end boundaries, reversed endpoints, zero-length ranges, and one-past-the-end positions
+- Cross-line or cross-record selections, especially an endpoint at the next item's start
+- Inclusive versus half-open semantics and separators that belong between items
+- Overflow, underflow, divide-by-zero, precision loss, and invalid numeric conversions
+- Empty collections, duplicate identities, unstable ordering, and mutation during iteration
+- Clamping after the underlying collection shrinks or changes
+
+## State and UI
+
+- Every action in initial, active, completed, failed, and cancelled states
+- Back versus close, cancel versus confirm, retry versus duplicate submission
+- Mode switches with an existing selection, draft, cursor, or pending operation
+- Configured keybindings, focus ownership, narrow viewports, resize, and scroll anchoring
+- Raw source position versus wrapped rows; cursor visibility by terminal-cell width
+- Preservation of drafts, expanded paste content, and edits made while dialogs are open
+
+## Async and lifecycle
+
+- Cancellation before start, while waiting, after side effects, and during cleanup
+- State captured before `await` and changed before continuation resumes
+- Concurrent updates, lost writes, duplicate callbacks, retries, reconnects, disconnects, and out-of-order completion
+- Session, component, request, or generation replacement while work is in flight
+- Teardown after partial initialization and cleanup when one disposer fails
+- Timeouts where descendants, file handles, sockets, locks, transactions, subscriptions, or inherited streams outlive their owner
+- Memory or retained-state growth across retries, replacements, and long-lived sessions
+
+## Files, processes, network, and trust boundaries
+
+- HTTP, WebSocket, CLI, file, environment, database, and external-API inputs validated at the boundary
+- Authentication, authorization, tenant ownership, unsafe deserialization, and sensitive logging
+- Absolute paths, `..`, symlink escapes/swaps, broken links, and containment after realpath
+- File identity changes between validation and use; bounded reads and partial writes
+- Argument boundaries, shell expansion, environment/config helpers, and terminal injection
+- Partial protocol messages, malformed success responses, truncation, and retry classification
+- Idempotency when a response is lost; only settled work may be evicted from deduplication state
+- Secret redaction in errors, logs, diagnostics, and persisted state
+
+## Time, consistency, and compatibility
+
+- Time zones, DST transitions, clock skew, expiry boundaries, and wall-clock versus monotonic time
+- Ordering assumptions, eventual consistency, stale reads, and partial failure across stores or services
+- Response-shape and schema evolution, backward compatibility, and mixed-version readers or writers
+- Packaging, runtime, platform, architecture, and configuration mismatches
+
+## Framing and trust boundaries
+
+- User-controlled opening and closing delimiters, including whitespace and nested variants
+- Content crossing from display-only text into prompts, markup, terminals, shells, or URLs
+- Escaping at the final sink rather than assuming an earlier representation remains safe
+- Role, provenance, and trust labels preserved through concatenation and serialization
+- Untrusted content unable to terminate, reopen, or append outside its intended frame
+
+## Test quality
+
+- Regression fails on the unfixed code for the claimed reason
+- Assertion captures the contract rather than the current implementation shape
+- Both directions or symmetric boundaries are covered where behavior is directional
+- Representative Unicode and control cases are literal enough to explain the invariant
+- Deterministic tests replace timing guesses; concurrency tests control ordering explicitly
+- A nearby equivalent variant would not bypass the fix

--- a/skills/workflow-repository/reviewing-code/SKILL.md
+++ b/skills/workflow-repository/reviewing-code/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reviewing-code
-description: Review diffs, pull requests, commits, patches, or source files for correctness, security, performance, maintainability, tests, and integration risk. Use for read-only review; when fixes are also requested, hand confirmed failure-mode findings to hardening-code-paths when available.
+description: Review diffs, pull requests, commits, patches, or source files for correctness, security, performance, maintainability, tests, and integration risk. Use for read-only review, including edge-case audits, PR preflight, and reviewer simulation; when fixes are also requested, hand confirmed failure-mode findings to hardening-code-paths when available.
 ---
 
 # Reviewing Code

--- a/skills/workflow-repository/reviewing-code/agents/openai.yaml
+++ b/skills/workflow-repository/reviewing-code/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Code Review"
-  short_description: "Review changes for concrete correctness and risk."
-  default_prompt: "Use $reviewing-code to review the requested change, lead with verified findings, and distinguish residual risk from confirmed defects."
+  short_description: "Review changes, edge cases, and integration risks."
+  default_prompt: "Use $reviewing-code to review the requested change or run a read-only edge-case preflight, lead with verified findings, and distinguish residual risk from confirmed defects."


### PR DESCRIPTION
## Summary

- consolidate edge-case hardening into `hardening-code-paths` instead of adding an overlapping standalone skill
- add a reusable edge-case checklist and bounded risk-matrix / fresh-pass guidance
- keep read-only edge-case audits and PR preflight under `reviewing-code`, with aligned catalog and OpenAI metadata

## Affected paths

- `skills/workflow-repository/hardening-code-paths/`
- `skills/workflow-repository/reviewing-code/`
- `README.md`

## Verification

- `UV_CACHE_DIR=/tmp/uv-cache uv run --no-project --with pytest pytest` — 93 passed
- `prek run -a` — passed
- `quick_validate.py skills/workflow-repository/hardening-code-paths` — valid
- `quick_validate.py skills/workflow-repository/reviewing-code` — valid
- confirmed `skills/workflow-repository/reviewing-edge-cases/` and exact-name references are absent
