### PR TITLE
feat(applying-tdd): define explicit test boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Repository path: `skills/workflow-repository/`
 | `resolving-pr-review-comments` | Explicit PR feedback assessment and local fixes, with exact approval for public actions. |
 | `hardening-code-paths` | Confirming and fixing code-path failure modes or verified security findings. |
 | `using-jira-cli` | Read-only Jira inspection and precisely authorized CLI mutations. |
-| `applying-tdd` | Practical red-green-refactor for non-trivial behavior changes. |
+| `applying-tdd` | Scoping red-green-refactor with explicit production-path, test-data, and observable-behavior boundaries. |
 | `writing-git-commits` | Drafting, validating, or creating focused Conventional Commits from diffs. |
 | `syncing-main-branch` | Explicit, state-preserving switch to `main` and fast-forward-only update. |
 | `managing-git-worktrees` | Loss-aware worktree creation, repair, removal, pruning, and branch cleanup. |

--- a/skills/workflow-repository/applying-tdd/SKILL.md
+++ b/skills/workflow-repository/applying-tdd/SKILL.md
@@ -1,17 +1,32 @@
 ---
 name: applying-tdd
-description: "Use when implementing a non-trivial behavior change with Test-Driven Development (TDD) when practical: prove a focused failure, make the smallest passing change, then refactor safely."
+description: "Use when implementing a non-trivial, observable behavior change with TDD under explicit ecosystem production-path and test-isolation boundaries. Do not apply red-first mechanically to static configuration, wiring, metadata, or production code outside the defined boundary."
 ---
 
 # Applying TDD
 
 Use tests as executable behavior specifications, not as a coverage ritual.
 
+## Scope the Boundary
+
+Before writing a test:
+
+1. Load [test boundaries](references/test-boundaries.md) and apply the matching ecosystem's production-scope and test-isolation rules. For a listed ecosystem, only eligible production paths may enter TDD, and tests may use only the permitted test-owned inputs, unless more-specific repository instructions replace that row.
+2. Partition eligible work by observable behavior rather than by file.
+3. Apply TDD to a work unit only when all are true:
+   - it changes a contract observable at a stable boundary
+   - a focused test can fail for the intended reason before implementation
+   - the test would catch a plausible regression that cheaper validation would not catch as clearly
+
+Treat supporting edits such as config, wiring, schemas, fixtures, and generated artifacts as part of the behavior slice, not as separate units that each require a red-green cycle. Test custom parsing, defaults, validation, precedence, or resulting runtime behavior; do not write a test that merely repeats static config values, standard framework declarations, or metadata.
+
+If no meaningful behavior contract exists, skip TDD and use the cheapest proportionate check: parse or schema validation, compile or type checking, linting, a focused smoke check, an existing integration test, or the repository gate. Do not add production abstractions solely to make a low-risk declarative edit unit-testable, and do not require an exception report for work that is outside this boundary.
+
 ## Cycle
 
 1. Identify the smallest observable behavior that should change.
-2. Add or update the lowest-level meaningful test. Control time, randomness, network, storage, and other external inputs so the test is deterministic and isolated.
-3. Run it and confirm it fails for the intended reason. If it passes, correct the test or establish why another check is the valid red state.
+2. Add or update the narrowest test at a stable boundary that proves the behavior. Control time, randomness, network, storage, and other external inputs so the test is deterministic and isolated.
+3. Run it and confirm the intended test executes and fails for the intended reason. Discovering zero tests is not a red state. If the test passes, correct it or establish why another check is the valid red state.
 4. Implement the smallest change that makes the test pass. Do not weaken or delete a correct test to accommodate the implementation.
 5. Run the focused test, then relevant integration or end-to-end coverage and the repository gate.
 6. Refactor only while tests are green and without changing behavior.
@@ -20,7 +35,7 @@ For a bug, add a regression test when feasible. For a multi-path change, repeat 
 
 ## Exceptions
 
-Pure formatting, comments, behavior-preserving renames, exploratory spikes, and visual-only styling may not benefit from a red-first cycle. Requirements may also be too uncertain to encode safely.
+Pure formatting, comments, behavior-preserving renames, exploratory spikes, visual-only styling, and declarative edits with no custom behavior are outside the normal TDD boundary. Requirements may also be too uncertain to encode safely.
 
 When a non-trivial behavior change cannot start with a failing test, state:
 

