### PR TITLE
feat(skills): add codebase architecture improvement skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Repository path: `skills/workflow-repository/`
 | Skill | Use it for |
 | --- | --- |
 | `creating-agent-skills` | Creating, naming, renaming, optimizing, and reviewing lean, discoverable agent skills. |
+| `improving-codebase-architecture` | Evidence-led codebase architecture assessment and behavior-preserving refactoring. |
 | `scoring-agent-skills` | Scoring or comparing agent skills numerically with a consistent evidence-based quality rubric. |
 | `reviewing-code` | Evidence-led read-only review, including edge-case audits and PR preflight, with authorized hardening handoff. |
 | `running-panel-review-loops` | Iterative multi-reviewer code review, verified fixes, and evidence-based acceptance. |

--- a/skills/workflow-repository/improving-codebase-architecture/SKILL.md
+++ b/skills/workflow-repository/improving-codebase-architecture/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: improving-codebase-architecture
+description: Assess or improve an existing codebase's architecture when the user asks about module boundaries, coupling, scattered ownership, testability, change locality, deep modules, seams, or behavior-preserving structural refactoring. Use for cross-module design rather than ordinary diff review or a confirmed edge-case bug fix.
+---
+
+# Improving Codebase Architecture
+
+Find evidence-backed structural improvements that concentrate behavior and ownership behind smaller, clearer interfaces. Treat review, assessment, diagnosis, and planning requests as read-only. Improvement, refactoring, or implementation requests authorize in-scope local edits and non-destructive validation. Require confirmation before external writes, destructive actions, an incompatible public API or data migration, or material scope expansion.
+
+## Establish Scope
+
+1. Read repository instructions and the domain glossary, architecture documents, and ADRs relevant to the target. Missing optional architecture documents are not blockers.
+2. Use the area, pain point, or behavior named by the user. Trace only its actual callers, contracts, dependencies, data and state ownership, tests, and directly affected runtime paths.
+3. When no target is named, inspect recent change history and repeatedly modified paths to bias the assessment toward architecture where future work is likely. Widen the scan only when no meaningful hotspot emerges.
+4. If multiple incompatible directions remain equally plausible, or the work would break a public API, require a migration, or cross the requested boundary, ask one focused question before choosing.
+
+## Assess
+
+Load [the architecture assessment reference](references/architecture-assessment.md) when evaluating candidates.
+
+- Observe concrete friction: concepts split across files, callers coordinating the same policy, state with unclear ownership, wide or unstable interfaces, leaking dependencies, duplicated adaptation, or tests that must bypass the intended interface.
+- Measure the interface by everything callers must know, including ordering, invariants, errors, configuration, side effects, and performance—not only method count.
+- Apply the deletion test: reject a proposed module when deleting it would only move the same complexity into callers. Reject speculative seams, pass-through abstractions, style-only rearrangement, and abstractions without a demonstrated variation or ownership need.
+- Compare the current and proposed ownership, interface, dependency direction, test surface, and migration path. Prefer the smallest structural change that improves locality or leverage without hiding important operational behavior.
+- Keep claims tied to source, tests, history, or executable evidence. Label assumptions and unverified risks.
+
+For an assessment-only request, return at most three candidates ordered by expected leverage, migration risk, and confidence. For each, include evidence paths, current friction, proposed seam and ownership, expected locality or leverage, migration risk, and a concrete verification method. Name the top recommendation and explain why it outranks the alternatives. Do not create a visual report unless the user asks for one.
+
+## Refactor Safely
+
+For an authorized implementation request:
+
+1. Select one highest-confidence, bounded candidate. Do not bundle unrelated cleanup.
+2. Establish a behavioral baseline with existing checks and, when practical, characterization or regression coverage at the current public contract.
+3. Move ownership in small, reversible steps. Preserve externally observable behavior and existing contracts unless the request explicitly changes them; keep the worktree runnable between steps when practical.
+4. Put policy at its owning module and adapt dependencies at the narrowest justified seam. Remove superseded paths instead of leaving parallel abstractions.
+5. Run focused checks after each meaningful step, then affected integration tests and the repository gate. Reinspect callers, dependency direction, tests, and the final diff to confirm the candidate's claimed benefit was actually achieved.
+6. Stop after the selected candidate is complete. Report changed ownership and interface, behavior evidence, checks run, residual risk, and any stronger candidate deferred because it needs a product or migration decision.
+
+Use `reviewing-code` for ordinary diff or pull-request correctness review. Use `hardening-code-paths` for confirmed edge-case and failure-mode bugs; an architecture finding may explain the root cause, but do not turn this workflow into a generic bug sweep.

