### PR TITLE
feat(skills): add agent skill scoring rubric

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Repository path: `skills/workflow-repository/`
 | Skill | Use it for |
 | --- | --- |
 | `creating-agent-skills` | Creating, naming, renaming, optimizing, and reviewing lean, discoverable agent skills. |
+| `scoring-agent-skills` | Scoring or comparing agent skills with a consistent evidence-based quality rubric. |
 | `reviewing-code` | Evidence-led read-only review, including edge-case audits and PR preflight, with authorized hardening handoff. |
 | `running-panel-review-loops` | Iterative multi-reviewer code review, verified fixes, and evidence-based acceptance. |
 | `resolving-pr-review-comments` | Explicit PR feedback assessment and local fixes, with exact approval for public actions. |

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Repository path: `skills/workflow-repository/`
 | Skill | Use it for |
 | --- | --- |
 | `creating-agent-skills` | Creating, naming, renaming, optimizing, and reviewing lean, discoverable agent skills. |
-| `scoring-agent-skills` | Scoring or comparing agent skills with a consistent evidence-based quality rubric. |
+| `scoring-agent-skills` | Scoring or comparing agent skills numerically with a consistent evidence-based quality rubric. |
 | `reviewing-code` | Evidence-led read-only review, including edge-case audits and PR preflight, with authorized hardening handoff. |
 | `running-panel-review-loops` | Iterative multi-reviewer code review, verified fixes, and evidence-based acceptance. |
 | `resolving-pr-review-comments` | Explicit PR feedback assessment and local fixes, with exact approval for public actions. |

--- a/skills/workflow-repository/scoring-agent-skills/SKILL.md
+++ b/skills/workflow-repository/scoring-agent-skills/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: scoring-agent-skills
+description: Score or compare one or more agent skills across trigger clarity, workflow actionability, safety boundaries, verification rigor, and leanness using a consistent evidence-based rubric. Use for skill ratings, quality scorecards, catalog comparisons, or prioritizing skill improvements.
+---
+
+# Scoring Agent Skills
+
+Produce a comparable quality scorecard, not a vague impression or a runtime capability claim.
+
+## Scope and Evidence
+
+1. Resolve the requested skill set. For “every skill,” use the repository's active discovery tree unless the user explicitly includes deprecated or external skills.
+2. Inspect applicable repository instructions, the model-specific prompting guide, each `SKILL.md`, UI metadata, catalog entry, and directly linked resources relevant to a score. Run repository validators when feasible.
+3. Treat structural checks, link integrity, metadata presence, and test results as supporting evidence. They do not by themselves prove prompt quality or task success.
+4. Read `references/rubric.md` and assign an integer from 1 to 10 for each dimension. Apply the same anchors to every skill and assess safety and verification proportionately to what the skill can do.
+5. Support each score with direct evidence from the inspected surfaces. Revisit conspicuous outliers after the first pass so differences reflect the rubric rather than category or ordering bias.
+
+## Calculate and Report
+
+Use equal weight for all five dimensions. Compute the overall score as their arithmetic mean and show one decimal place; do not add hidden bonuses or penalties.
+
+Return in the user's language unless requested otherwise:
+
+1. The rubric and scope, including whether the assessment is static or includes runtime evaluations.
+2. A table with skill name, all five dimension scores, overall score, and one concise evidence-based note. Group by repository category when the list is long.
+3. Verification evidence such as validators, tests, metadata inventory, or broken-link checks, clearly separated from qualitative scoring.
+4. A short synthesis covering strongest dimensions, material weaknesses, and the highest-value improvement priorities.
+
+State that a source-and-structure-only review is not a runtime effectiveness benchmark. Do not imply measured success rates, model compatibility, accessibility, safety, or tool reliability unless representative evaluations directly established them.
+
+## Judgment Rules
+
+- Score the artifact that exists, not the likely intent or the reputation of its domain.
+- Do not reward length, resource count, strictness, or passing tests automatically; reward justified guidance that improves correct task completion.
+- Do not penalize a simple read-only skill for lacking destructive-operation policy it cannot need.
+- Penalize material trigger collisions, contradictory instructions, unjustified approval gates, unverifiable completion claims, repeated content, stale references, and missing stopping conditions in the relevant dimensions.
+- Label missing or inaccessible evidence and lower only the dimensions it prevents assessing confidently.
+- Preserve meaningful score differences. Do not force a ranking or curve, and do not inflate all scores because repository-wide checks pass.
+
+This skill scores and recommends; it does not authorize editing the assessed skills unless the user also requests changes.

