### PR TITLE
fix(creating-telegraph-pages): discover existing tokens

### DIFF
--- a/skills/writing-research/creating-telegraph-pages/SKILL.md
+++ b/skills/writing-research/creating-telegraph-pages/SKILL.md
@@ -16,9 +16,9 @@ Use the bundled `scripts/telegraph.py` by absolute path. A page is a public exte
 
 ## Credentials and Account Boundary
 
-Prefer `TELEGRAPH_ACCESS_TOKEN` from the user's secure environment. Never place a token in arguments, repository files, captured output, logs, or the response.
+Resolve credentials without exposing them: use a non-empty `TELEGRAPH_ACCESS_TOKEN`, then an explicit trusted `--token-file`, then `$XDG_CONFIG_HOME/telegraph/access-token` (or `~/.config/telegraph/access-token`). Before proposing account creation, check whether the environment variable is set or the default file is readable without printing either value. Do not mistake an unset environment variable for a missing account. Never place a token in arguments, repository files, captured output, logs, or the response.
 
-If no account exists, obtain separate approval for account creation, short name, and a new secret-file path. Then run:
+Only when no usable token exists, obtain separate approval for account creation, short name, and a new secret-file path. Then run:
 
 ```shell
 uv run --no-project python "$SKILL_DIR/scripts/telegraph.py" create-account \
@@ -40,7 +40,9 @@ uv run --no-project python "$SKILL_DIR/scripts/telegraph.py" create-page \
   /tmp/telegraph-content.json
 ```
 
-Pass the approved byline values explicitly. To suppress account-default identity, include `--author-name '' --author-url ''`; omitting these fields can publish the account's default author name or URL. Inject the token through the execution environment and load an approved token file without printing it.
+The helper automatically uses the standard token file when the environment variable is unset. For another existing token file, add `--token-file '<trusted-secret-path>'`; the helper reads it internally so its contents do not enter captured output.
+
+Pass the approved byline values explicitly. To suppress account-default identity, include `--author-name '' --author-url ''`; omitting these fields can publish the account's default author name or URL.
 
 Require an `https://telegra.ph/...` result, then fetch or open the public page and verify title, byline, links, and content structure. Report the URL and any unavailable check. Remove sensitive temporary drafts after successful publication.
 

--- a/skills/writing-research/creating-telegraph-pages/scripts/telegraph.py
+++ b/skills/writing-research/creating-telegraph-pages/scripts/telegraph.py
@@ -42,6 +42,33 @@ ALLOWED_NODE_FIELDS = {"tag", "attrs", "children"}
 MAX_CONTENT_BYTES = 64 * 1024
 
 
+def _default_token_file():
+    config_home = os.environ.get("XDG_CONFIG_HOME")
+    if config_home:
+        return Path(config_home).expanduser() / "telegraph" / "access-token"
+    return Path.home() / ".config" / "telegraph" / "access-token"
+
+
+def _load_access_token(token_file=None):
+    token = os.environ.get("TELEGRAPH_ACCESS_TOKEN", "").strip()
+    if token:
+        return token
+
+    token_file = Path(token_file) if token_file is not None else _default_token_file()
+    try:
+        token = token_file.read_text(encoding="utf-8").strip()
+    except FileNotFoundError as error:
+        raise ValueError(
+            "Set TELEGRAPH_ACCESS_TOKEN or provide an access-token file "
+            f"(default: {token_file})"
+        ) from error
+    except OSError as error:
+        raise ValueError(f"Unable to read access-token file: {token_file}") from error
+    if not token:
+        raise ValueError(f"Access-token file is empty: {token_file}")
+    return token
+
+
 def validate_content(content):
     if not isinstance(content, list):
         raise ValueError("Content must be a JSON array of Telegraph nodes")
@@ -231,6 +258,15 @@ def build_parser():
     page.add_argument("content", type=Path, help="JSON file containing Telegraph nodes")
     page.add_argument("--title", required=True)
     page.add_argument(
+        "--token-file",
+        type=Path,
+        help=(
+            "Existing access-token file; defaults to "
+            "$XDG_CONFIG_HOME/telegraph/access-token or "
+            "~/.config/telegraph/access-token when TELEGRAPH_ACCESS_TOKEN is unset"
+        ),
+    )
+    page.add_argument(
         "--author-name",
         required=True,
         help="Approved author name, or an empty string to suppress the account default",
@@ -250,9 +286,10 @@ def main(argv=None):
             args.short_name, args.token_file, args.author_name, args.author_url
         )
     else:
-        token = os.environ.get("TELEGRAPH_ACCESS_TOKEN")
-        if not token:
-            raise SystemExit("TELEGRAPH_ACCESS_TOKEN is required for create-page")
+        try:
+            token = _load_access_token(args.token_file)
+        except ValueError as error:
+            raise SystemExit(str(error)) from error
         with args.content.open(encoding="utf-8") as content_file:
             content = json.load(content_file)
         result = create_page(


### PR DESCRIPTION
## Summary

- discover Telegraph access tokens from the environment, an explicit token file, or the standard XDG/config path
- prevent the skill from treating an unset environment variable as evidence that no account exists
- keep token-file contents inside the helper rather than captured command output

## Affected paths

- `skills/writing-research/creating-telegraph-pages/SKILL.md`
- `skills/writing-research/creating-telegraph-pages/scripts/telegraph.py`

## Verification

- `prek run -a` — passed
- `uv run --no-project python -m py_compile skills/writing-research/creating-telegraph-pages/scripts/telegraph.py` — passed
- helper checks for environment precedence, XDG/default-file fallback, explicit token-file fallback, and existing `~/.config/telegraph/access-token` discovery — passed
- `create-page --help` token-file option check — passed