### PR TITLE
feat(skills): add code security audit workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,11 @@ Repository path: `skills/workflow-repository/`
 | `creating-agent-skills` | Creating, naming, renaming, optimizing, and reviewing lean, discoverable agent skills. |
 | `improving-codebase-architecture` | Evidence-led codebase architecture assessment and behavior-preserving refactoring. |
 | `scoring-agent-skills` | Scoring or comparing agent skills numerically with a consistent evidence-based quality rubric. |
-| `reviewing-code` | Evidence-led read-only review, including edge-case audits and PR preflight, with authorized hardening handoff. |
+| `auditing-code-security` | Evidence-led, security-first, read-only code audits with verified findings and bounded tool use. |
+| `reviewing-code` | Evidence-led ordinary code review with baseline security checks and authorized hardening handoff. |
 | `running-panel-review-loops` | Iterative multi-reviewer code review, verified fixes, and evidence-based acceptance. |
 | `resolving-pr-review-comments` | Explicit PR feedback assessment and local fixes, with exact approval for public actions. |
-| `hardening-code-paths` | Confirming, fixing, and verifying plausible code-path failure modes. |
+| `hardening-code-paths` | Confirming and fixing code-path failure modes or verified security findings. |
 | `using-jira-cli` | Read-only Jira inspection and precisely authorized CLI mutations. |
 | `applying-tdd` | Practical red-green-refactor for non-trivial behavior changes. |
 | `writing-git-commits` | Drafting, validating, or creating focused Conventional Commits from diffs. |

--- a/skills/workflow-repository/auditing-code-security/SKILL.md
+++ b/skills/workflow-repository/auditing-code-security/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: auditing-code-security
+description: Perform read-only security audits, vulnerability assessments, or threat-focused reviews of diffs, pull requests, code paths, or explicitly scoped repositories when security is the primary objective or acceptance criterion. Use reviewing-code for ordinary review with baseline security coverage and hardening-code-paths for fixing confirmed findings.
+---
+
+# Auditing Code Security
+
+Treat audits, assessments, and diagnoses as read-only. An audit request does not authorize code changes, intrusive testing, credential use, or testing beyond the requested target.
+
+## Scope and Threat Frame
+
+1. Determine the exact target from the request and repository or pull-request context. For a branch or pull request, compare from the target branch's merge base rather than assuming a branch name. For a named code path, trace its directly relevant callers, data stores, and downstream sinks.
+2. If no target is named, inspect `git status --short` and relevant staged, unstaged, and untracked changes. Ask for one target only when the current changes and request still do not identify a bounded scope. A repository-wide audit must be explicitly requested; never silently turn a focused request into an unbounded scan.
+3. Infer the intended security properties from code, tests, documentation, deployment configuration, and surrounding contracts. Label material assumptions.
+4. Identify the assets, attacker capabilities, entry points, trust boundaries, sensitive data flows, and security decisions reachable within scope.
+5. Load [the security audit checklist](references/security-audit-checklist.md) and select only domains supported by that threat frame.
+
+## Audit and Verify
+
+1. Trace attacker-controlled identity and data from source to validation, normalization, authorization, storage, side effects, and final sink. Check both the permitted path and the nearest denied or malformed path.
+2. Where reachable, assess authentication and session handling; authorization and tenant or object ownership; injection and unsafe parsing; file, process, and network boundaries; secrets and sensitive data; cryptographic use; resource exhaustion and abuse controls; dependencies and supply chain; and configuration or deployment exposure.
+3. Prefer non-destructive SAST, dependency, secret, and configuration tools that the repository has already configured or the environment has already made available. Record the relevant command, version when available, target, and limitations. Do not install tools, modify lockfiles or configuration, or add generated scanner artifacts.
+4. Treat scanner output as unverified until the reported input is attacker-influenceable, the vulnerable code or dependency is present in the shipped/runtime path, existing guards are accounted for, and the claimed impact follows. A tool alert without a reachable path is not a confirmed vulnerability.
+5. Use only safe, bounded local checks to test a hypothesis. Do not probe external or live targets, run destructive or persistence-producing tests, use credentials, make purchases, or materially expand scope without exact authorization for the operation and target; stop and request that authorization when it is required. Prefer the minimum proof that establishes the issue without exposing secrets or weaponizing the result.
+6. Stop after the requested surface, directly affected trust boundaries, focused tool evidence, and plausible high-impact paths have been examined. Record unavailable checks instead of substituting confidence.
+
+## Findings
+
+Lead with confirmed findings ordered by the repository scale:
+
+- **Critical:** a reachable issue with severe compromise, broad unauthorized access, destructive impact, or secret exposure.
+- **Major:** an exploitable security failure that should block release or merge but has narrower impact or stronger prerequisites.
+- **Minor:** a real, bounded weakness with low impact that is still worth correcting.
+
+For each finding, provide attack prerequisites, affected assets, file and line evidence, the source-to-sink or authorization path, impact, actionable remediation, and confidence. Keep scanner identifiers or standards mappings secondary to the concrete code evidence.
+
+Separate defense-in-depth recommendations, unverified risks, unavailable checks, and uncovered scope from confirmed vulnerabilities. If no finding survives verification, say that no confirmed finding was found in the examined scope; do not claim the target is secure or the audit is complete.
+
+## Confirmed-Finding Handoff
+
+When the user also requests fixes, hand only confirmed findings to `hardening-code-paths`. Preserve the original attack conditions in a failing regression check when practical, fix the shared trust boundary, and scan directly affected sibling paths for the same root cause. Then re-audit the fix diff and original attack path. Keep broader threat analysis and unverified alerts in this audit workflow rather than turning them into speculative code changes.