--- a/skills/workflow-repository/scoring-agent-skills/SKILL.md
+++ b/skills/workflow-repository/scoring-agent-skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scoring-agent-skills
-description: Score or compare one or more agent skills across trigger clarity, workflow actionability, safety boundaries, verification rigor, and leanness using a consistent evidence-based rubric. Use for skill ratings, quality scorecards, catalog comparisons, or prioritizing skill improvements.
+description: Score or compare one or more agent skills across trigger clarity, workflow actionability, safety boundaries, verification rigor, and leanness. Use only when the user explicitly asks for ratings, numerical quality scores, rubric-based scorecards, or scored comparisons; use creating-agent-skills for unscored reviews or revisions.
 ---
 
 # Scoring Agent Skills
@@ -10,14 +10,15 @@ Produce a comparable quality scorecard, not a vague impression or a runtime capa
 ## Scope and Evidence
 
 1. Resolve the requested skill set. For “every skill,” use the repository's active discovery tree unless the user explicitly includes deprecated or external skills.
-2. Inspect applicable repository instructions, the model-specific prompting guide, each `SKILL.md`, UI metadata, catalog entry, and directly linked resources relevant to a score. Run repository validators when feasible.
-3. Treat structural checks, link integrity, metadata presence, and test results as supporting evidence. They do not by themselves prove prompt quality or task success.
-4. Read `references/rubric.md` and assign an integer from 1 to 10 for each dimension. Apply the same anchors to every skill and assess safety and verification proportionately to what the skill can do.
-5. Support each score with direct evidence from the inspected surfaces. Revisit conspicuous outliers after the first pass so differences reflect the rubric rather than category or ordering bias.
+2. Inspect applicable repository instructions, the model-specific prompting guide, each `SKILL.md`, UI metadata, catalog entry, and directly linked resources relevant to a score.
+3. For the trusted current repository, run its established non-destructive validators when feasible. For an external or untrusted repository, default to source inspection or a trusted validator. Do not run repository-supplied code unless it is sandboxed and the user explicitly authorizes the exact command.
+4. Treat structural checks, link integrity, metadata presence, and test results as supporting evidence. They do not by themselves prove prompt quality or task success.
+5. Read `references/rubric.md` and assign an integer from 1 to 10 for each assessable dimension. Apply the same anchors to every skill and assess safety and verification proportionately to what the skill can do.
+6. Support each score with direct evidence from the inspected surfaces. Revisit conspicuous outliers after the first pass so differences reflect the rubric rather than category or ordering bias.
 
 ## Calculate and Report
 
-Use equal weight for all five dimensions. Compute the overall score as their arithmetic mean and show one decimal place; do not add hidden bonuses or penalties.
+Use equal weight for all assessed dimensions. When all five are assessed, compute the overall score as their arithmetic mean and show one decimal place. If environment-specific inaccessible evidence prevents a defensible dimension score, mark that dimension unassessed, exclude it from the aggregate, and report score coverage and confidence; do not add hidden bonuses or penalties.
 
 Return in the user's language unless requested otherwise:
 
@@ -34,7 +35,7 @@ State that a source-and-structure-only review is not a runtime effectiveness ben
 - Do not reward length, resource count, strictness, or passing tests automatically; reward justified guidance that improves correct task completion.
 - Do not penalize a simple read-only skill for lacking destructive-operation policy it cannot need.
 - Penalize material trigger collisions, contradictory instructions, unjustified approval gates, unverifiable completion claims, repeated content, stale references, and missing stopping conditions in the relevant dimensions.
-- Label missing or inaccessible evidence and lower only the dimensions it prevents assessing confidently.
+- Lower a score for confirmed missing required evidence in the artifact. For inaccessible evidence caused by the review environment, mark the materially affected dimension unassessed rather than treating uncertainty as an artifact defect.
 - Preserve meaningful score differences. Do not force a ranking or curve, and do not inflate all scores because repository-wide checks pass.
 
 This skill scores and recommends; it does not authorize editing the assessed skills unless the user also requests changes.

--- a/skills/workflow-repository/scoring-agent-skills/agents/openai.yaml
+++ b/skills/workflow-repository/scoring-agent-skills/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Agent Skill Scoring"
+  short_description: "Score agent skills with a consistent evidence rubric."
+  default_prompt: "Use $scoring-agent-skills to score the requested agent skills across trigger clarity, workflow actionability, safety boundaries, verification rigor, and leanness, with direct evidence and clearly stated assessment limits."

--- a/skills/workflow-repository/scoring-agent-skills/agents/openai.yaml
+++ b/skills/workflow-repository/scoring-agent-skills/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Agent Skill Scoring"
-  short_description: "Score agent skills with a consistent evidence rubric."
-  default_prompt: "Use $scoring-agent-skills to score the requested agent skills across trigger clarity, workflow actionability, safety boundaries, verification rigor, and leanness, with direct evidence and clearly stated assessment limits."
+  short_description: "Create numerical agent skill quality scorecards."
+  default_prompt: "Use $scoring-agent-skills to numerically score or compare the requested agent skills across trigger clarity, workflow actionability, safety boundaries, verification rigor, and leanness, with direct evidence and clearly stated assessment limits."

