### PR TITLE
feat(scoring-agent-skills): score incremental knowledge value

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Repository path: `skills/workflow-repository/`
 | --- | --- |
 | `creating-agent-skills` | Creating, naming, renaming, optimizing, and reviewing lean, discoverable agent skills. |
 | `improving-codebase-architecture` | Evidence-led codebase architecture assessment and behavior-preserving refactoring. |
-| `scoring-agent-skills` | Scoring or comparing agent skills numerically with a consistent evidence-based quality rubric. |
+| `scoring-agent-skills` | Scoring or comparing agent skills numerically with a six-dimension rubric that includes incremental knowledge value. |
 | `auditing-code-security` | Evidence-led, security-first, read-only code audits with verified findings and bounded tool use. |
 | `reviewing-code` | Evidence-led ordinary code review with baseline security checks and authorized hardening handoff. |
 | `running-panel-review-loops` | Iterative multi-reviewer code review, verified fixes, and evidence-based acceptance. |

--- a/skills/workflow-repository/scoring-agent-skills/SKILL.md
+++ b/skills/workflow-repository/scoring-agent-skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scoring-agent-skills
-description: Score or compare one or more agent skills across trigger clarity, workflow actionability, safety boundaries, verification rigor, and leanness. Use only when the user explicitly asks for ratings, numerical quality scores, rubric-based scorecards, or scored comparisons; use creating-agent-skills for unscored reviews or revisions.
+description: Score or compare one or more agent skills across trigger clarity, workflow actionability, safety boundaries, verification rigor, incremental knowledge value, and leanness. Use only when the user explicitly asks for ratings, numerical quality scores, rubric-based scorecards, or scored comparisons; use creating-agent-skills for unscored reviews or revisions.
 ---
 
 # Scoring Agent Skills
@@ -10,29 +10,31 @@ Produce a comparable quality scorecard, not a vague impression or a runtime capa
 ## Scope and Evidence
 
 1. Resolve the requested skill set. For “every skill,” use the repository's active discovery tree unless the user explicitly includes deprecated or external skills.
-2. Inspect applicable repository instructions, the model-specific prompting guide, each `SKILL.md`, UI metadata, catalog entry, and directly linked resources relevant to a score.
-3. For the trusted current repository, run its established non-destructive validators when feasible. For an external or untrusted repository, default to source inspection or a trusted validator. Do not run repository-supplied code unless it is sandboxed and the user explicitly authorizes the exact command.
-4. Treat structural checks, link integrity, metadata presence, and test results as supporting evidence. They do not by themselves prove prompt quality or task success.
-5. Read `references/rubric.md` and assign an integer from 1 to 10 for each assessable dimension. Apply the same anchors to every skill and assess safety and verification proportionately to what the skill can do.
-6. Support each score with direct evidence from the inspected surfaces. Revisit conspicuous outliers after the first pass so differences reflect the rubric rather than category or ordering bias.
+2. Establish the target-model baseline from the user's request, the repository's model-specific guide, or the execution environment, in that order. If none identifies one, use a “general capable model” baseline and disclose that low-confidence assumption.
+3. Inspect applicable repository instructions, the model-specific prompting guide, each `SKILL.md`, UI metadata, catalog entry, and directly linked resources relevant to a score.
+4. For the trusted current repository, run its established non-destructive validators when feasible. For an external or untrusted repository, default to source inspection or a trusted validator. Do not run repository-supplied code unless it is sandboxed and the user explicitly authorizes the exact command.
+5. Treat structural checks, link integrity, metadata presence, and test results as supporting evidence. They do not by themselves prove prompt quality, incremental value, or task success.
+6. Before scoring, read [the rubric](references/rubric.md) and assign an integer from 1 to 10 for each assessable dimension. Apply the same anchors to every skill and assess each dimension proportionately to what the skill can do.
+7. Support each score with direct evidence. For incremental knowledge value, label representative content as domain delta, justified activation, or redundancy candidate without inventing precise ratios. Revisit conspicuous outliers after the first pass so differences reflect the rubric rather than category or ordering bias.
 
 ## Calculate and Report
 
