### PR TITLE
feat(skills): track repository conventions in memory

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -6,7 +6,6 @@
 - In this sandbox, `~/.cache/uv` may be read-only; when running one-off `uv run --with ...` tools, set `UV_CACHE_DIR=/tmp/uv-cache` first for more reliable behavior.
 - In this sandbox, the first run of skill metadata tools like `uv run --with pyyaml` may still need temporary network access if the local cache does not already contain the package, so `uv` can fetch `PyYAML`.
 - IMRaD now only lives under `skills/writing-research/applying-imrad/`; there are no remaining `imrad-*` legacy skill names in the repo to update.
-- Root document ownership is fixed as `README.md` for external-facing docs and `AGENTS.md` for maintainer-facing docs; standard skill installation uses `npx skills add`, while `justfile` contains repository maintenance recipes only.
 - `atuin search --delete` deletes every history row matching the query under the active search semantics; do not treat preview uniqueness or local substring counts as proof of single-row safety.
 - `atuin search -i` can panic inside Codex's filesystem sandbox because Atuin fails to create its log file on a read-only path; run interactive inspector deletions with escalated permissions.
 - For Atuin cleanup automation, snapshot `history.db` with SQLite's backup API instead of a raw file copy so live-database state and WAL pages stay consistent.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -16,4 +16,6 @@
 - Prefer preserving a skill's original user intent when naming or renaming skills; do not force `<verb-ing>-<object>` if it changes the meaning.
 - Prefer retaining explicit-invocation skills that act as useful mode shortcuts even when the model can infer the behavior; specifically keep `explaining-step-by-step` for requesting progressive explanations.
 - `writing-git-commits` should rely on the repo-level `AGENTS.md` for the Git baseline; `SKILL.md` should keep only the flow and judgment from diff to commit message, while less common Conventional Commits details belong in `references/`.
-- `maintaining-memory-md` should check at conversation start without creating `MEMORY.md` merely because it is missing; when the first qualifying `GOTCHA` or durable `TASTE` emerges, it should create the repository-root file without extra confirmation and revise stale or similar entries in place.
+- `maintaining-memory-md` should check at conversation start without creating `MEMORY.md` merely because it is missing; when the first qualifying `GOTCHA`, durable `TASTE`, or evidence-backed entry under `CONVENTIONS` emerges, it should create the repository-root file without extra confirmation and revise stale or similar entries in place.
+
+## CONVENTIONS

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Repository path: `skills/workflow-repository/`
 | `writing-git-commits` | Drafting, validating, or creating focused Conventional Commits from diffs. |
 | `syncing-main-branch` | Explicit, state-preserving switch to `main` and fast-forward-only update. |
 | `managing-git-worktrees` | Loss-aware worktree creation, repair, removal, pruning, and branch cleanup. |
-| `maintaining-memory-md` | Reads and maintains verified, concise repository gotchas and preferences. |
+| `maintaining-memory-md` | Reads and maintains verified, concise repository gotchas, preferences, and conventions. |
 | `writing-agents-md` | Creating or reviewing lean, scoped, evidence-backed `AGENTS.md` guidance. |
 
 ## 🗄️ Deprecated Skills

--- a/skills/workflow-repository/maintaining-memory-md/SKILL.md
+++ b/skills/workflow-repository/maintaining-memory-md/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: maintaining-memory-md
-description: Read and maintain concise repository-root MEMORY.md notes for verified gotchas and durable user preferences. Use at repository-conversation start, when MEMORY.md is mentioned or may be stale, or when a qualifying memory emerges.
+description: Read and maintain concise repository-root MEMORY.md notes for verified gotchas, durable user preferences, and established repository conventions. Use at repository-conversation start, when MEMORY.md is mentioned or may be stale, or when a qualifying memory emerges.
 ---
 
 # Maintaining MEMORY.md
@@ -11,8 +11,9 @@ Resolve the repository root and inspect `MEMORY.md` at the start of repository w
 
 - **GOTCHA:** repository evidence proves a reusable trap or failure mode and its cause, recovery, or avoidance is known.
 - **TASTE:** the user expresses a durable preference that will change future repository work.
+- **CONVENTIONS:** repository evidence proves a stable, repository-specific pattern in code, structure, naming, testing, or workflow that will change future work.
 