--- a/skills/workflow-repository/improving-codebase-architecture/agents/openai.yaml
+++ b/skills/workflow-repository/improving-codebase-architecture/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Improving Codebase Architecture"
+  short_description: "Improve module boundaries with evidence and safe refactoring."
+  default_prompt: "Use $improving-codebase-architecture to assess structural friction, rank evidence-backed module improvements, and safely implement only the scope I authorize."

--- a/skills/workflow-repository/improving-codebase-architecture/references/architecture-assessment.md
+++ b/skills/workflow-repository/improving-codebase-architecture/references/architecture-assessment.md
@@ -1,0 +1,59 @@
+# Architecture Assessment
+
+Use these concepts to compare the current structure with a concrete alternative. They are evaluation tools, not a requirement to introduce more types or layers.
+
+## Vocabulary
+
+- **Module:** code that owns a coherent capability behind an interface. It may be a function, class, package, process, or vertical slice.
+- **Interface:** everything a caller must know to use a module correctly: operations, inputs, invariants, sequencing, errors, side effects, configuration, and performance constraints.
+- **Implementation:** behavior hidden behind the interface.
+- **Depth:** useful behavior provided per unit of interface burden. A deep module hides meaningful policy behind a smaller stable interface; a shallow module exposes nearly as much complexity as it contains.
+- **Seam:** a justified point where behavior or dependencies can vary without editing the caller.
+- **Adapter:** an implementation that translates across a seam. An adapter should absorb a real integration difference rather than merely rename calls.
+- **Ownership:** the one place responsible for a policy, invariant, state transition, or lifecycle.
+- **Locality:** related knowledge, change, failure, and verification stay together.
+- **Leverage:** one implementation or policy benefits multiple callers and tests through a stable interface.
+
+## Candidate Tests
+
+A strong candidate has direct evidence for several of these:
+
+- One domain behavior requires coordinated edits across unrelated callers.
+- Multiple callers repeat ordering, validation, recovery, or state-transition policy.
+- State is written or invalidated by several modules without one lifecycle owner.
+- A dependency's details leak through multiple interfaces.
+- Tests must reproduce caller orchestration or reach past the intended interface.
+- Recent changes repeatedly cross the same files or seams for one conceptual change.
+- The proposed owner can enforce an invariant once and expose a smaller contract.
+
+Apply the **deletion test** to current and proposed modules: if deletion merely copies or moves the same complexity into callers, the module provides little depth. A useful module makes deletion disperse policy, knowledge, or verification that was legitimately concentrated.
+
+## Evidence and Ranking
+
+For each candidate, capture:
+
+1. source and test paths demonstrating the friction;
+2. the present owner, callers, interface burden, and dependency direction;
+3. the proposed owner and seam;
+4. which caller knowledge or repeated coordination disappears;
+5. behavior and contracts that must remain stable;
+6. migration and rollback shape;
+7. verification that would prove the improvement; and
+8. confidence, including contrary evidence.
+
+Rank candidates by expected locality and leverage, frequency of future change, migration risk, and confidence. Prefer a smaller high-confidence change over a broad redesign supported only by taste.
+
+## Rejection Signals
+
+Reject or downgrade a candidate when it:
+
+- adds a pass-through interface, manager, facade, or wrapper without absorbing policy;
+- introduces a seam for a hypothetical variation with no ownership, test, deployment, or integration need;
+- replaces direct readable code with indirection while preserving the same caller burden;
+- optimizes naming, folder symmetry, line count, or architectural fashion without runtime or change evidence;
+- centralizes unrelated behavior into a large module with a wide interface;
+- hides transactions, retries, authorization, latency, or failure semantics callers still need to reason about;
+- conflicts with an ADR without new evidence that its trade-off has changed; or
+- requires a broad migration before any independently verifiable benefit appears.
+
+A proposed deep module is not automatically good. Verify that its interface is smaller in required caller knowledge, its ownership is coherent, dependencies still point in a sustainable direction, and tests exercise meaningful behavior through the same contract callers use.