-Use equal weight for all assessed dimensions. When all five are assessed, compute the overall score as their arithmetic mean and show one decimal place. If environment-specific inaccessible evidence prevents a defensible dimension score, mark that dimension unassessed, exclude it from the aggregate, and report score coverage and confidence; do not add hidden bonuses or penalties.
+Use equal weight for all assessed dimensions. When all six are assessed, compute the overall score as their arithmetic mean and show one decimal place. If inaccessible evidence prevents a defensible dimension score, mark that dimension unassessed, exclude it from the aggregate, and report score coverage and confidence; do not add hidden bonuses or penalties.
 
 Return in the user's language unless requested otherwise:
 
-1. The rubric and scope, including whether the assessment is static or includes runtime evaluations.
-2. A table with skill name, all five dimension scores, overall score, and one concise evidence-based note. Group by repository category when the list is long.
+1. The rubric, scope, target-model baseline, assumptions, and whether the assessment is static or includes a representative baseline-versus-skill runtime comparison.
+2. A table with skill name, all six dimension scores, overall score, and one concise evidence-based note. Group by repository category when the list is long.
 3. Verification evidence such as validators, tests, metadata inventory, or broken-link checks, clearly separated from qualitative scoring.
-4. A short synthesis covering strongest dimensions, material weaknesses, and the highest-value improvement priorities.
+4. A short synthesis covering the highest-value content, safely removable redundancy candidates, material weaknesses, and improvement priorities.
 
-State that a source-and-structure-only review is not a runtime effectiveness benchmark. Do not imply measured success rates, model compatibility, accessibility, safety, or tool reliability unless representative evaluations directly established them.
+State that a source-and-structure-only review estimates incremental value and is not a runtime effectiveness benchmark. Only representative baseline-versus-skill evaluations can establish observed gains. Do not imply measured success rates, model compatibility, accessibility, safety, or tool reliability without direct evidence. Also state that this six-dimension aggregate is not directly comparable with historical five-dimension scores.
 
 ## Judgment Rules
 
 - Score the artifact that exists, not the likely intent or the reputation of its domain.
-- Do not reward length, resource count, strictness, or passing tests automatically; reward justified guidance that improves correct task completion.
+- Do not reward length, resource count, strictness, passing tests, or unfamiliarity automatically; reward justified guidance that improves correct task completion.
+- Do not call content redundant merely because a capable model may know it. Preserve concise disambiguation, current facts, safety and authorization boundaries, output contracts, stopping conditions, and reminders backed by observed failures.
 - Do not penalize a simple read-only skill for lacking destructive-operation policy it cannot need.
 - Penalize material trigger collisions, contradictory instructions, unjustified approval gates, unverifiable completion claims, repeated content, stale references, and missing stopping conditions in the relevant dimensions.
 - Lower a score for confirmed missing required evidence in the artifact. For inaccessible evidence caused by the review environment, mark the materially affected dimension unassessed rather than treating uncertainty as an artifact defect.

--- a/skills/workflow-repository/scoring-agent-skills/agents/openai.yaml
+++ b/skills/workflow-repository/scoring-agent-skills/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Agent Skill Scoring"
   short_description: "Create numerical agent skill quality scorecards."
-  default_prompt: "Use $scoring-agent-skills to numerically score or compare the requested agent skills across trigger clarity, workflow actionability, safety boundaries, verification rigor, and leanness, with direct evidence and clearly stated assessment limits."
+  default_prompt: "Use $scoring-agent-skills to numerically score or compare the requested agent skills across trigger clarity, workflow actionability, safety boundaries, verification rigor, incremental knowledge value, and leanness, with direct evidence and clearly stated assessment limits."

--- a/skills/workflow-repository/scoring-agent-skills/references/rubric.md
+++ b/skills/workflow-repository/scoring-agent-skills/references/rubric.md
@@ -41,18 +41,42 @@ Assess whether important claims and outcomes require direct, relevant evidence. 
 
 Apply this proportionately: an explanatory skill need not require a test suite, but it should ground claims in available sources and distinguish evidence from inference. Lower the score for unverified completion claims, stale evidence, vague “test it” language, or checks that cannot prove the stated outcome.
 