-Do not record transient status, task history, broad summaries, speculation, or secrets. Sanitize any reusable lesson involving credentials, tokens, private endpoints, proprietary data, or personal information.
+Do not record transient status, task history, broad summaries, speculation, generic best practices, or secrets. Do not duplicate conventions already stated in `AGENTS.md` or authoritative documentation. If a convention should govern all contributors, update its authoritative owner instead of `MEMORY.md`. Sanitize any reusable lesson involving credentials, tokens, private endpoints, proprietary data, or personal information.
 
 ## Create or Update
 
@@ -24,6 +25,8 @@ Do not record transient status, task history, broad summaries, speculation, or s
 ## GOTCHA
 
 ## TASTE
+
+## CONVENTIONS
 ```
 
 - Add one concise bullet under the matching section. Revise a similar, stale, wrong, or contradicted entry instead of appending a duplicate.
@@ -32,6 +35,7 @@ Do not record transient status, task history, broad summaries, speculation, or s
 ```markdown
 - Symptom: <failure>. Cause: <reason>. Fix: <future action>.
 - Prefer <choice> when <context>; avoid <alternative> because <reason>.
+- Use <pattern> for <context>; repository evidence: <concise evidence>.
 ```
 
-After editing, reread the file to verify both headings, placement, deduplication, and absence of sensitive or task-log content. Report the entry created or revised; do not claim memory was updated when writes were unavailable.
+After editing, reread the file to verify all three headings, placement, deduplication, and absence of sensitive or task-log content. Report the entry created or revised; do not claim memory was updated when writes were unavailable.

--- a/skills/workflow-repository/maintaining-memory-md/SKILL.md
+++ b/skills/workflow-repository/maintaining-memory-md/SKILL.md
@@ -13,7 +13,7 @@ Resolve the repository root and inspect `MEMORY.md` at the start of repository w
 - **TASTE:** the user expresses a durable preference that will change future repository work.
 - **CONVENTIONS:** repository evidence proves a stable, repository-specific pattern in code, structure, naming, testing, or workflow that will change future work.
 
-Do not record transient status, task history, broad summaries, speculation, generic best practices, or secrets. Do not duplicate conventions already stated in `AGENTS.md` or authoritative documentation. If a convention should govern all contributors, update its authoritative owner instead of `MEMORY.md`. Sanitize any reusable lesson involving credentials, tokens, private endpoints, proprietary data, or personal information.
+Do not record transient status, task history, broad summaries, speculation, generic best practices, or secrets. Do not duplicate conventions already stated in `AGENTS.md` or authoritative documentation. If a convention should govern all contributors, recommend updating its authoritative owner unless that file is already within the user's requested scope; do not record it in `MEMORY.md`. Sanitize any reusable lesson involving credentials, tokens, private endpoints, proprietary data, or personal information.
 
 ## Create or Update
 

--- a/skills/workflow-repository/maintaining-memory-md/agents/openai.yaml
+++ b/skills/workflow-repository/maintaining-memory-md/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "MEMORY.md Keeper"
-  short_description: "Maintain verified repository gotchas and preferences."
-  default_prompt: "Use $maintaining-memory-md to read repository memory and create or revise only a qualifying, concise, sanitized GOTCHA or TASTE entry."
+  short_description: "Maintain verified gotchas, preferences, and conventions."
+  default_prompt: "Use $maintaining-memory-md to read repository memory and create or revise only a qualifying, concise, sanitized entry under GOTCHA, TASTE, or CONVENTIONS."


### PR DESCRIPTION
## Summary

- add `CONVENTIONS` as a qualifying `MEMORY.md` entry category
- guard against duplicating authoritative repository guidance
- align the skill metadata and README catalog with the expanded purpose
- update the repository memory template to include all three required sections

## Affected paths

- `MEMORY.md`
- `README.md`
- `skills/workflow-repository/maintaining-memory-md/SKILL.md`
- `skills/workflow-repository/maintaining-memory-md/agents/openai.yaml`

## Verification

- `UV_CACHE_DIR=/tmp/uv-cache uv run --no-project --with pytest pytest` — 93 passed
- `prek run -a` — passed
