### PR TITLE
chore(skills): remove OpenAI metadata

### DIFF
--- a/deprecated/building-codex-hooks/agents/openai.yaml
+++ b/deprecated/building-codex-hooks/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Codex CLI Hooks (Deprecated)"
-  short_description: "Interpret legacy Codex hook configs and scripts."
-  default_prompt: "Use $building-codex-hooks as a deprecated reference, verify current Codex documentation first, and then migrate or diagnose this hook."

--- a/deprecated/checking-cli-help/agents/openai.yaml
+++ b/deprecated/checking-cli-help/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Checking CLI Help (Deprecated)"
-  short_description: "Decide when exact command help is needed."
-  default_prompt: "Use $checking-cli-help to decide whether this exact command is understood well enough to run or needs focused help inspection first."

--- a/deprecated/cleaning-atuin-history/agents/openai.yaml
+++ b/deprecated/cleaning-atuin-history/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Atuin Cleanup (Deprecated)"
-  short_description: "Audit Atuin history with transactional cleanup disabled."
-  default_prompt: "Use $cleaning-atuin-history to audit duplicates and typo candidates, keep cleanup-typos disabled, and prepare only fixed-scope dedup or user-run inspector steps."

--- a/deprecated/naming-agent-skills/agents/openai.yaml
+++ b/deprecated/naming-agent-skills/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Naming Agent Skills (Deprecated)"
-  short_description: "Use the merged skill-naming reference."
-  default_prompt: "Use $naming-agent-skills as a deprecated compatibility reference; prefer $creating-agent-skills for current naming, review, and authorized rename work."

--- a/deprecated/researching-gourmet-venues/agents/openai.yaml
+++ b/deprecated/researching-gourmet-venues/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Gourmet Venue Research (Deprecated)"
-  short_description: "Use the legacy gourmet research workflow."
-  default_prompt: "Use $researching-gourmet-venues as a deprecated compatibility reference to create or update a traceable city dining research pack with scope-checked sources, synchronized scores, and caveats."

--- a/deprecated/syncing-main-branch/agents/openai.yaml
+++ b/deprecated/syncing-main-branch/agents/openai.yaml
@@ -1,6 +1,0 @@
-interface:
-  display_name: "Sync Main Branch (Deprecated)"
-  short_description: "Use the legacy safe main-sync workflow."
-  default_prompt: "Use $syncing-main-branch as a deprecated compatibility reference to preserve current state, switch this repository to main, and fast-forward only from its verified upstream."
-policy:
-  allow_implicit_invocation: false

--- a/deprecated/writing-work-logs/agents/openai.yaml
+++ b/deprecated/writing-work-logs/agents/openai.yaml
@@ -1,6 +1,0 @@
-interface:
-  display_name: "Work Logs (Deprecated)"
-  short_description: "Write concise Git-evidence work logs."
-  default_prompt: "Use $writing-work-logs to summarize the explicitly requested date range from this repository's Git evidence."
-policy:
-  allow_implicit_invocation: false

--- a/skills/learning-explanation/explaining-step-by-step/agents/openai.yaml
+++ b/skills/learning-explanation/explaining-step-by-step/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Explaining Step by Step"
-  short_description: "Explain complex material progressively from evidence."
-  default_prompt: "Use $explaining-step-by-step to build a clear evidence-grounded mental model from the big picture to the exact mechanism."

--- a/skills/python/building-typer-clis/agents/openai.yaml
+++ b/skills/python/building-typer-clis/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Building Typer CLIs"
-  short_description: "Build current Typer CLIs without grammar regressions."
-  default_prompt: "Use $building-typer-clis to preserve command grammar while building this Typer CLI with Annotated parameters, deliberate callbacks and exits, supported entry points, and current CliRunner tests."

--- a/skills/python/configuring-python-logging/agents/openai.yaml
+++ b/skills/python/configuring-python-logging/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Python Logging"
-  short_description: "Choose and configure Python logging boundaries."
-  default_prompt: "Use $configuring-python-logging to choose the appropriate logging backend, configure it at the correct boundary, and verify representative records."

