### PR TITLE
feat(skills): add codebase memory CLI discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Repository path: `skills/workflow-repository/`
 | `resolving-pr-review-comments` | Explicit PR feedback assessment and local fixes, with exact approval for public actions. |
 | `hardening-code-paths` | Confirming and fixing code-path failure modes or verified security findings. |
 | `using-jira-cli` | Read-only Jira inspection and precisely authorized CLI mutations. |
+| `using-codebase-memory-cli` | Proactive CLI-only graph discovery, tracing, architecture, and change-impact analysis. |
 | `applying-tdd` | Scoping red-green-refactor with explicit production-path, test-data, and observable-behavior boundaries. |
 | `writing-git-commits` | Drafting, validating, or creating focused Conventional Commits from diffs. |
 | `managing-git-worktrees` | Loss-aware worktree creation, repair, removal, pruning, and branch cleanup. |

--- a/skills/workflow-repository/using-codebase-memory-cli/SKILL.md
+++ b/skills/workflow-repository/using-codebase-memory-cli/SKILL.md
@@ -5,9 +5,25 @@ description: Index and explore codebases with the `codebase-memory-mcp` command-
 
 # Using Codebase Memory CLI
 
-Use codebase-memory proactively as the default discovery path for unfamiliar or non-trivial code. Prefer its graph over grep, globbing, or broad file reads for symbols, relationships, architecture, and impact analysis, even when the user does not name the tool. Skip it for a known small file, a literal or configuration search, or when `command -v codebase-memory-mcp` shows that the CLI is unavailable.
+Use codebase-memory proactively as the default discovery path for unfamiliar or non-trivial code. Prefer its graph over grep, globbing, or broad file reads for symbols, relationships, architecture, and impact analysis, even when the user does not name the tool. Skip it for a known small file, a literal or configuration search, or when the CLI is unavailable and installation has not been authorized.
 
 Do not start the MCP server, call MCP graph tools, or configure an agent to use them. Every graph operation must have the form `codebase-memory-mcp cli <tool> ...`; never run bare `codebase-memory-mcp`, because that starts the stdio server.
+
+## Install When Missing
+
+When `command -v codebase-memory-mcp` fails, offer the upstream installer instead of silently abandoning graph discovery:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/DeusData/codebase-memory-mcp/main/install.sh | bash
+```
+
+Downloading and executing a remote script requires explicit user approval. The upstream command defaults to automatic agent configuration, which conflicts with this CLI-only workflow; for an approved installation, preserve the installer but disable that configuration:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/DeusData/codebase-memory-mcp/main/install.sh | bash -s -- --skip-config
+```
+
+After installation, verify `command -v codebase-memory-mcp` and `codebase-memory-mcp --version`, then continue without starting the server.
 
 ## Establish the Index
 