--- a/skills/workflow-repository/applying-tdd/agents/openai.yaml
+++ b/skills/workflow-repository/applying-tdd/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Applying TDD"
-  short_description: "Drive behavior changes with TDD when practical."
-  default_prompt: "Use $applying-tdd to prove the focused failure, make the smallest passing change, and refactor safely when a red-first cycle is practical."
+  short_description: "Scope TDD by source and test-data boundaries."
+  default_prompt: "Use $applying-tdd to enforce the ecosystem's production-scope and test-isolation boundaries, then apply red-green-refactor only to eligible observable behavior."

--- a/skills/workflow-repository/applying-tdd/references/test-boundaries.md
+++ b/skills/workflow-repository/applying-tdd/references/test-boundaries.md
@@ -1,0 +1,81 @@
+# Test Boundaries
+
+These are explicit policy defaults for this skill, not claims that every project in an ecosystem uses the same layout. More-specific repository instructions may replace a row. Otherwise, apply a listed row exactly; do not substitute another production root because the project uses a different layout.
+
+A work unit enters TDD only when:
+
+1. its production path matches the ecosystem row
+2. it passes the behavior gate in `SKILL.md`
+3. its test uses only the permitted test-owned inputs
+
+For an unlisted ecosystem, use the general behavior gate until an explicit row is added.
+
+## Boundary List
+
+| Ecosystem | Project boundary | Production behavior eligible for TDD | Test placement and owned inputs |
+| --- | --- | --- | --- |
+| Python | Nearest ancestor containing `pyproject.toml`, `setup.cfg`, or `setup.py` | Behavior and packaged runtime resources under `src/`; exclude generated and vendored code | Tests under `tests/`; inline builders, `tests/fixtures/`, temporary paths, mocks, and fakes |
+| Rust | Nearest ancestor whose `Cargo.toml` defines a package; evaluate each workspace member separately | Behavior and packaged runtime resources under `src/`; exclude generated and vendored code | Unit and documentation tests attached to `src/`; integration tests and fixtures under `tests/`; temporary paths, mocks, and fakes |
+| Go | Nearest ancestor containing `go.mod`; evaluate each workspace module separately | Non-test, non-generated `.go` files in packages selected by `go list ./...`; exclude `vendor/` and `testdata/` | Colocated `*_test.go`; the target package's `testdata/`, `t.TempDir()`, mocks, fakes, and local in-process test servers |
+| TypeScript | Nearest ancestor containing `package.json`; evaluate each monorepo member separately | Runtime source under `src/` using `.ts`, `.tsx`, `.mts`, or `.cts`; exclude declarations, generated code, tests, fixtures, and mocks | Files discovered by the configured runner; conservative fallback: `tests/**/*.test.{ts,tsx,mts,cts}`; test-owned fixtures, temporary paths, mocks, and fakes |
+| JavaScript | Nearest ancestor containing `package.json`; evaluate each monorepo member separately | Runtime source under `src/` using `.js`, `.jsx`, `.mjs`, or `.cjs`; exclude generated code, tests, fixtures, and mocks | Files discovered by the configured runner; conservative fallback: `tests/**/*.test.{js,jsx,mjs,cjs}`; test-owned fixtures, temporary paths, mocks, and fakes |
+
+## Isolation Rules
+
+- Test only behavior provided by the eligible production path. Helpers and fixtures are support code, not the subject under test.
+- Exercise a stable interface; do not inspect source text or repeat static source or config values in assertions.
+- If eligible behavior normally reads data from outside its production path, recreate the smallest representative input in a permitted fixture location or per-test temporary workspace, then pass or inject it.
+- Tests may import ordinary dependencies, but replace external side effects with controlled test doubles or local in-process substitutes.
+- Test code must not open or assert against real manifests, lockfiles, tool configuration, scripts, migrations, examples, benchmarks, build output, user files, host environment values, network services, or databases. Build and test tools may still read their own configuration to compile and discover tests.
+- A production change outside the listed path is outside TDD. Tests may still be added in the listed test location for eligible production behavior.
+
+## Ecosystem-Specific Rules
+
+### Python
+
+Test `src/package/config.py` with data under `tests/fixtures/` or generated in a temporary directory. Do not read the project's real `pyproject.toml` as test data.
+
+### Rust
+
+Keep focused unit tests in `#[cfg(test)]` modules beside the behavior. Use `tests/` for public integration behavior and documentation tests for documented public examples. Treat `build.rs`, `examples/`, `benches/`, manifests, lockfiles, and `target/` as outside TDD.
+
+### Go
+
+Use the package name when private access is necessary and its `_test` variant when testing only the exported contract. Keep static samples in that package's `testdata/`; the Go tool excludes this directory from normal package discovery. Use `t.TempDir()` for mutable files and `httptest` for HTTP behavior.
+
+### TypeScript and JavaScript
+
+Determine the runner from package scripts and runner configuration before choosing the test filename. Configuration controls discovery, but it is not test data.
+
+- If the runner defines `include`, `testMatch`, or an equivalent matcher, the test must match it.
+- Without a custom matcher, Vitest discovers `*.test.*` and `*.spec.*`; Jest discovers those suffixes and supported files under `__tests__/`.
+- For another or unknown runner, use the conservative `tests/<behavior>.test.<extension>` fallback and invoke that file explicitly when supported.
+- Store static data under a fixture or mock directory owned by the discovered test location; otherwise generate it in a per-test temporary directory.
+- TypeScript declaration-only changes such as `.d.ts` are outside TDD; validate them with the configured type checker or type-test tooling.
+- Treat package manifests, lockfiles, `tsconfig`, runner and bundler configuration, scripts, distribution output, coverage output, and real browser profiles as outside TDD.
+
+## Outside-TDD Validation
+
+Always run relevant existing tests or a focused smoke check plus the repository gate when available. Add the cheapest ecosystem-specific checks that cover the change:
+
+| Ecosystem | Typical checks |
+| --- | --- |
+| Python | Parser or schema validation, lint, formatting, type checking, packaging, or build checks |
+| Rust | `cargo fmt --check`, `cargo check`, Clippy, or package and workspace builds |
+| Go | `gofmt`, `go vet`, package and module builds, migration checks, or generation checks |
+| TypeScript | Configuration parsing, lint, formatting, type checking, or package builds |
+| JavaScript | Configuration parsing, lint, formatting, package or bundle builds |
+
+## Convention Basis
+
+The `src/` restrictions for Python, TypeScript, and JavaScript are deliberate skill policy defaults. Python's `src` layout is documented but not universal; JavaScript and TypeScript have no single mandatory source layout. Rust and Go locations follow their toolchains more directly. Test discovery must still be verified against the active runner.
+
+- [Python `src` layout versus flat layout](https://packaging.python.org/en/latest/discussions/src-layout-vs-flat-layout/)
+- [Cargo package layout](https://doc.rust-lang.org/cargo/guide/project-layout.html)
+- [Cargo tests](https://doc.rust-lang.org/cargo/guide/tests.html)
+- [Go test packages](https://pkg.go.dev/cmd/go#hdr-Test_packages)
+- [Vitest test inclusion](https://vitest.dev/config/include)
+- [Jest `testMatch`](https://jestjs.io/docs/configuration#testmatch-arraystring)
+- [Node.js test runner](https://nodejs.org/api/test.html#running-tests-from-the-command-line)
+
+Add another ecosystem only when its production scope, test discovery, permitted inputs, and outside-boundary validation can all be defined explicitly.


### PR DESCRIPTION
## Summary

- gate TDD by explicit production-path and observable-behavior boundaries
- define isolated test-data conventions for Python, Rust, Go, TypeScript, and JavaScript
- align skill metadata and catalog wording with the new scope decision

## Affected paths

- `README.md`
- `skills/workflow-repository/applying-tdd/SKILL.md`
- `skills/workflow-repository/applying-tdd/agents/openai.yaml`
- `skills/workflow-repository/applying-tdd/references/test-boundaries.md`

## Verification

- `UV_CACHE_DIR=/tmp/uv-cache uv run --no-project --python 3.13 --with pyyaml python "$HOME/.codex/skills/.system/skill-creator/scripts/quick_validate.py" skills/workflow-repository/applying-tdd` — passed
- `prek run -a` — passed
- `git diff --check` — passed