--- a/skills/python/managing-python-with-uv/agents/openai.yaml
+++ b/skills/python/managing-python-with-uv/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Python with uv"
-  short_description: "Manage Python projects, scripts, checks, and builds with uv."
-  default_prompt: "Use $managing-python-with-uv to manage this Python project or script with uv, preserving repository tooling and publication boundaries."

--- a/skills/python/using-peewee-orm/agents/openai.yaml
+++ b/skills/python/using-peewee-orm/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Python Peewee"
-  short_description: "Wire Peewee lifecycle, transactions, and isolated tests."
-  default_prompt: "Use $using-peewee-orm to define the Peewee binding, connection, transaction, and SQLite test lifecycle for this task."

--- a/skills/slides-visuals/authoring-marp-slides/agents/openai.yaml
+++ b/skills/slides-visuals/authoring-marp-slides/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Marp Authoring"
-  short_description: "Author and validate focused Marp slide decks."
-  default_prompt: "Use $authoring-marp-slides to write or revise this Marp deck, load only the needed authoring references, and report rendered validation honestly."

--- a/skills/slides-visuals/creating-mermaid-diagrams/agents/openai.yaml
+++ b/skills/slides-visuals/creating-mermaid-diagrams/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Mermaid Diagrams"
-  short_description: "Create editable Mermaid diagrams and optional SVGs."
-  default_prompt: "Use $creating-mermaid-diagrams to create or revise this diagram, preserve editable Mermaid source, and render SVG only if the consumer needs it."

--- a/skills/slides-visuals/creating-slide-decks/agents/openai.yaml
+++ b/skills/slides-visuals/creating-slide-decks/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Creating Slide Decks"
-  short_description: "Create coherent, validated Marp decks and visuals."
-  default_prompt: "Use $creating-slide-decks to build or revise this complete Marp deck with a coherent narrative, palette, visuals, and rendered checks."

--- a/skills/slides-visuals/creating-svg-illustrations/agents/openai.yaml
+++ b/skills/slides-visuals/creating-svg-illustrations/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "SVG Illustrations"
-  short_description: "Create accessible, portable SVG illustrations."
-  default_prompt: "Use $creating-svg-illustrations to create or revise this SVG for the target artifact and report source and visual validation separately."

--- a/skills/slides-visuals/designing-slide-colors/agents/openai.yaml
+++ b/skills/slides-visuals/designing-slide-colors/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Slide Color Design"
-  short_description: "Design semantic slide palettes with contrast evidence."
-  default_prompt: "Use $designing-slide-colors to design or validate this slide palette, define semantic roles, calculate actual pairings, and leave unperformed checks open."

--- a/skills/ui-ux-design/designing-user-experiences/agents/openai.yaml
+++ b/skills/ui-ux-design/designing-user-experiences/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Designing User Experiences"
-  short_description: "Plan new or redesigned digital user experiences."
-  default_prompt: "Use $designing-user-experiences to analyze the goals and constraints for this new or existing digital product, propose an evidence-backed UX design with acceptance criteria, and wait for approval before implementation."

--- a/skills/ui-ux-design/designing-user-interfaces/agents/openai.yaml
+++ b/skills/ui-ux-design/designing-user-interfaces/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Designing User Interfaces"
-  short_description: "Design accessible interfaces without false simplicity."
-  default_prompt: "Use $designing-user-interfaces to apply Apple-derived philosophy through the target platform while preserving capability, agency, accessibility, and evidence-backed behavior."

--- a/skills/ui-ux-design/iterating-ui-improvements/agents/openai.yaml
+++ b/skills/ui-ux-design/iterating-ui-improvements/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Iterating UI Improvements"
-  short_description: "Explicitly run DevTools audit-fix-commit UI loops."
-  default_prompt: "Explicitly invoke $iterating-ui-improvements to audit the target interface with Chrome DevTools, plan and implement one evidence-backed improvement at a time, validate it, and create focused local commits until the selected stopping condition is met."