--- a/skills/workflow-repository/auditing-code-security/agents/openai.yaml
+++ b/skills/workflow-repository/auditing-code-security/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Code Security Audit"
+  short_description: "Run security-first, read-only audits with verified evidence."
+  default_prompt: "Use $auditing-code-security to run a security-first, read-only audit of the requested code scope, verify tool alerts against reachable paths, and report evidence-backed findings without changing code."

--- a/skills/workflow-repository/auditing-code-security/references/security-audit-checklist.md
+++ b/skills/workflow-repository/auditing-code-security/references/security-audit-checklist.md
@@ -1,0 +1,80 @@
+# Security audit checklist
+
+Use this as a prompt library, not a mechanical checklist. Select only categories connected to the reachable attack surface and requested scope. Absence of a finding in selected checks is not proof that the target is secure.
+
+## Threat frame
+
+- Name the protected assets and intended confidentiality, integrity, availability, authenticity, and tenant-isolation properties.
+- State realistic attacker capabilities: anonymous, authenticated, privileged, same-tenant, cross-tenant, local process, compromised dependency, or control of an upstream response.
+- Enumerate reachable entry points, including HTTP and RPC handlers, queues, webhooks, file imports, CLI arguments, environment and configuration, database records, browser messages, and dependency callbacks.
+- Mark trust boundaries, privilege changes, parsers, authorization decisions, persistence, side effects, and outbound connections.
+- Follow sensitive data flows through logs, errors, metrics, caches, queues, backups, exports, and deletion paths—not only the primary response.
+
+## Evidence and reachability
+
+For each candidate, trace the complete source-to-sink path:
+
+1. What input, identity, state, package, or configuration can the attacker influence?
+2. What parsing, canonicalization, validation, authorization, or escaping occurs, and in what order?
+3. Can an equivalent encoding, alternate route, stale state, race, retry, or direct object reference bypass the guard?
+4. Which sink or security decision is reached, under what attack prerequisites, and with what affected asset and impact?
+5. Does a test, safe local reproduction, specification, or framework contract confirm the claim?
+
+Reject a scanner alert as a false positive or report it as unverified when the source is not attacker-controlled, the sink is unreachable, the vulnerable feature is unused, a real guard blocks the path, the dependency is absent from the runtime artifact, or the claimed consequence does not follow. Do not dismiss an alert merely because a nearby layer appears to validate; verify the actual ordering and all equivalent routes.
+
+## Identity, sessions, and authorization
+
+- Authentication confusion across API keys, cookies, bearer tokens, proxies, callbacks, account linking, password reset, and multi-factor recovery
+- Session fixation, replay, rotation, revocation, expiry, cookie attributes, CSRF, redirect handling, and state or nonce binding
+- Function-level and object-level authorization on every route, job, export, websocket, and indirect lookup
+- Tenant, owner, organization, role, and scope checks performed against authoritative current state rather than user-supplied identifiers or stale caches
+- Default, error, retry, bulk, administrative, and migration paths that accidentally fail open or bypass policy
+
+## Injection, parsing, and output boundaries
+
+- SQL, query-language, template, HTML, header, log, terminal, shell, argument, expression, and command injection at the final sink
+- Unsafe deserialization, schema confusion, polymorphic types, parser differentials, request smuggling, and unbounded recursive or compressed input
+- Encoding and canonicalization order across Unicode, URL, path, hostname, delimiter, quoting, escaping, and double-decoding variants
+- Untrusted content crossing into prompts, markup, browser DOM, terminals, generated code, or structured protocols without preserving provenance and framing
+- Output encoding matched to the actual consumer rather than assumed safe from an earlier representation
+
+## Files, processes, and network
+
+- Absolute paths, `..`, symlink escape or swap, archive extraction, temporary files, permissions, ownership, and time-of-check/time-of-use races
+- Process execution with structured arguments, controlled executable resolution, minimal environment inheritance, bounded output, timeout, cancellation, and child cleanup
+- SSRF, open redirects, hostname and IP validation, alternate address forms, DNS rebinding, redirect revalidation, cloud metadata access, and egress policy
+- Protocol downgrade, certificate validation, webhook authenticity, replay, message ordering, partial responses, retry classification, and idempotency
+
+## Secrets, sensitive data, and cryptography
+
+- Credentials or personal data in source, history, fixtures, build artifacts, command arguments, logs, traces, metrics, errors, URLs, caches, or exports
+- Data minimization, retention, deletion, access logging, redaction, backup handling, and least-privilege access
+- Standard cryptographic primitives and protocols used with suitable randomness, nonces, key separation, comparison, rotation, storage, and failure behavior
+- Encryption that authenticates data and binds the necessary context; signatures or tokens that verify algorithm, issuer, audience, purpose, and expiry
+- Secret scanners handled without reproducing secret values in commands, logs, captured output, or the final report
+
+## Availability and abuse resistance
+
+- Bounded request bodies, collections, recursion, regex work, decompression, parsing, fan-out, concurrency, queues, retries, and retained state
+- Rate, quota, cost, and amplification controls applied to the correct actor, tenant, route, and expensive downstream operation
+- Lock, transaction, cancellation, timeout, and cleanup behavior under partial failure or attacker-controlled ordering
+- Duplicate submission, replay, race, inventory or balance invariants, workflow skipping, and abuse of valid functionality
+
+## Dependencies, supply chain, configuration, and deployment
+
+- Direct and transitive dependency findings verified against the resolved version, vulnerable feature, runtime artifact, and reachable application path
+- Lockfile integrity, source and registry provenance, install or build scripts, generated artifacts, update policy, and compromised maintainer risk where supported by evidence
+- CI and release token permissions, untrusted pull-request execution, artifact provenance, cache poisoning, secret exposure, and deployment approval boundaries
+- Debug or development modes, default credentials, permissive CORS, public binding, proxy trust, unsafe feature flags, exposed management endpoints, and weak production defaults
+- Infrastructure and runtime controls that materially change exploitability; do not assume an undocumented external control exists
+
+## Tool evidence
+
+- Prefer repository-configured commands and already available scanners; do not install a preferred tool just to complete the checklist.
+- Record what was actually scanned, relevant exclusions, tool and ruleset versions when available, network or registry freshness, and command failures.
+- For SAST, inspect the reported source, sanitizers, control flow, and sink. For dependency tools, verify resolved and shipped versions plus feature reachability. For secret tools, determine validity without disclosing the value. For configuration tools, compare findings with the deployed path rather than templates alone.
+- Treat passing tools as evidence only for the rules, files, dependency data, and configuration they covered. Name meaningful gaps and unavailable checks.
+
+## Classification check
+
+Before reporting a confirmed finding, verify that the attack prerequisites are plausible, the affected assets and impact are concrete, file and line evidence identifies the path, remediation addresses the shared boundary, and confidence reflects any unverified premise. Put useful hardening ideas without a demonstrated violation under defense-in-depth rather than inflating the vulnerability list.