--- a/skills/workflow-repository/using-codebase-memory-cli/SKILL.md
+++ b/skills/workflow-repository/using-codebase-memory-cli/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: using-codebase-memory-cli
+description: Index and explore codebases with the `codebase-memory-mcp` command-line interface for graph-first symbol search, call and data-flow tracing, source snippets, architecture, Cypher queries, and change impact. Use proactively for non-trivial code discovery, architecture exploration, relationship tracing, or change-impact analysis whenever the CLI is installed, and whenever the user or repository requests codebase-memory; never start or use an MCP server.
+---
+
+# Using Codebase Memory CLI
+
+Use codebase-memory proactively as the default discovery path for unfamiliar or non-trivial code. Prefer its graph over grep, globbing, or broad file reads for symbols, relationships, architecture, and impact analysis, even when the user does not name the tool. Skip it for a known small file, a literal or configuration search, or when `command -v codebase-memory-mcp` shows that the CLI is unavailable.
+
+Do not start the MCP server, call MCP graph tools, or configure an agent to use them. Every graph operation must have the form `codebase-memory-mcp cli <tool> ...`; never run bare `codebase-memory-mcp`, because that starts the stdio server.
+
+## Establish the Index
+
+1. Run `command -v codebase-memory-mcp`, `codebase-memory-mcp --version`, and the narrowest relevant help: `codebase-memory-mcp cli <tool> --help`.
+2. Run `codebase-memory-mcp cli list_projects` and match the target by `root_path`, not only by project name.
+3. Run `index_status` for an existing project. Compare its root and Git HEAD with the target repository; re-index when it is absent or stale. If semantic search is required and the existing index mode is unknown, re-index with an explicit semantic-capable mode.
+4. Use `index_repository` with an explicit repository path. Prefer `fast` for ordinary structural discovery, `moderate` when semantic search is needed with filtered files, and `full` only when excluded files or complete semantic coverage justify the extra work. Do not enable persistence unless a repository artifact was requested.
+
+Read [references/commands.md](references/commands.md) when choosing flags, structured input, index modes, or a less common tool.
+
+## Discover Graph-First
+
+Use this order, stopping when the required evidence is sufficient:
+
+1. `search_graph` to locate functions, methods, classes, interfaces, routes, channels, or other symbols. Start with `--query`; use `--name-pattern` or `--qn-pattern` for regex-like identifier matching. Do not combine `--query` with `--name-pattern`, because the query takes precedence.
+2. `trace_path` to find inbound callers, outbound callees, parameter data flow, or cross-service paths. Resolve ambiguous short names with search results before trusting a trace.
+3. `get_code_snippet` with the returned `qualified_name` to inspect exact source and optional immediate neighbors.
+4. `query_graph` only for relationships or aggregations the focused tools cannot express. Run `get_graph_schema` first and build Cypher from the reported labels, properties, and edge types.
+5. `get_architecture` for a high-level or path-scoped view, not as a substitute for focused symbol evidence.
+
+Use `search_graph` pagination while `has_more` is true when completeness matters. Semantic queries require a `moderate` or `full` index and an array of keywords.
+
+Treat graph results as discovery evidence rather than infallible source truth. For critical behavior, verify the reported file, lines, snippet, and relevant tests or runtime evidence. Report unresolved ambiguity, filtered paths, stale index state, or missing edges instead of filling gaps by inference.
+
+## Fallback and Change Impact
+
+- Use CLI `search_code` for literals, error text, regexes, and exact source patterns that are a poor fit for symbol search.
+- Fall back to repository `rg`, `find`, or file reads for non-code files, generated or excluded paths, or when graph results remain insufficient. State why the fallback was needed.
+- Use `detect_changes` to identify symbols affected by the working tree or a requested Git range. Re-index before relying on subsequent graph exploration if source has changed since the index was built.
+
+## CLI and Safety Boundaries
+
+Prefer flags for simple values and piped JSON or `--args-file` for arrays and complex values. Positional raw JSON is deprecated. Parse stdout as JSON; initialization logs may appear on stderr. Inspect installed help rather than assuming remembered flags or schemas.
+
+Indexing without persistence is an expected local operation for an authorized discovery task. `delete_project`, persisted indexing, ADR updates, and trace ingestion are state-changing or potentially sensitive operations: perform them only when explicitly requested, after checking their installed help and exact target. Do not run `install`, agent integration setup, or server configuration as part of this workflow.
+
+Conclude with the project and index mode used, the relevant symbols and file/line evidence, any fallback performed, and material coverage limits. Do not leave a temporary test index behind unless the user wants to reuse it.