--- a/skills/workflow-repository/applying-tdd/agents/openai.yaml
+++ b/skills/workflow-repository/applying-tdd/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Applying TDD"
-  short_description: "Scope TDD by source and test-data boundaries."
-  default_prompt: "Use $applying-tdd to enforce the ecosystem's production-scope and test-isolation boundaries, then apply red-green-refactor only to eligible observable behavior."

--- a/skills/workflow-repository/auditing-code-security/agents/openai.yaml
+++ b/skills/workflow-repository/auditing-code-security/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Code Security Audit"
-  short_description: "Run security-first, read-only audits with verified evidence."
-  default_prompt: "Use $auditing-code-security to run a security-first, read-only audit of the requested code scope, verify tool alerts against reachable paths, and report evidence-backed findings without changing code."

--- a/skills/workflow-repository/creating-agent-skills/agents/openai.yaml
+++ b/skills/workflow-repository/creating-agent-skills/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Creating and Naming Agent Skills"
-  short_description: "Create, name, rename, and review lean agent skills."
-  default_prompt: "Use $creating-agent-skills to create, name, rename, optimize, or review this skill for reliable triggering, low naming overlap, lean instructions, aligned metadata, and validation."

--- a/skills/workflow-repository/hardening-code-paths/agents/openai.yaml
+++ b/skills/workflow-repository/hardening-code-paths/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Hardening Code Paths"
-  short_description: "Fix confirmed failure modes and security findings safely."
-  default_prompt: "Use $hardening-code-paths to confirm failure modes or security findings, reproduce the original conditions, fix the shared boundary, and verify bounded sibling cases."

--- a/skills/workflow-repository/improving-codebase-architecture/agents/openai.yaml
+++ b/skills/workflow-repository/improving-codebase-architecture/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Improving Codebase Architecture"
-  short_description: "Improve module boundaries with evidence and safe refactoring."
-  default_prompt: "Use $improving-codebase-architecture to assess structural friction, rank evidence-backed module improvements, and safely implement only the scope I authorize."

--- a/skills/workflow-repository/maintaining-memory-md/agents/openai.yaml
+++ b/skills/workflow-repository/maintaining-memory-md/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "MEMORY.md Keeper"
-  short_description: "Maintain and conservatively curate repository memory."
-  default_prompt: "Use $maintaining-memory-md to maintain qualifying repository memory, applying lightweight curation during ordinary work and a conservative full review when curation is requested or staleness is suspected."

--- a/skills/workflow-repository/managing-git-worktrees/agents/openai.yaml
+++ b/skills/workflow-repository/managing-git-worktrees/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Managing Git Worktrees"
-  short_description: "Manage worktrees without losing data or commits."
-  default_prompt: "Use $managing-git-worktrees to inspect and perform this worktree lifecycle task while preserving local data, refs, and detached commits."

--- a/skills/workflow-repository/resolving-pr-review-comments/agents/openai.yaml
+++ b/skills/workflow-repository/resolving-pr-review-comments/agents/openai.yaml
@@ -1,6 +1,0 @@
-interface:
-  display_name: "Resolve PR Review Comments"
-  short_description: "Verify PR feedback and prepare bounded resolutions."
-  default_prompt: "Use $resolving-pr-review-comments to inspect all PR feedback, fix and verify reasonable findings locally, then prepare exact public actions for approval."
-policy:
-  allow_implicit_invocation: false

--- a/skills/workflow-repository/reviewing-code/agents/openai.yaml
+++ b/skills/workflow-repository/reviewing-code/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Code Review"
-  short_description: "Review changes with baseline security and integration checks."
-  default_prompt: "Use $reviewing-code for an ordinary read-only review with baseline security checks; use $auditing-code-security for a security audit when security is the primary objective."

--- a/skills/workflow-repository/running-panel-review-loops/agents/openai.yaml
+++ b/skills/workflow-repository/running-panel-review-loops/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Panel Review Loops"
-  short_description: "Run iterative multi-reviewer code-review consensus loops."
-  default_prompt: "Use $running-panel-review-loops to run independent code-review panels, verify their findings, apply only explicitly requested fixes, and re-review the updated diff until the acceptance or stopping condition is met."