--- a/skills/workflow-repository/hardening-code-paths/SKILL.md
+++ b/skills/workflow-repository/hardening-code-paths/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: hardening-code-paths
-description: Use when asked to proactively harden a specific code path by finding and fixing plausible edge-case, boundary, failure-mode, or lifecycle bugs, or when a concrete bug fix suggests nearby same-pattern regression risks.
+description: Use when asked to proactively harden a specific code path by confirming and fixing plausible edge-case, boundary, failure-mode, or lifecycle bugs; to fix a confirmed security finding; or to check nearby same-pattern regression risks. Use auditing-code-security first for broad threat analysis or unverified security alerts.
 ---
 
 # Hardening Code Paths
 
-Actively inspect the relevant code path, confirm plausible edge-case and failure-mode bugs, and fix or harden them. Do not wait for the user to enumerate cases.
+Actively inspect the relevant code path, confirm plausible edge-case and failure-mode bugs, and fix or harden them. Do not wait for the user to enumerate cases. Accept confirmed security findings from `auditing-code-security`; leave broad threat analysis and unverified alerts in that audit workflow rather than making speculative security changes.
 
 ## Default Scope
 
@@ -17,9 +17,9 @@ When the user does not provide files, a commit, or a diff, inspect `git status -
 2. Trace the real flow end to end, including callers, sibling routes, cleanup paths, stored state, and representation changes.
 3. Load [the edge-case checklist](references/edge-case-checklist.md) and select only domains reachable in this flow.
 4. Build a bounded risk matrix across the few dimensions most likely to interact: representative inputs, operations, before/during/after states, lifecycle events, and representations. Prioritize security, data loss, corruption, hangs, and broken core behavior; avoid exhaustive Cartesian products and unsupported platform speculation.
-5. Establish that each candidate violates intended behavior, then add the smallest regression test or executable check that fails before the fix when practical. If the failure cannot be verified, report the risk as unverified instead of changing behavior.
-6. Fix or harden each confirmed bug at the shared root path, not only the reported symptom.
-7. Run the narrow check, then scan sibling callers/routes for the same pattern.
+5. Establish that each candidate violates intended behavior, then add the smallest regression test or executable check that fails before the fix when practical. For a security finding, reproduce the original attack conditions without exposing secrets or targeting an external system. If the failure cannot be verified, report the risk as unverified instead of changing behavior.
+6. Fix or harden each confirmed bug at the shared root path, not only the reported symptom. Put security fixes at the shared trust boundary so equivalent callers cannot bypass them.
+7. Run the narrow check, then scan sibling callers/routes for the same pattern, including alternate encodings, identities, tenants, or objects implicated by a security finding.
 8. Perform one fresh pass over the resulting diff for opposite bounds, equivalent encodings, stale or cancelled state at asynchronous boundaries, cleanup, and whether the regression test would fail if the bug returned.
 9. Repeat only while the fix exposes a concrete adjacent case in the same failure class; stop before materially different behavior or scope.
 10. Run the repo's normal verification gate before final response.
@@ -30,7 +30,8 @@ When the user does not provide files, a commit, or a diff, inspect `git status -
 - Preserve existing contracts unless the task explicitly changes them.
 - If retained state is introduced, add the minimal eviction or cleanup path.
 - If a timeout or cancellation can fire, close or clear the resource too.