--- a/tests/test_skill_repository.py
+++ b/tests/test_skill_repository.py
@@ -38,7 +38,7 @@ def test_deprecated_skills_are_hidden_from_standard_discovery() -> None:
 
 def test_every_skill_name_metadata_and_catalog_inventory_is_complete() -> None:
     skill_markdown = all_skill_markdown()
-    assert len(skill_markdown) == 37
+    assert len(skill_markdown) == 38
     readme = (ROOT / "README.md").read_text()
 
     for skill_md in skill_markdown:
@@ -327,6 +327,38 @@ def test_running_panel_review_loops_has_evidence_based_stopping_rules() -> None:
     assert "Iterative multi-reviewer code review" in readme
 
 
+def test_improving_codebase_architecture_is_evidence_led_and_bounded() -> None:
+    skill_dir = SKILLS / "workflow-repository/improving-codebase-architecture"
+    skill = (skill_dir / "SKILL.md").read_text()
+    reference = (skill_dir / "references/architecture-assessment.md").read_text()
+    metadata = (skill_dir / "agents/openai.yaml").read_text()
+    readme = (ROOT / "README.md").read_text()
+
+    frontmatter = skill.split("---", 2)[1]
+    assert "existing codebase" in frontmatter
+    assert "module boundaries" in frontmatter
+    assert "Use only when" not in frontmatter
+    assert (
+        "Treat review, assessment, diagnosis, and planning requests as read-only"
+        in skill
+    )
+    assert "Improvement, refactoring, or implementation requests authorize" in skill
+    assert "recent change history" in skill
+    assert "at most three candidates" in skill
+    assert "evidence paths" in skill
+    assert "actual callers" in skill
+    assert "deletion test" in skill
+    assert "Preserve externally observable behavior and existing contracts" in skill
+    assert "characterization or regression coverage" in skill
+    assert "repository gate" in skill
+    assert "public API" in skill and "ask one focused question" in skill
+    assert "pass-through" in reference
+    assert "Locality" in reference and "Leverage" in reference
+    assert "$improving-codebase-architecture" in metadata
+    assert "Improve module boundaries" in metadata
+    assert "Evidence-led codebase architecture assessment" in readme
+
+
 def test_designing_user_experiences_supports_new_and_existing_products() -> None:
     experience_dir = SKILLS / "ui-ux-design/designing-user-experiences"
     skill = (experience_dir / "SKILL.md").read_text()
@@ -370,7 +402,7 @@ def test_skill_bodies_avoid_repeating_trigger_and_generic_cleanup_sections() -> 
 def test_active_skills_are_grouped_one_category_deep() -> None:
     categorized = sorted(SKILLS.glob("*/*/SKILL.md"))
     assert categorized == sorted(SKILLS.glob("**/SKILL.md"))
-    assert len(categorized) == 31
+    assert len(categorized) == 32
     assert len({skill_md.parent.name for skill_md in categorized}) == len(categorized)
 
 


### PR DESCRIPTION
## Summary

- add a naturally triggered `improving-codebase-architecture` skill aligned with the GPT-5.6 lean-prompt guidance
- separate evidence-led read-only assessment from authorized behavior-preserving refactoring
- add a focused architecture assessment reference covering deep modules, seams, ownership, locality, leverage, and rejection signals
- register the skill in the README catalog and add repository tests for its trigger, boundaries, metadata, and validation requirements

## Affected paths

- `skills/workflow-repository/improving-codebase-architecture/`
- `README.md`
- `tests/test_skill_repository.py`

## Verification

- `quick_validate.py skills/workflow-repository/improving-codebase-architecture` — passed
- `uv run --no-project --with pytest pytest` — 95 passed
- `prek run -a` — passed
- `git diff --check` — passed