+## Incremental knowledge value
+
+Assess how much task-relevant guidance the skill adds beyond the declared target-model baseline. Reward non-obvious decision rules and trade-offs, real-world failure modes, current version or repository constraints, critical ordering, and concise reminders with evidence or a concrete failure rationale.
+
+Label representative passages rather than every paragraph:
+
+- **Domain delta:** specialized facts, decisions, constraints, or failure handling that materially extends the baseline.
+- **Justified activation:** likely familiar knowledge whose brief reminder has evidence or a concrete failure rationale for improving reliable application.
+- **Redundancy candidate:** generic background, basic tutorials, routine operations, repeated rules, or decorative examples with no identified behavioral value.
+
+Use these dimension-specific landmarks together with the shared anchors; use intermediate scores when the evidence falls between them:
+
+| Score | Incremental-value landmark |
+| --- | --- |
+| 10 | Substantive guidance is concentrated domain delta or justified activation, with no material redundancy found. |
+| 8 | Strong task-specific value with only localized baseline restatement. |
+| 6 | Useful specialized guidance is materially diluted by generic or routine content. |
+| 4 | The body is mostly baseline explanation or tutorial content with little non-obvious guidance. |
+| 2 | It provides effectively no task-relevant increment or materially mischaracterizes baseline knowledge. |
+
+Do not mark concise disambiguation, current facts, safety or authorization boundaries, output contracts, stopping conditions, or evidence-backed error prevention as redundant solely because the model may know them. Static inspection supports only an inferred increment; representative baseline-versus-skill evaluations can establish an observed gain.
+
 ## Leanness and maintainability
 
 Assess whether every instruction earns its context cost. Look for one clear purpose, low repetition, outcome-focused constraints, direct on-demand resource routing, aligned metadata, bounded examples, and stable guidance rather than incidental implementation detail.
 
 Lower the score for duplicated trigger sections, generic background, decorative examples, unjustified files, repeated approval language, oversized unstructured bodies, or version-sensitive facts without a verification path. Do not penalize necessary complexity merely because a high-risk workflow is longer.
 
+Judge organization and context economy separately from novelty: a concise generic skill can be lean but low in incremental value, while a necessarily detailed fragile workflow can score well in both.
+
 ## Overall score
 
 Use equal weighting across assessed dimensions. With complete evidence:
 
 ```text
-overall = (trigger + workflow + safety + verification + leanness) / 5
+overall = (trigger + workflow + safety + verification + incremental value + leanness) / 6
 ```
 
 When review-environment limitations make a dimension materially unassessable, do not convert that uncertainty into a low score. Mark the dimension `unassessed`, exclude it from the aggregate, and calculate a provisional overall from the assessed dimensions:
@@ -61,4 +85,4 @@ When review-environment limitations make a dimension materially unassessable, do
 provisional overall = sum(assessed dimension scores) / count(assessed dimensions)
 ```
 
-Report coverage such as `4/5 dimensions`, the unavailable evidence, and confidence. Do not rank or directly compare aggregate scores with different coverage. Display a full or provisional result to one decimal place; do not round or normalize individual scores, apply a curve, or convert repository test results into bonus points.
+Report coverage such as `5/6 dimensions`, the unavailable evidence, and confidence. Do not rank or directly compare aggregate scores with different coverage, or compare this six-dimension aggregate directly with historical five-dimension scores. Display a full or provisional result to one decimal place; do not round or normalize individual scores, apply a curve, or convert repository test results into bonus points.


### PR DESCRIPTION
## Summary

- add incremental knowledge value as a sixth, equally weighted scoring dimension
- distinguish inferred static value from observed baseline-versus-skill runtime gains
- preserve justified activation and safety constraints while identifying safely removable redundancy
- align the skill trigger, OpenAI metadata, rubric, and README catalog entry

## Affected paths

- `skills/workflow-repository/scoring-agent-skills/SKILL.md`
- `skills/workflow-repository/scoring-agent-skills/references/rubric.md`
- `skills/workflow-repository/scoring-agent-skills/agents/openai.yaml`
- `README.md`

## Verification

- `UV_CACHE_DIR=/tmp/uv-cache uv run --no-project --python 3.13 --with pyyaml python "$HOME/.codex/skills/.system/skill-creator/scripts/quick_validate.py" skills/workflow-repository/scoring-agent-skills` — passed
- `prek run -a` — all hooks passed
- `git diff --check` — passed
- manually verified six-dimension headings, aggregate formula, partial coverage, rubric link, and discovery-surface alignment

No automated tests were added because this repository does not maintain repository tests. No runtime baseline-versus-skill evaluation was performed; the updated rubric explicitly labels static conclusions as inferred.