-- If input crosses a trust boundary, validate type and shape before use.
+- If input crosses a trust boundary, validate type and shape before use; keep authentication, authorization, and tenant or object ownership checks at the authoritative boundary.
+- For confirmed security findings, cover the denied attack path and a permitted control path so the fix neither bypasses policy nor breaks authorized behavior.
 - If a package/config points to code, prove the referenced file exists in the packaged/runtime form.
 - Keep the sibling scan bounded to the same root cause and directly affected flow. Stop and report when the next candidate requires a new behavior decision or material scope expansion.
 - Stop when checks pass and the sibling scan finds no same-pattern bug; report fixed cases, checks run, and any unverified risk plainly.

--- a/skills/workflow-repository/hardening-code-paths/agents/openai.yaml
+++ b/skills/workflow-repository/hardening-code-paths/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Hardening Code Paths"
-  short_description: "Confirm and fix plausible code-path failure modes."
-  default_prompt: "Use $hardening-code-paths to trace this code path, confirm plausible failures, fix the shared cause, and verify bounded sibling cases."
+  short_description: "Fix confirmed failure modes and security findings safely."
+  default_prompt: "Use $hardening-code-paths to confirm failure modes or security findings, reproduce the original conditions, fix the shared boundary, and verify bounded sibling cases."