--- a/skills/workflow-repository/scoring-agent-skills/agents/openai.yaml
+++ b/skills/workflow-repository/scoring-agent-skills/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Agent Skill Scoring"
-  short_description: "Create numerical agent skill quality scorecards."
-  default_prompt: "Use $scoring-agent-skills to numerically score or compare the requested agent skills across trigger clarity, workflow actionability, safety boundaries, verification rigor, incremental knowledge value, and leanness, with direct evidence and clearly stated assessment limits."

--- a/skills/workflow-repository/using-jira-cli/agents/openai.yaml
+++ b/skills/workflow-repository/using-jira-cli/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Using Jira CLI"
-  short_description: "Inspect Jira and perform exact authorized mutations."
-  default_prompt: "Use $using-jira-cli to inspect the confirmed Jira instance or prepare and verify the exact Jira mutation I authorize."

--- a/skills/workflow-repository/writing-agents-md/agents/openai.yaml
+++ b/skills/workflow-repository/writing-agents-md/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Writing AGENTS.md"
-  short_description: "Write lean, scoped, evidence-backed agent guidance."
-  default_prompt: "Use $writing-agents-md to create or review concise repository guidance with grounded commands, clear authority, and verifiable completion."

--- a/skills/workflow-repository/writing-git-commits/agents/openai.yaml
+++ b/skills/workflow-repository/writing-git-commits/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Writing Git Commits"
-  short_description: "Draft, validate, or create focused Conventional Commits."
-  default_prompt: "Use $writing-git-commits to inspect the selected diff and draft, validate, or create the focused Conventional Commit requested."

--- a/skills/writing-research/applying-imrad/agents/openai.yaml
+++ b/skills/writing-research/applying-imrad/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Applying IMRaD"
-  short_description: "Fit-check, review, transform, or draft IMRaD."
-  default_prompt: "Use $applying-imrad to choose the right IMRaD mode, preserve strict section boundaries, and keep every claim traceable to evidence or explicit assumptions."

--- a/skills/writing-research/creating-telegraph-pages/agents/openai.yaml
+++ b/skills/writing-research/creating-telegraph-pages/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Creating Telegraph Pages"
-  short_description: "Prepare and publish one authorized Telegra.ph page."
-  default_prompt: "Use $creating-telegraph-pages to prepare and publish this one explicitly authorized Telegra.ph article with safe credentials and public-page verification."

--- a/skills/writing-research/grilling-designs/agents/openai.yaml
+++ b/skills/writing-research/grilling-designs/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Grilling Designs"
-  short_description: "Resolve design decisions one hard question at a time."
-  default_prompt: "Use $grilling-designs to stress-test this design one evidence-informed decision at a time until no major branch remains unresolved."

--- a/skills/writing-research/grounding-with-google-genai/agents/openai.yaml
+++ b/skills/writing-research/grounding-with-google-genai/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Google GenAI Grounding"
-  short_description: "Grounded research with Google GenAI tools"
-  default_prompt: "Use $grounding-with-google-genai to answer this request with Google Search, Google Maps, or URL Context grounding."

--- a/skills/writing-research/writing-plans/agents/openai.yaml
+++ b/skills/writing-research/writing-plans/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Writing Plans"
-  short_description: "Draft, execute, and track lean implementation plans."
-  default_prompt: "Use $writing-plans to draft, execute, or track the requested implementation plan with bounded tasks, acceptance evidence, and finite completion checks."

--- a/skills/writing-research/writing-roadmap/agents/openai.yaml
+++ b/skills/writing-research/writing-roadmap/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Writing Roadmaps"
-  short_description: "Create concise, progress-trackable strategic roadmaps."
-  default_prompt: "Use $writing-roadmap to create, revise, or review a concise, evidence-grounded strategic roadmap with milestone checkboxes, adding detailed sections only when they are useful."


### PR DESCRIPTION
## Summary
- remove all tracked `agents/openai.yaml` skill metadata files
- cover active skills and deprecated skills

## Affected paths
- `skills/**/agents/openai.yaml`
- `deprecated/**/agents/openai.yaml`

## Verification
- `find . -type f -path '*/agents/openai.yaml' -print` — no files found
- `prek run -a` — passed