--- a/skills/workflow-repository/scoring-agent-skills/references/rubric.md
+++ b/skills/workflow-repository/scoring-agent-skills/references/rubric.md
@@ -1,6 +1,6 @@
 # Agent Skill Scoring Rubric
 
-Assign an integer score from 1 to 10 for every dimension. Use these shared anchors:
+Assign an integer score from 1 to 10 for every assessable dimension. Use these shared anchors:
 
 | Score | Meaning |
 | --- | --- |
@@ -49,10 +49,16 @@ Lower the score for duplicated trigger sections, generic background, decorative 
 
 ## Overall score
 
-Use equal weighting:
+Use equal weighting across assessed dimensions. With complete evidence:
 
 ```text
 overall = (trigger + workflow + safety + verification + leanness) / 5
 ```
 
-Display the result to one decimal place. Do not round or normalize individual dimension scores, apply a curve, or convert repository test results into bonus points.
+When review-environment limitations make a dimension materially unassessable, do not convert that uncertainty into a low score. Mark the dimension `unassessed`, exclude it from the aggregate, and calculate a provisional overall from the assessed dimensions:
+
+```text
+provisional overall = sum(assessed dimension scores) / count(assessed dimensions)
+```
+
+Report coverage such as `4/5 dimensions`, the unavailable evidence, and confidence. Do not rank or directly compare aggregate scores with different coverage. Display a full or provisional result to one decimal place; do not round or normalize individual scores, apply a curve, or convert repository test results into bonus points.

--- a/skills/workflow-repository/scoring-agent-skills/references/rubric.md
+++ b/skills/workflow-repository/scoring-agent-skills/references/rubric.md
@@ -1,0 +1,58 @@
+# Agent Skill Scoring Rubric
+
+Assign an integer score from 1 to 10 for every dimension. Use these shared anchors:
+
+| Score | Meaning |
+| --- | --- |
+| 10 | Exemplary: no material weakness found in the inspected scope |
+| 9 | Excellent: only minor, non-material improvement remains |
+| 8 | Strong: reliable with one or more localized limitations |
+| 7 | Adequate: usable, but notable improvement is warranted |
+| 6 | Workable: a material gap limits reliability or completeness |
+| 5 | Inconsistent: useful elements exist, but substantial correction is needed |
+| 4 | Weak: defects regularly interfere with correct application |
+| 3 | Severe: only a small portion of the dimension is reliable |
+| 2 | Effectively absent or materially misleading |
+| 1 | Actively harmful or incompatible with the intended task |
+
+Use the full range when evidence supports it. Intermediate differences must reflect inspected evidence rather than a preference for round numbers.
+
+## Trigger clarity
+
+Assess whether frontmatter states both what the skill does and when it should activate. Check specificity, collision risk with sibling skills, explicit-invocation requirements where needed, and alignment among name, description, UI metadata, and catalog text.
+
+Lower the score for vague domain labels, trigger rules hidden only in the body, materially overlapping descriptions without routing, or mismatched discovery surfaces.
+
+## Workflow actionability
+
+Assess whether the post-trigger body lets another agent complete the task. Look for clear outcomes, relevant context gathering, executable decisions, justified sequencing, scope control, stopping conditions, and a defined deliverable.
+
+Lower the score for generic advice, over-prescribed routine steps, missing decisions, plans that cannot be executed, or workflows that stop before the requested outcome.
+
+## Safety boundaries
+
+Assess authorization and risk controls proportionately to the skill's actual effects. Local read-only work may need only a concise boundary; external writes, destructive actions, credentials, costs, publication, and remote mutations require explicit approval and verification rules.
+
+Lower the score for overbroad authority, missing target/content approval, secret exposure, unsafe recovery, or blanket confirmation gates that unnecessarily block safe local work.
+
+## Verification rigor
+
+Assess whether important claims and outcomes require direct, relevant evidence. Look for focused checks, representative validation, current-snapshot verification, honest handling of unavailable checks, and separation between source inspection, structural validation, rendering, runtime behavior, and external state.
+
+Apply this proportionately: an explanatory skill need not require a test suite, but it should ground claims in available sources and distinguish evidence from inference. Lower the score for unverified completion claims, stale evidence, vague “test it” language, or checks that cannot prove the stated outcome.
+
+## Leanness and maintainability
+
+Assess whether every instruction earns its context cost. Look for one clear purpose, low repetition, outcome-focused constraints, direct on-demand resource routing, aligned metadata, bounded examples, and stable guidance rather than incidental implementation detail.
+
+Lower the score for duplicated trigger sections, generic background, decorative examples, unjustified files, repeated approval language, oversized unstructured bodies, or version-sensitive facts without a verification path. Do not penalize necessary complexity merely because a high-risk workflow is longer.
+
+## Overall score
+
+Use equal weighting:
+
+```text
+overall = (trigger + workflow + safety + verification + leanness) / 5
+```
+
+Display the result to one decimal place. Do not round or normalize individual dimension scores, apply a curve, or convert repository test results into bonus points.