--- a/skills/workflow-repository/reviewing-code/SKILL.md
+++ b/skills/workflow-repository/reviewing-code/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: reviewing-code
-description: Review diffs, pull requests, commits, patches, or source files for correctness, security, performance, maintainability, tests, and integration risk. Use for read-only review, including edge-case audits, PR preflight, and reviewer simulation; when fixes are also requested, hand confirmed failure-mode findings to hardening-code-paths when available.
+description: Review diffs, pull requests, commits, patches, or source files for correctness, baseline security, performance, maintainability, tests, and integration risk. Use for ordinary read-only review, edge-case audits, PR preflight, and reviewer simulation; use auditing-code-security when security is the primary objective, and hardening-code-paths to fix confirmed failure modes.
 ---
 
 # Reviewing Code
 
-Review the requested change, not the entire codebase. Treat the task as read-only unless fixes are requested.
+Review the requested change, not the entire codebase. Treat the task as read-only unless fixes are requested. Keep this as an ordinary code review with a security baseline; when security is the primary objective or acceptance criterion, use `auditing-code-security` instead of expanding this workflow into a full security audit.
 
 ## Workflow
 
@@ -16,13 +16,13 @@ Review the requested change, not the entire codebase. Treat the task as read-onl
    - correctness, boundaries, state transitions, retries, concurrency, partial failure, and cleanup
    - where repeated work without progress stops, and its worst-case time, resources, cost, and side effects
    - interfaces, schemas, migrations, jobs, caches, feature flags, permissions, and configuration
-   - trust boundaries, authn/authz, validation, injection, secrets, logging, and sensitive data
+   - security baseline: affected assets and trust boundaries; authn/authz and tenant or object ownership; source-to-sink validation and injection; secrets, logging, and sensitive data; dependency and configuration exposure
    - repeated work, I/O, queries, blocking, leaks, and expected scale
    - tests for changed behavior and concrete error paths; maintainability only where it creates real cost or risk
 5. Run focused checks when feasible. Passing checks support but do not prove correctness.
 6. Stop after the relevant diff, directly affected contracts/callers, and focused evidence are covered. Distinguish confirmed findings, inferred risks, and unverified areas.
 
-When fixes are requested, confirm the finding first, then use `hardening-code-paths` for bounded edge-case or failure-mode work. Do not hand off speculative or preference-only comments. Return to review the resulting diff and evidence.
+When fixes are requested, confirm the finding first, then use `hardening-code-paths` for bounded edge-case or failure-mode work. Do not hand off speculative or preference-only comments. Use `auditing-code-security` first when a security alert needs threat-focused reachability analysis. Return to review the resulting diff and evidence.
 
 ## Findings
 

--- a/skills/workflow-repository/reviewing-code/agents/openai.yaml
+++ b/skills/workflow-repository/reviewing-code/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Code Review"
-  short_description: "Review changes, edge cases, and integration risks."
-  default_prompt: "Use $reviewing-code to review the requested change or run a read-only edge-case preflight, lead with verified findings, and distinguish residual risk from confirmed defects."
+  short_description: "Review changes with baseline security and integration checks."
+  default_prompt: "Use $reviewing-code for an ordinary read-only review with baseline security checks; use $auditing-code-security for a security audit when security is the primary objective."

--- a/tests/test_skill_repository.py
+++ b/tests/test_skill_repository.py
@@ -38,7 +38,7 @@ def test_deprecated_skills_are_hidden_from_standard_discovery() -> None:
 
 def test_every_skill_name_metadata_and_catalog_inventory_is_complete() -> None:
     skill_markdown = all_skill_markdown()
-    assert len(skill_markdown) == 38
+    assert len(skill_markdown) == 39
     readme = (ROOT / "README.md").read_text()
 
     for skill_md in skill_markdown:
@@ -300,6 +300,82 @@ def test_scoring_agent_skills_has_a_consistent_evidence_based_rubric() -> None:
     assert "Scoring or comparing agent skills" in readme
 
 
