### PR TITLE
docs(writing-agents-md): streamline guidance

### DIFF
--- a/skills/workflow-repository/writing-agents-md/SKILL.md
+++ b/skills/workflow-repository/writing-agents-md/SKILL.md
@@ -9,21 +9,19 @@ Write the smallest repository guidance that gives an agent the context, constrai
 
 ## Workflow
 
-1. Resolve the target directory and all applicable `AGENTS.md` files. Explicit user instructions outrank repository guidance; the closest scoped file outranks ancestors. Default to one root file and add nested files only for genuinely different subproject rules.
-2. Inspect current guidance, README/CONTRIBUTING, manifests, task files, CI, and relevant package docs. Verify paths and commands from executable configuration where possible; label unresolved facts instead of importing ecosystem conventions.
-3. Identify generated, vendored, migration-sensitive, destructive, external, large-data, and ownership boundaries that materially change agent behavior.
-4. Preserve correct project-specific rules and remove stale, repeated, speculative, generic, or misplaced content. Keep global rules in parents and local differences in children.
-5. Verify every command and path, check the instruction chain for conflicts, run proportionate documentation or repository checks, and inspect the diff for duplication and scope growth.
-6. For edits, report changed paths, purpose, checks, and caveats. For review, lead with concrete findings and replacement guidance.
+1. Resolve the target directory and applicable `AGENTS.md` chain. Explicit user instructions outrank repository guidance; the closest scoped file outranks ancestors. Default to one root file and add nested files only for genuinely different subproject rules.
+2. Inspect current guidance, human docs, manifests, task files, CI, and relevant package docs. Verify commands and paths from executable configuration where possible, and identify generated, vendored, migration-sensitive, destructive, external, large-data, or ownership boundaries that change agent behavior.
+3. Keep only correct project-specific rules. Remove stale, repeated, speculative, generic, or misplaced content; keep shared rules in parents and local differences in children.
+4. Check the instruction chain for conflicts, run proportionate checks, and inspect the diff for duplication or scope growth. Label facts that remain unresolved.
+5. For reviews, prioritize wrong commands, stale paths, conflicting scope, unsafe authority, and missing verification. Give each finding a severity, location, evidence, and replacement; if none remain, state that and note material evidence gaps.
 
-## Instruction Design
+## Writing Rules
 
-- State outcome, relevant context, hard constraints, approval boundaries, and success criteria. Prescribe sequence only when order is operationally important.
+- State the outcome, relevant context, hard constraints, approval boundaries, and success criteria. Prescribe sequence only when order matters.
 - State each rule once at the narrowest scope. Use direct imperatives and concrete paths, commands, conditions, evidence, and stopping points.
-- Keep examples only when they encode a project requirement or prevent a demonstrated mistake.
-- When response length matters, say which facts, evidence, caveats, and next action must remain; trim repetition and generic background first.
-- Define tone through observable choices rather than personality labels.
-- Name ambiguities that require a question; do not add blanket approval requests for safe local work.
+- Include only agent-needed scope, commands, code/test conventions, security or data constraints, and collaboration or release rules. Keep product positioning and human walkthroughs in human docs.
+- Keep examples or response-style rules only when they encode a project requirement or prevent a demonstrated mistake.
+- Name ambiguities that require a question; do not require blanket approval for safe local work.
 
 When action policy is needed, keep one compact block:
 
@@ -33,12 +31,6 @@ For change, build, or fix requests, make bounded local changes and run relevant 
 Require confirmation for external writes, destructive or costly actions, and material scope expansion.
 ```
 
-Adapt that policy to repository evidence. Name safe local actions and any domain-specific exception; do not scatter duplicates.
+Adapt the policy to repository evidence, naming safe local actions and domain-specific exceptions without repeating it elsewhere.
 
-## Content and Tool Rules
-
-Include only needed structure/scope, commands, code/test conventions, security/data constraints, and collaboration/release rules. Keep product positioning and human installation walkthroughs in human docs unless an agent needs a specific command.
-
-Add orchestration guidance only for workflows the repository actually uses. For bounded automation, specify the stage, allowed tools, output/evidence schema, concurrency or retry limits, stopping condition, and the handoff to semantic judgment or approval. Avoid generic “use tools efficiently” rules.
-
-In review mode, prioritize wrong commands, stale paths, conflicting scope, unsafe authority, and missing verification. Each finding needs severity, location, evidence, and a specific replacement. If no findings remain, say so and identify material evidence gaps.
+Add orchestration rules only for workflows the repository uses. For bounded automation, define the stage, allowed tools, evidence, limits, stopping condition, and handoff to judgment or approval.


### PR DESCRIPTION
## Summary

- consolidate overlapping workflow and writing guidance
- remove generic response-style instructions and duplicated review rules
- preserve scope precedence, evidence requirements, approval boundaries, and verification criteria

## Affected paths

- `skills/workflow-repository/writing-agents-md/SKILL.md`

## Verification

- `prek run -a` — passed
- `git diff --check` — passed