### PR TITLE
feat(maintaining-memory-md): add curation workflow

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -15,6 +15,6 @@
 - Prefer preserving a skill's original user intent when naming or renaming skills; do not force `<verb-ing>-<object>` if it changes the meaning.
 - Prefer retaining explicit-invocation skills that act as useful mode shortcuts even when the model can infer the behavior; specifically keep `explaining-step-by-step` for requesting progressive explanations.
 - `writing-git-commits` should rely on the repo-level `AGENTS.md` for the Git baseline; `SKILL.md` should keep only the flow and judgment from diff to commit message, while less common Conventional Commits details belong in `references/`.
-- `maintaining-memory-md` should check at conversation start without creating `MEMORY.md` merely because it is missing; when the first qualifying `GOTCHA`, durable `TASTE`, or evidence-backed entry under `CONVENTIONS` emerges, it should create the repository-root file without extra confirmation and revise stale or similar entries in place.
+- `maintaining-memory-md` should check at conversation start without creating `MEMORY.md` merely because it is missing; when the first qualifying `GOTCHA`, durable `TASTE`, or evidence-backed entry under `CONVENTIONS` emerges, it should create the repository-root file without extra confirmation. On every inspection or update, lightly curate provable defects; when explicitly asked to curate or concrete evidence suggests staleness, review every entry and conservatively retain and report unverified entries unless contrary evidence exists.
 
 ## CONVENTIONS

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Repository path: `skills/workflow-repository/`
 | `writing-git-commits` | Drafting, validating, or creating focused Conventional Commits from diffs. |
 | `syncing-main-branch` | Explicit, state-preserving switch to `main` and fast-forward-only update. |
 | `managing-git-worktrees` | Loss-aware worktree creation, repair, removal, pruning, and branch cleanup. |
-| `maintaining-memory-md` | Reads and maintains verified, concise repository gotchas, preferences, and conventions. |
+| `maintaining-memory-md` | Reads, maintains, and conservatively curates verified repository gotchas, preferences, and conventions. |
 | `writing-agents-md` | Creating or reviewing lean, scoped, evidence-backed `AGENTS.md` guidance. |
 
 ## 🗄️ Deprecated Skills

--- a/skills/workflow-repository/maintaining-memory-md/SKILL.md
+++ b/skills/workflow-repository/maintaining-memory-md/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: maintaining-memory-md
-description: Read and maintain concise repository-root MEMORY.md notes for verified gotchas, durable user preferences, and established repository conventions. Use at repository-conversation start, when MEMORY.md is mentioned or may be stale, or when a qualifying memory emerges.
+description: Read, maintain, and curate concise repository-root MEMORY.md notes for verified gotchas, durable user preferences, and established repository conventions. Use at repository-conversation start, when MEMORY.md is mentioned, when its curation or cleanup is requested, when concrete evidence suggests it may be stale, or when a qualifying memory emerges.
 ---
 
 # Maintaining MEMORY.md
@@ -13,7 +13,18 @@ Resolve the repository root and inspect `MEMORY.md` at the start of repository w
 - **TASTE:** the user expresses a durable preference that will change future repository work.
 - **CONVENTIONS:** repository evidence proves a stable, repository-specific pattern in code, structure, naming, testing, or workflow that will change future work.
 
-Do not record transient status, task history, broad summaries, speculation, generic best practices, or secrets. Do not duplicate conventions already stated in `AGENTS.md` or authoritative documentation. If a convention should govern all contributors, recommend updating its authoritative owner unless that file is already within the user's requested scope; do not record it in `MEMORY.md`. Sanitize any reusable lesson involving credentials, tokens, private endpoints, proprietary data, or personal information.
+Do not record transient status, task history, broad summaries, speculation, generic best practices, or secrets. Do not add conventions already stated in `AGENTS.md` or authoritative documentation. If a convention should govern all contributors, recommend updating its authoritative owner unless that file is already within the user's requested scope; do not add a new memory entry for it. During curation, retain an existing entry that is the sole record until its authoritative update is completed, then remove the duplicate. Sanitize any reusable lesson involving credentials, tokens, private endpoints, proprietary data, or personal information.
+
+## Curate
+
+Perform lightweight curation whenever inspecting or updating memory. Using the evidence already gathered, merge, revise, remove, or sanitize entries that are demonstrably duplicated, misplaced, contradicted, stale, non-qualifying, or sensitive. Do not broaden a lightweight pass into a repository-wide audit.
+
+Perform full curation when the user explicitly requests it or concrete evidence suggests `MEMORY.md` may be stale. Check every entry against current repository evidence, authoritative guidance, and later explicit user preferences:
+
+- Keep entries that remain correct and qualifying.
+- Merge or rewrite entries that remain useful but are inaccurate, misplaced, or overlapping.
+- Remove or safely rewrite entries proven wrong, stale, superseded, duplicated, non-qualifying, or sensitive.
+- Leave an entry unchanged when it cannot currently be reverified and no evidence contradicts it. Report it as unverified; absence of evidence is not evidence that it is stale.
 
 ## Create or Update
 
@@ -38,4 +49,4 @@ Do not record transient status, task history, broad summaries, speculation, gene
 - Use <pattern> for <context>; repository evidence: <concise evidence>.
 ```
 
-After editing, reread the file to verify all three headings, placement, deduplication, and absence of sensitive or task-log content. Report the entry created or revised; do not claim memory was updated when writes were unavailable.
+After editing, reread the file to verify all three headings, placement, deduplication, and absence of sensitive or task-log content. For an ordinary update or lightweight pass, report only entries actually changed. For full curation, summarize kept, merged or revised, removed or sanitized, and unverified entries. Do not claim edits or verification that were not completed.

--- a/skills/workflow-repository/maintaining-memory-md/agents/openai.yaml
+++ b/skills/workflow-repository/maintaining-memory-md/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "MEMORY.md Keeper"
-  short_description: "Maintain verified gotchas, preferences, and conventions."
-  default_prompt: "Use $maintaining-memory-md to read repository memory and create or revise only a qualifying, concise, sanitized entry under GOTCHA, TASTE, or CONVENTIONS."
+  short_description: "Maintain and conservatively curate repository memory."
+  default_prompt: "Use $maintaining-memory-md to maintain qualifying repository memory, applying lightweight curation during ordinary work and a conservative full review when curation is requested or staleness is suspected."


### PR DESCRIPTION
## Summary

- add lightweight curation during ordinary MEMORY.md inspection and updates
- add conservative full-file curation when requested or when concrete evidence suggests staleness
- define evidence, authoritative-source, sanitization, and unverified-entry handling
- align skill metadata, the README catalog, and the repository's recorded preference

## Affected paths

- `skills/workflow-repository/maintaining-memory-md/SKILL.md`
- `skills/workflow-repository/maintaining-memory-md/agents/openai.yaml`
- `README.md`
- `MEMORY.md`

## Verification

- `UV_CACHE_DIR=/tmp/uv-cache uv run --no-project --python 3.13 --with pyyaml python \"$HOME/.codex/skills/.system/skill-creator/scripts/quick_validate.py\" skills/workflow-repository/maintaining-memory-md` — passed (`Skill is valid!`)
- `prek run -a` — all hooks passed
- `git diff --check` — passed