+def test_auditing_code_security_is_security_first_and_bounded() -> None:
+    skill_dir = SKILLS / "workflow-repository/auditing-code-security"
+    skill = (skill_dir / "SKILL.md").read_text()
+    reference = (skill_dir / "references/security-audit-checklist.md").read_text()
+    metadata = (skill_dir / "agents/openai.yaml").read_text()
+    readme = (ROOT / "README.md").read_text()
+    reviewing = (SKILLS / "workflow-repository/reviewing-code/SKILL.md").read_text()
+    reviewing_metadata = (
+        SKILLS / "workflow-repository/reviewing-code/agents/openai.yaml"
+    ).read_text()
+    hardening = (
+        SKILLS / "workflow-repository/hardening-code-paths/SKILL.md"
+    ).read_text()
+    hardening_metadata = (
+        SKILLS / "workflow-repository/hardening-code-paths/agents/openai.yaml"
+    ).read_text()
+
+    frontmatter = skill.split("---", 2)[1]
+    assert "security audit" in frontmatter.lower()
+    assert "security is the primary" in frontmatter
+    assert "read-only" in skill
+    assert "repository-wide" in skill and "explicitly" in skill
+    for threat_element in (
+        "assets",
+        "attacker capabilities",
+        "entry points",
+        "trust boundaries",
+        "sensitive data flows",
+    ):
+        assert threat_element in skill
+    assert "already configured" in skill
+    assert "environment" in skill and "available" in skill
+    assert "Do not install" in skill
+    assert "lockfiles" in skill and "configuration" in skill
+    assert "scanner output" in skill and "unverified" in skill
+    assert "external or live targets" in skill
+    assert "exact authorization" in skill
+    for severity in ("Critical", "Major", "Minor"):
+        assert severity in skill
+    for finding_field in (
+        "attack prerequisites",
+        "affected assets",
+        "file and line evidence",
+        "impact",
+        "actionable remediation",
+        "confidence",
+    ):
+        assert finding_field in skill
+    assert "defense-in-depth" in skill
+    assert "uncovered scope" in skill
+    assert "hardening-code-paths" in skill
+    assert "source-to-sink" in reference
+    assert "false positive" in reference
+    assert "reachable attack surface" in reference
+    assert "mechanical checklist" in reference
+    assert "$auditing-code-security" in metadata
+    assert "read-only" in metadata
+    assert "security-first" in metadata
+    assert not (skill_dir / "scripts").exists()
+    assert not (skill_dir / "assets").exists()
+    assert "Evidence-led, security-first, read-only code audits" in readme
+
+    assert "ordinary read-only review" in reviewing.split("---", 2)[1]
+    assert "security is the primary objective" in reviewing
+    assert "auditing-code-security" in reviewing
+    assert "security baseline" in reviewing
+    assert "security audit" in reviewing_metadata.lower()
+    assert "confirmed security findings" in hardening
+    assert "shared trust boundary" in hardening
+    assert "original attack conditions" in hardening
+    assert "auditing-code-security" in hardening
+    assert "confirmed security finding" in hardening.split("---", 2)[1]
+    assert "security findings" in hardening_metadata.lower()
+    assert "verified security findings" in readme
+
+
 def test_running_panel_review_loops_has_evidence_based_stopping_rules() -> None:
     skill_dir = SKILLS / "workflow-repository/running-panel-review-loops"
     skill = (skill_dir / "SKILL.md").read_text()
@@ -402,7 +478,7 @@ def test_skill_bodies_avoid_repeating_trigger_and_generic_cleanup_sections() -> 
 def test_active_skills_are_grouped_one_category_deep() -> None:
     categorized = sorted(SKILLS.glob("*/*/SKILL.md"))
     assert categorized == sorted(SKILLS.glob("**/SKILL.md"))
-    assert len(categorized) == 32
+    assert len(categorized) == 33
     assert len({skill_md.parent.name for skill_md in categorized}) == len(categorized)
 
 


### PR DESCRIPTION
## Summary

- add `auditing-code-security` as a security-first, read-only audit skill with bounded scope, verified findings, and explicit authorization boundaries
- keep `reviewing-code` focused on ordinary reviews with baseline security checks and route confirmed security fixes through `hardening-code-paths`
- add an on-demand security audit checklist, aligned OpenAI metadata, README discovery, and repository assertions

This separates deep threat-focused auditing from routine code review while preserving one confirmed-finding repair path.

## Affected paths

- `skills/workflow-repository/auditing-code-security/`
- `skills/workflow-repository/reviewing-code/`
- `skills/workflow-repository/hardening-code-paths/`
- `tests/test_skill_repository.py`
- `README.md`

## Verification

- `quick_validate.py` for all three affected skills — passed
- `UV_CACHE_DIR=/tmp/uv-cache uv run --no-project --with pytest pytest` — 96 passed
- `prek run -a` — passed
- `git diff --check` — passed
- representative routing and authorization cases are covered by the new repository test