--- a/skills/workflow-repository/using-codebase-memory-cli/references/commands.md
+++ b/skills/workflow-repository/using-codebase-memory-cli/references/commands.md
@@ -1,0 +1,155 @@
+# Codebase Memory CLI Command Shapes
+
+These shapes were verified with `codebase-memory-mcp 0.9.0`. Check `codebase-memory-mcp cli <tool> --help` because flags and output schemas may change.
+
+## Invocation and Input
+
+```sh
+codebase-memory-mcp --version
+codebase-memory-mcp --help
+codebase-memory-mcp cli <tool> --help
+codebase-memory-mcp cli <tool> --flag value
+codebase-memory-mcp cli <tool> --args-file /tmp/codebase-memory-args.json
+printf '%s\n' '{"project":"my-project"}' | codebase-memory-mcp cli index_status
+```
+
+Do not use the deprecated positional raw-JSON form. Normal tool output is JSON on stdout; informational initialization logs are written to stderr. Bare `codebase-memory-mcp` starts the MCP stdio server and is forbidden by this skill.
+
+## Projects and Indexing
+
+```sh
+codebase-memory-mcp cli list_projects
+codebase-memory-mcp cli index_status --project my-project
+codebase-memory-mcp cli index_repository \
+  --repo-path /absolute/path/to/repository \
+  --mode fast \
+  --name my-project
+```
+
+`--name` is optional; use it to avoid collisions or make worktree identity explicit.
+
+Index modes from installed help:
+
+- `fast`: filtered files, type-aware LSP call/usage resolution, no similarity or semantic edges.
+- `moderate`: filtered files plus similarity and semantic edges.
+- `full`: all files plus similarity and semantic edges.
+- `cross-repo-intelligence`: match routes and channels across projects; pass `--target-projects` as an array.
+
+All modes perform per-file and cross-file type-aware LSP resolution. `--persistence true` writes `.codebase-memory/graph.db.zst` into the target repository; omit it unless that artifact is explicitly wanted.
+
+## Focused Discovery
+
+Keyword or natural-language BM25 search:
+
+```sh
+codebase-memory-mcp cli search_graph \
+  --project my-project \
+  --query 'extension loader' \
+  --limit 20 \
+  --offset 0
+```
+
+Identifier or structural search:
+
+```sh
+codebase-memory-mcp cli search_graph \
+  --project my-project \
+  --name-pattern '.*OrderHandler.*' \
+  --label Function \
+  --include-connected true \
+  --limit 20
+```
+
+A supplied `--query` ignores `--name-pattern`. Responses include `total` and `has_more`; increase `offset` by `limit` until complete when exhaustive coverage is required.
+
+Semantic search needs a `moderate` or `full` index. Use structured input so `semantic_query` remains an array:
+
+```sh
+printf '%s\n' '{
+  "project": "my-project",
+  "semantic_query": ["send", "pubsub", "publish"],
+  "limit": 20
+}' | codebase-memory-mcp cli search_graph
+```
+
+Each semantic keyword is scored independently, and semantic matches appear separately under `semantic_results`.
+
+## Tracing and Source
+
+```sh
+codebase-memory-mcp cli trace_path \
+  --project my-project \
+  --function-name OrderHandler \
+  --direction inbound \
+  --depth 3 \
+  --mode calls \
+  --risk-labels true \
+  --include-tests false
+
+codebase-memory-mcp cli trace_path \
+  --project my-project \
+  --function-name OrderHandler \
+  --direction outbound \
+  --depth 3 \
+  --mode data_flow \
+  --parameter-name order
+
+codebase-memory-mcp cli get_code_snippet \
+  --project my-project \
+  --qualified-name my-project.pkg.orders.OrderHandler \
+  --include-neighbors true
+```
+
+Trace modes are `calls`, `data_flow`, and `cross_service`. Cross-service mode follows HTTP, async, data-flow, and available cross-repository edges. When test callers matter, set `--include-tests true` explicitly.
+
+## Schema, Cypher, and Architecture
+
+Inspect the actual graph before writing Cypher:
+
+```sh
+codebase-memory-mcp cli get_graph_schema --project my-project
+
+codebase-memory-mcp cli query_graph \
+  --project my-project \
+  --query "MATCH (n:Function) WHERE n.name = 'OrderHandler' RETURN n.name, n.qualified_name, n.file_path LIMIT 20" \
+  --max-rows 20
+
+codebase-memory-mcp cli get_architecture \
+  --project my-project \
+  --aspects overview
+
+codebase-memory-mcp cli get_architecture \
+  --project my-project \
+  --path packages/orders \
+  --aspects all
+```
+
+`query_graph` has no offset pagination; constrain Cypher and `--max-rows`. `search_graph` is the better choice for paginated browsing.
+
+## Literal Search and Change Impact
+
+```sh
+codebase-memory-mcp cli search_code \
+  --project my-project \
+  --pattern 'ORDER_NOT_FOUND' \
+  --file-pattern '*.ts' \
+  --mode compact \
+  --context 2 \
+  --limit 20
+
+codebase-memory-mcp cli detect_changes \
+  --project my-project \
+  --scope all \
+  --depth 2
+
+codebase-memory-mcp cli detect_changes \
+  --project my-project \
+  --since HEAD~5 \
+  --depth 2
+```
+
+`search_code` modes are `compact`, `full`, and `files`. It reports grep and enriched-result totals but has no offset; narrow the path or file pattern, or raise the limit.
+
+## Non-Discovery Tools
+
+The CLI also exposes `delete_project`, `manage_adr`, and `ingest_traces`. These mutate stored state or may ingest sensitive runtime data. Do not use them during ordinary discovery. If explicitly requested, inspect the installed tool help, confirm the exact project and payload, execute only the approved operation, and verify the resulting state.


### PR DESCRIPTION
## Summary

- add a proactive `using-codebase-memory-cli` skill for graph-first code discovery without an MCP server
- document the upstream installer and a `--skip-config` variant that preserves the CLI-only boundary
- document tested CLI command shapes for indexing, symbol search, tracing, snippets, architecture, Cypher, literal search, and change impact
- add the skill to the README catalog

## Affected paths

- `skills/workflow-repository/using-codebase-memory-cli/SKILL.md`
- `skills/workflow-repository/using-codebase-memory-cli/references/commands.md`
- `README.md`

## Verification

- `UV_CACHE_DIR=/tmp/uv-cache uv run --no-project --python 3.13 --with pyyaml python "$HOME/.codex/skills/.system/skill-creator/scripts/quick_validate.py" skills/workflow-repository/using-codebase-memory-cli` — passed
- `prek run -a` — passed
- verified the upstream installer supports `--skip-config`
- exercised the documented CLI-only workflow with `codebase-memory-mcp 0.9.0` against `~/workspace/pi`: project/status discovery, architecture, symbol and semantic search, call/data-flow tracing, snippets, schema/Cypher queries, literal search, and change impact — passed
- no MCP server was started or used