--- a/tests/test_skill_repository.py
+++ b/tests/test_skill_repository.py
@@ -274,6 +274,8 @@ def test_scoring_agent_skills_has_a_consistent_evidence_based_rubric() -> None:
 
     frontmatter = skill.split("---", 2)[1]
     assert "Score or compare" in frontmatter
+    assert "explicitly asks for" in frontmatter
+    assert "unscored reviews or revisions" in frontmatter
     for dimension in (
         "Trigger clarity",
         "Workflow actionability",
@@ -287,7 +289,13 @@ def test_scoring_agent_skills_has_a_consistent_evidence_based_rubric() -> None:
     assert "integer" in rubric
     assert "not a runtime effectiveness benchmark" in skill
     assert "direct evidence" in skill
+    assert "external or untrusted" in skill
+    assert "Do not run repository-supplied code" in skill
+    assert "inaccessible evidence" in skill
+    assert "unassessed" in skill
+    assert "exclude it from the aggregate" in skill
     assert "proportionate" in rubric
+    assert "assessed dimensions" in rubric
     assert "$scoring-agent-skills" in metadata
     assert "Scoring or comparing agent skills" in readme
 

--- a/tests/test_skill_repository.py
+++ b/tests/test_skill_repository.py
@@ -38,7 +38,7 @@ def test_deprecated_skills_are_hidden_from_standard_discovery() -> None:
 
 def test_every_skill_name_metadata_and_catalog_inventory_is_complete() -> None:
     skill_markdown = all_skill_markdown()
-    assert len(skill_markdown) == 36
+    assert len(skill_markdown) == 37
     readme = (ROOT / "README.md").read_text()
 
     for skill_md in skill_markdown:
@@ -265,6 +265,33 @@ def test_iterating_ui_improvements_is_a_devtools_commit_loop() -> None:
     assert "Explicitly invoked DevTools audit-fix-commit loops" in readme
 
 
+def test_scoring_agent_skills_has_a_consistent_evidence_based_rubric() -> None:
+    skill_dir = SKILLS / "workflow-repository/scoring-agent-skills"
+    skill = (skill_dir / "SKILL.md").read_text()
+    rubric = (skill_dir / "references/rubric.md").read_text()
+    metadata = (skill_dir / "agents/openai.yaml").read_text()
+    readme = (ROOT / "README.md").read_text()
+
+    frontmatter = skill.split("---", 2)[1]
+    assert "Score or compare" in frontmatter
+    for dimension in (
+        "Trigger clarity",
+        "Workflow actionability",
+        "Safety boundaries",
+        "Verification rigor",
+        "Leanness and maintainability",
+    ):
+        assert dimension in rubric
+    assert "equal weight" in skill
+    assert "one decimal place" in skill
+    assert "integer" in rubric
+    assert "not a runtime effectiveness benchmark" in skill
+    assert "direct evidence" in skill
+    assert "proportionate" in rubric
+    assert "$scoring-agent-skills" in metadata
+    assert "Scoring or comparing agent skills" in readme
+
+
 def test_running_panel_review_loops_has_evidence_based_stopping_rules() -> None:
     skill_dir = SKILLS / "workflow-repository/running-panel-review-loops"
     skill = (skill_dir / "SKILL.md").read_text()
@@ -335,7 +362,7 @@ def test_skill_bodies_avoid_repeating_trigger_and_generic_cleanup_sections() -> 
 def test_active_skills_are_grouped_one_category_deep() -> None:
     categorized = sorted(SKILLS.glob("*/*/SKILL.md"))
     assert categorized == sorted(SKILLS.glob("**/SKILL.md"))
-    assert len(categorized) == 30
+    assert len(categorized) == 31
     assert len({skill_md.parent.name for skill_md in categorized}) == len(categorized)
 
 


### PR DESCRIPTION
## Summary

- add `scoring-agent-skills` for consistent evidence-based skill scorecards
- define integer scoring anchors for trigger clarity, workflow actionability, safety boundaries, verification rigor, and leanness
- add aligned OpenAI metadata, catalog discovery, and repository coverage

## Affected paths

- `skills/workflow-repository/scoring-agent-skills/`
- `README.md`
- `tests/test_skill_repository.py`

## Verification

- `uv run --no-project --with pytest pytest` — 94 passed
- `prek run -a` — passed
- `git diff --check` — passed
