### PR TITLE
docs(codebase-memory): refine CLI discovery guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Repository path: `skills/workflow-repository/`
 | `resolving-pr-review-comments` | Explicit PR feedback assessment and local fixes, with exact approval for public actions. |
 | `hardening-code-paths` | Confirming and fixing code-path failure modes or verified security findings. |
 | `using-jira-cli` | Read-only Jira inspection and precisely authorized CLI mutations. |
-| `using-codebase-memory-cli` | Proactive CLI-only graph discovery, tracing, architecture, and change-impact analysis. |
+| `using-codebase-memory-cli` | Always-preferred CLI-only graph discovery, tracing, architecture, and change-impact analysis before repository search fallback. |
 | `applying-tdd` | Scoping red-green-refactor with explicit production-path, test-data, and observable-behavior boundaries. |
 | `writing-git-commits` | Drafting, validating, or creating focused Conventional Commits from diffs. |
 | `managing-git-worktrees` | Loss-aware worktree creation, repair, removal, pruning, and branch cleanup. |

--- a/docs/plans/archived/2026-08-06_refine-codebase-memory-cli-skill-plan.md
+++ b/docs/plans/archived/2026-08-06_refine-codebase-memory-cli-skill-plan.md
@@ -1,0 +1,25 @@
+## Goal
+
+Refine `using-codebase-memory-cli` into a lean, accurate, and operationally safe skill whose trigger, workflow, command reference, catalog entry, and validation evidence agree with the installed CLI and current repository guidance.
+
+## Plan
+
+- [x] Audit the current skill, command reference, catalog, repository conventions, GPT-5.6 prompt guidance, installed `codebase-memory-mcp` help, and upstream documentation; verified against v0.9.0 help/release docs and live `skills`/`pi` output, exposing cache-vs-artifact ambiguity, contradictory temporary-index cleanup, unreported mode/freshness limits, broad semantic-result behavior, and an over-eager installer path.
+- [x] Revise `SKILL.md` so graph-first routing, index freshness, evidence escalation, fallbacks, mutation boundaries, and completion reporting are discriminating and non-duplicative; verified by direct diff audit against the trigger, safety, and completion criteria.
+- [x] Revise `references/commands.md` with version-qualified, help-verified command shapes and only the operational details worth loading on demand; verified every documented flag against v0.9.0 help or live output, while the existing README catalog remains accurately aligned without an edit.
+- [x] Forward-test representative index, search, trace/snippet, literal-search, architecture/schema, and change-impact paths without starting an MCP server; verified on `~/workspace/pi` and a task-scoped fast index of this repository, then deleted `skills-refine-cbm-cli-20260806` and confirmed it was absent from `list_projects`.
+- [x] Validate frontmatter, links, formatting, repository gates, diff scope, and instruction consistency; verified the target with `quick_validate.py`, `just`, relative-link validation, `prek run -a`, `git diff --check`, final file/diff audit, catalog comparison, and temporary-index absence.
+
+## Risks
+
+- Version-sensitive flags or schemas may drift; mitigate by distinguishing installed-help evidence from upstream guidance and requiring runtime help checks.
+- Aggressive shortening may remove a safety or evidence invariant; mitigate with a requirement-by-requirement final audit and representative CLI execution.
+- Indexing creates local tool state; use a clearly task-scoped project identity and delete it after validation.
+
+## Completion Checklist
+
+- [x] Trigger metadata clearly distinguishes graph discovery from literal/configuration search and from unavailable-CLI fallback.
+- [x] Every command and behavioral claim is supported by installed help, representative output, or explicitly qualified upstream evidence.
+- [x] Local indexing and external/destructive/persistent operations have precise autonomy and approval boundaries.
+- [x] `SKILL.md`, its reference, and README catalog are aligned, lean, and free of stale or duplicate guidance.
+- [x] `prek run -a`, `git diff --check`, relative-link validation, and representative CLI checks pass with no task-only index left behind.

--- a/skills/workflow-repository/using-codebase-memory-cli/SKILL.md
+++ b/skills/workflow-repository/using-codebase-memory-cli/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: using-codebase-memory-cli
-description: Use `codebase-memory-mcp` in CLI-only mode for graph-first codebase indexing, symbol search, call and data-flow tracing, source snippets, architecture, Cypher, and change impact. Use proactively for unfamiliar or non-trivial code discovery, relationship tracing, architecture analysis, or impact work when the CLI is installed, and whenever the user or repository requests codebase-memory; use ordinary repository tools for known-file, literal/config-only, or unsupported-path searches. Never start or configure the MCP server.
+description: Use `codebase-memory-mcp` in CLI-only mode for graph-first codebase indexing, symbol search, call and data-flow tracing, source snippets, architecture, Cypher, and change impact. Always prefer it over grep, glob, or file search for code discovery whenever the CLI is installed, even when the user does not name it, and use it whenever the user or repository requests codebase-memory. Fall back only for literal/config searches, non-code or unsupported paths, or insufficient graph results; never start or configure the MCP server.
 ---
 
 # Using Codebase Memory CLI
 
-Use the graph to locate structure and relationships before broad file search or reading. It is discovery evidence, not a replacement for source, tests, history, or runtime evidence.
+Always prefer codebase-memory CLI graph tools over grep, glob, or file search for code discovery when the CLI is installed, even if the user does not name the tool. Use the graph to locate structure and relationships before broad repository search. It is discovery evidence, not a replacement for source, tests, history, or runtime evidence.
 
 Run graph tools only as `codebase-memory-mcp cli <tool> ...`. `codebase-memory-mcp` with no arguments starts the stdio server; never run it. Do not call MCP graph tools or configure an agent to use them.
 
@@ -19,23 +19,31 @@ Read [the command reference](references/commands.md) only when selecting index m
 4. For a new or stale project, run `index_repository` with an absolute path and an unambiguous name. Default to `fast`; use `moderate` only for semantic/similarity search, `full` only when relevant files filtered by ordinary modes must be included, and `cross-repo-intelligence` only for repositories within the requested scope.
 5. Inspect the indexing result. Treat `degraded`, skipped files, exclusions, a mismatched root, or an unexpected node count as coverage limits, not a successful complete index. Omit `--persistence` unless a repository artifact was explicitly requested.
 
-## Query from Narrow to Broad
+## Discovery Priority
 
-Stop when evidence is sufficient:
+Use this order and stop when evidence is sufficient:
 
-- For a diff or Git range, use `detect_changes` to identify changed files and candidate impacted symbols, then inspect the important paths.
-- Use `search_graph --query` for BM25 keyword discovery. Use `--name-pattern` or `--qn-pattern` for identifier matching, with label and file filters where useful; do not combine `--query` with `--name-pattern`, because the query wins. Paginate until `has_more` is false when completeness matters.
-- Use semantic search only on a known `moderate` or `full` index. Pass `semantic_query` as an array and evaluate `semantic_results`; ordinary `results` and `total` are separate and can be broad when no structural filter was supplied.
-- Use `trace_path` for inbound callers, outbound callees, parameter data flow, or cross-service traversal. Resolve a short or duplicated name through `search_graph`, then pass the returned `qualified_name`; include tests explicitly when they matter.
-- Use `get_code_snippet` with that qualified name to inspect the symbol's source and optional neighbors.
-- Use `query_graph` only when focused tools cannot express the relationship or aggregation. Run `get_graph_schema` first and constrain the read-only Cypher result.
-- Use path-scoped `get_architecture` for a compact overview after focused evidence, not instead of it.
+1. `search_graph` — find functions, methods, classes, interfaces, routes, variables, or other symbols. Start with `--query` for BM25 keywords or `--name-pattern`/`--qn-pattern` for identifiers; add label and file filters where useful. Do not combine `--query` with `--name-pattern`, because the query wins. Paginate until `has_more` is false when completeness matters.
+2. `trace_path` — find inbound callers, outbound callees, parameter data flow, or cross-service traversal. Resolve a short or duplicated name through `search_graph`, then pass the returned `qualified_name`; include tests explicitly when they matter.
+3. `get_code_snippet` — inspect the selected symbol's source and optional neighbors by qualified name.
+4. `query_graph` — express a relationship or aggregation the focused tools cannot. Run `get_graph_schema` first and constrain the read-only Cypher result.
+5. `get_architecture` — obtain a compact, preferably path-scoped project summary after focused evidence, not instead of it.
+
+For semantic discovery, use `search_graph` only on a known `moderate` or `full` index. Pass `semantic_query` as an array and evaluate `semantic_results`; ordinary `results` and `total` are separate and can be broad without a structural filter. For a diff or Git range, use `detect_changes` to identify changed files and candidate impacted symbols before following the priority order on important paths.
+
+Example chain:
+
+```sh
+codebase-memory-mcp cli search_graph --project my-project --name-pattern '.*OrderHandler.*'
+codebase-memory-mcp cli trace_path --project my-project --function-name OrderHandler --direction inbound
+codebase-memory-mcp cli get_code_snippet --project my-project --qualified-name my-project.pkg.orders.OrderHandler
+```
 
 Verify critical claims in the reported source lines and relevant tests or runtime behavior. Missing edges do not prove that no relationship exists. Re-index when later traversal must reflect source changes, and report stale index state, ambiguity, exclusions, skipped files, or unresolved edges instead of inferring through them.
 
 ## Fallback and Boundaries
 
-Use CLI `search_code` for exact text or regex within indexed files. Use `rg`, `find`, and targeted reads for non-code, generated, ignored, excluded, changed-but-unindexed, or unsupported files, or when graph results are insufficient. State the material fallback and why it was needed.
+Leave the graph-tool priority only when searching string literals, error messages, or configuration values; searching non-code files such as Dockerfiles, shell scripts, or configs; or when graph tools return insufficient results. Prefer CLI `search_code` for exact text or regex in indexed files before repository search. Use `rg`, `find`, globbing, or targeted reads only for non-code, generated, ignored, excluded, changed-but-unindexed, unsupported, or still-unresolved paths. State the material fallback and why it was needed.
 
 Ordinary discovery authorizes an index in the tool's local cache without `--persistence`; it does not authorize repository artifacts or unrelated repositories. `--persistence` additionally writes into the repository. Existing-index deletion, ADR mutation, trace ingestion, cross-repository expansion, native `install`/`update`/`config`, agent integration, and server/UI setup require explicit scope or authorization. A uniquely named temporary index created during the current task may be deleted during cleanup; never delete a pre-existing or reused index without exact approval.
 

--- a/skills/workflow-repository/using-codebase-memory-cli/SKILL.md
+++ b/skills/workflow-repository/using-codebase-memory-cli/SKILL.md
@@ -1,63 +1,52 @@
 ---
 name: using-codebase-memory-cli
-description: Index and explore codebases with the `codebase-memory-mcp` command-line interface for graph-first symbol search, call and data-flow tracing, source snippets, architecture, Cypher queries, and change impact. Use proactively for non-trivial code discovery, architecture exploration, relationship tracing, or change-impact analysis whenever the CLI is installed, and whenever the user or repository requests codebase-memory; never start or use an MCP server.
+description: Use `codebase-memory-mcp` in CLI-only mode for graph-first codebase indexing, symbol search, call and data-flow tracing, source snippets, architecture, Cypher, and change impact. Use proactively for unfamiliar or non-trivial code discovery, relationship tracing, architecture analysis, or impact work when the CLI is installed, and whenever the user or repository requests codebase-memory; use ordinary repository tools for known-file, literal/config-only, or unsupported-path searches. Never start or configure the MCP server.
 ---
 
 # Using Codebase Memory CLI
 
-Use codebase-memory proactively as the default discovery path for unfamiliar or non-trivial code. Prefer its graph over grep, globbing, or broad file reads for symbols, relationships, architecture, and impact analysis, even when the user does not name the tool. Skip it for a known small file, a literal or configuration search, or when the CLI is unavailable and installation has not been authorized.
+Use the graph to locate structure and relationships before broad file search or reading. It is discovery evidence, not a replacement for source, tests, history, or runtime evidence.
 
-Do not start the MCP server, call MCP graph tools, or configure an agent to use them. Every graph operation must have the form `codebase-memory-mcp cli <tool> ...`; never run bare `codebase-memory-mcp`, because that starts the stdio server.
+Run graph tools only as `codebase-memory-mcp cli <tool> ...`. `codebase-memory-mcp` with no arguments starts the stdio server; never run it. Do not call MCP graph tools or configure an agent to use them.
 
-## Install When Missing
+Read [the command reference](references/commands.md) only when selecting index modes, constructing structured input, or using a less common tool.
 
-When `command -v codebase-memory-mcp` fails, offer the upstream installer instead of silently abandoning graph discovery:
+## Establish a Trustworthy Index
 
-```sh
-curl -fsSL https://raw.githubusercontent.com/DeusData/codebase-memory-mcp/main/install.sh | bash
-```
+1. Check `command -v codebase-memory-mcp`, `codebase-memory-mcp --version`, and `codebase-memory-mcp cli <tool> --help`. If the binary is missing, continue with repository tools and report the lost graph coverage; do not block ordinary discovery on installation.
+2. Run `list_projects`. Select a project by its exact `root_path`; for worktrees also verify the reported canonical root, worktree root, branch, and HEAD rather than trusting the derived name.
+3. For a match, run `index_status` and compare its root and indexed HEAD with the target repository. Re-index before relying on graph evidence when the root or HEAD differs, when uncommitted source being explored is newer than the index, or when the required index mode cannot be established. In v0.9.0, status does not report the mode or prove working-tree freshness.
+4. For a new or stale project, run `index_repository` with an absolute path and an unambiguous name. Default to `fast`; use `moderate` only for semantic/similarity search, `full` only when relevant files filtered by ordinary modes must be included, and `cross-repo-intelligence` only for repositories within the requested scope.
+5. Inspect the indexing result. Treat `degraded`, skipped files, exclusions, a mismatched root, or an unexpected node count as coverage limits, not a successful complete index. Omit `--persistence` unless a repository artifact was explicitly requested.
 
-Downloading and executing a remote script requires explicit user approval. The upstream command defaults to automatic agent configuration, which conflicts with this CLI-only workflow; for an approved installation, preserve the installer but disable that configuration:
+## Query from Narrow to Broad
+
+Stop when evidence is sufficient:
+
+- For a diff or Git range, use `detect_changes` to identify changed files and candidate impacted symbols, then inspect the important paths.
+- Use `search_graph --query` for BM25 keyword discovery. Use `--name-pattern` or `--qn-pattern` for identifier matching, with label and file filters where useful; do not combine `--query` with `--name-pattern`, because the query wins. Paginate until `has_more` is false when completeness matters.
+- Use semantic search only on a known `moderate` or `full` index. Pass `semantic_query` as an array and evaluate `semantic_results`; ordinary `results` and `total` are separate and can be broad when no structural filter was supplied.
+- Use `trace_path` for inbound callers, outbound callees, parameter data flow, or cross-service traversal. Resolve a short or duplicated name through `search_graph`, then pass the returned `qualified_name`; include tests explicitly when they matter.
+- Use `get_code_snippet` with that qualified name to inspect the symbol's source and optional neighbors.
+- Use `query_graph` only when focused tools cannot express the relationship or aggregation. Run `get_graph_schema` first and constrain the read-only Cypher result.
+- Use path-scoped `get_architecture` for a compact overview after focused evidence, not instead of it.
+
+Verify critical claims in the reported source lines and relevant tests or runtime behavior. Missing edges do not prove that no relationship exists. Re-index when later traversal must reflect source changes, and report stale index state, ambiguity, exclusions, skipped files, or unresolved edges instead of inferring through them.
+
+## Fallback and Boundaries
+
+Use CLI `search_code` for exact text or regex within indexed files. Use `rg`, `find`, and targeted reads for non-code, generated, ignored, excluded, changed-but-unindexed, or unsupported files, or when graph results are insufficient. State the material fallback and why it was needed.
+
+Ordinary discovery authorizes an index in the tool's local cache without `--persistence`; it does not authorize repository artifacts or unrelated repositories. `--persistence` additionally writes into the repository. Existing-index deletion, ADR mutation, trace ingestion, cross-repository expansion, native `install`/`update`/`config`, agent integration, and server/UI setup require explicit scope or authorization. A uniquely named temporary index created during the current task may be deleted during cleanup; never delete a pre-existing or reused index without exact approval.
+
+Installation expands scope. Only with explicit approval to download and execute the upstream script, use its binary-only mode because the default configures detected agents:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/DeusData/codebase-memory-mcp/main/install.sh | bash -s -- --skip-config
 ```
 
-After installation, verify `command -v codebase-memory-mcp` and `codebase-memory-mcp --version`, then continue without starting the server.
+Verify the installed path and version afterward; do not start the server.
 
-## Establish the Index
+Prefer flags for scalar values and stdin JSON or `--args-file` for arrays and complex input. Positional raw JSON is deprecated. Parse stdout as JSON; initialization and progress logs can appear on stderr. Trust installed help over remembered flags or this version-qualified reference.
 
-1. Run `command -v codebase-memory-mcp`, `codebase-memory-mcp --version`, and the narrowest relevant help: `codebase-memory-mcp cli <tool> --help`.
-2. Run `codebase-memory-mcp cli list_projects` and match the target by `root_path`, not only by project name.
-3. Run `index_status` for an existing project. Compare its root and Git HEAD with the target repository; re-index when it is absent or stale. If semantic search is required and the existing index mode is unknown, re-index with an explicit semantic-capable mode.
-4. Use `index_repository` with an explicit repository path. Prefer `fast` for ordinary structural discovery, `moderate` when semantic search is needed with filtered files, and `full` only when excluded files or complete semantic coverage justify the extra work. Do not enable persistence unless a repository artifact was requested.
-
-Read [references/commands.md](references/commands.md) when choosing flags, structured input, index modes, or a less common tool.
-
-## Discover Graph-First
-
-Use this order, stopping when the required evidence is sufficient:
-
-1. `search_graph` to locate functions, methods, classes, interfaces, routes, channels, or other symbols. Start with `--query`; use `--name-pattern` or `--qn-pattern` for regex-like identifier matching. Do not combine `--query` with `--name-pattern`, because the query takes precedence.
-2. `trace_path` to find inbound callers, outbound callees, parameter data flow, or cross-service paths. Resolve ambiguous short names with search results before trusting a trace.
-3. `get_code_snippet` with the returned `qualified_name` to inspect exact source and optional immediate neighbors.
-4. `query_graph` only for relationships or aggregations the focused tools cannot express. Run `get_graph_schema` first and build Cypher from the reported labels, properties, and edge types.
-5. `get_architecture` for a high-level or path-scoped view, not as a substitute for focused symbol evidence.
-
-Use `search_graph` pagination while `has_more` is true when completeness matters. Semantic queries require a `moderate` or `full` index and an array of keywords.
-
-Treat graph results as discovery evidence rather than infallible source truth. For critical behavior, verify the reported file, lines, snippet, and relevant tests or runtime evidence. Report unresolved ambiguity, filtered paths, stale index state, or missing edges instead of filling gaps by inference.
-
-## Fallback and Change Impact
-
-- Use CLI `search_code` for literals, error text, regexes, and exact source patterns that are a poor fit for symbol search.
-- Fall back to repository `rg`, `find`, or file reads for non-code files, generated or excluded paths, or when graph results remain insufficient. State why the fallback was needed.
-- Use `detect_changes` to identify symbols affected by the working tree or a requested Git range. Re-index before relying on subsequent graph exploration if source has changed since the index was built.
-
-## CLI and Safety Boundaries
-
-Prefer flags for simple values and piped JSON or `--args-file` for arrays and complex values. Positional raw JSON is deprecated. Parse stdout as JSON; initialization logs may appear on stderr. Inspect installed help rather than assuming remembered flags or schemas.
-
-Indexing without persistence is an expected local operation for an authorized discovery task. `delete_project`, persisted indexing, ADR updates, and trace ingestion are state-changing or potentially sensitive operations: perform them only when explicitly requested, after checking their installed help and exact target. Do not run `install`, agent integration setup, or server configuration as part of this workflow.
-
-Conclude with the project and index mode used, the relevant symbols and file/line evidence, any fallback performed, and material coverage limits. Do not leave a temporary test index behind unless the user wants to reuse it.
+Conclude with the matched root/project, known index mode and freshness, decisive symbols and file/line evidence, relevant impact paths, material fallbacks, and coverage limits. Do not claim an unknown reused-index mode or complete coverage.

--- a/skills/workflow-repository/using-codebase-memory-cli/references/commands.md
+++ b/skills/workflow-repository/using-codebase-memory-cli/references/commands.md
@@ -1,21 +1,21 @@
-# Codebase Memory CLI Command Shapes
+# Codebase Memory CLI Command Reference
 
-These shapes were verified with `codebase-memory-mcp 0.9.0`. Check `codebase-memory-mcp cli <tool> --help` because flags and output schemas may change.
+Verified with `codebase-memory-mcp 0.9.0` and its release documentation. Run `codebase-memory-mcp --version` and `codebase-memory-mcp cli <tool> --help`; installed schemas override this reference.
 
-## Invocation and Input
+## Invocation Contract
 
 ```sh
-codebase-memory-mcp --version
 codebase-memory-mcp --help
+codebase-memory-mcp --version
 codebase-memory-mcp cli <tool> --help
 codebase-memory-mcp cli <tool> --flag value
 codebase-memory-mcp cli <tool> --args-file /tmp/codebase-memory-args.json
 printf '%s\n' '{"project":"my-project"}' | codebase-memory-mcp cli index_status
 ```
 
-Do not use the deprecated positional raw-JSON form. Normal tool output is JSON on stdout; informational initialization logs are written to stderr. Bare `codebase-memory-mcp` starts the MCP stdio server and is forbidden by this skill.
+Use flags for scalar values and stdin or `--args-file` JSON for arrays. Positional raw JSON still works in v0.9.0 but emits a deprecation warning. Tool results are JSON on stdout; initialization logs are written to stderr. Bare `codebase-memory-mcp` starts the MCP stdio server.
 
-## Projects and Indexing
+## Project Identity and Indexing
 
 ```sh
 codebase-memory-mcp cli list_projects
@@ -26,30 +26,41 @@ codebase-memory-mcp cli index_repository \
   --name my-project
 ```
 
-`--name` is optional; use it to avoid collisions or make worktree identity explicit.
+Match `list_projects` output against `root_path` and, for Git worktrees, its `git.canonical_root`, `git.worktree_root`, branch, and `head_sha`. `index_status` in v0.9.0 reports identity and indexed Git state but not index mode or working-tree freshness. `--name` is optional; use an unambiguous value to avoid path- or worktree-derived collisions.
 
 Index modes from installed help:
 
-- `fast`: filtered files, type-aware LSP call/usage resolution, no similarity or semantic edges.
+- `fast`: filtered files and type-aware per-file/cross-file call and usage resolution; no similarity or semantic edges.
 - `moderate`: filtered files plus similarity and semantic edges.
-- `full`: all files plus similarity and semantic edges.
-- `cross-repo-intelligence`: match routes and channels across projects; pass `--target-projects` as an array.
+- `full`: all normally indexable files plus similarity and semantic edges; safety exclusions and unsupported paths can still limit coverage.
+- `cross-repo-intelligence`: route/channel matching across specified projects; pass `target_projects` as an array.
 
-All modes perform per-file and cross-file type-aware LSP resolution. `--persistence true` writes `.codebase-memory/graph.db.zst` into the target repository; omit it unless that artifact is explicitly wanted.
+```sh
+printf '%s\n' '{
+  "repo_path": "/absolute/path/to/repository",
+  "mode": "cross-repo-intelligence",
+  "name": "orders-service",
+  "target_projects": ["billing-service", "notifications-service"]
+}' | codebase-memory-mcp cli index_repository
+```
 
-## Focused Discovery
+Every index is stored in the local codebase-memory cache. `--persistence true` additionally writes `.codebase-memory/graph.db.zst` in the repository for sharing; omit it during ordinary discovery. Inspect `status`, `excluded`, `skipped_count` or `skipped`, node/edge counts, and any degraded result before trusting coverage.
 
-Keyword or natural-language BM25 search:
+## Symbol Search
+
+BM25 keyword search:
 
 ```sh
 codebase-memory-mcp cli search_graph \
   --project my-project \
   --query 'extension loader' \
+  --label Function \
+  --file-pattern 'src/*' \
   --limit 20 \
   --offset 0
 ```
 
-Identifier or structural search:
+Identifier search:
 
 ```sh
 codebase-memory-mcp cli search_graph \
@@ -60,9 +71,9 @@ codebase-memory-mcp cli search_graph \
   --limit 20
 ```
 
-A supplied `--query` ignores `--name-pattern`. Responses include `total` and `has_more`; increase `offset` by `limit` until complete when exhaustive coverage is required.
+`--query` is whitespace-tokenized BM25 search and can be broad; it ignores `--name-pattern` when both are supplied. Use `--qn-pattern` for qualified-name matching. Responses expose `total` and `has_more`; increase `offset` by `limit` until complete when exhaustive coverage is required.
 
-Semantic search needs a `moderate` or `full` index. Use structured input so `semantic_query` remains an array:
+Semantic search requires `moderate` or `full` and an array:
 
 ```sh
 printf '%s\n' '{
@@ -72,23 +83,23 @@ printf '%s\n' '{
 }' | codebase-memory-mcp cli search_graph
 ```
 
-Each semantic keyword is scored independently, and semantic matches appear separately under `semantic_results`.
+The keywords are combined as an all-keyword semantic match. Read `semantic_results` and its scores separately. With no structural query or filters, ordinary `results`/`total` can describe a broad graph listing rather than semantic matches.
 
-## Tracing and Source
+## Trace and Source
 
 ```sh
 codebase-memory-mcp cli trace_path \
   --project my-project \
-  --function-name OrderHandler \
+  --function-name my-project.pkg.orders.OrderHandler \
   --direction inbound \
   --depth 3 \
   --mode calls \
   --risk-labels true \
-  --include-tests false
+  --include-tests true
 
 codebase-memory-mcp cli trace_path \
   --project my-project \
-  --function-name OrderHandler \
+  --function-name my-project.pkg.orders.OrderHandler \
   --direction outbound \
   --depth 3 \
   --mode data_flow \
@@ -100,11 +111,9 @@ codebase-memory-mcp cli get_code_snippet \
   --include-neighbors true
 ```
 
-Trace modes are `calls`, `data_flow`, and `cross_service`. Cross-service mode follows HTTP, async, data-flow, and available cross-repository edges. When test callers matter, set `--include-tests true` explicitly.
+Trace modes are `calls`, `data_flow`, and `cross_service`. Cross-service mode follows available HTTP, async, data-flow, and cross-repository edges. Tests are excluded by default. The optional risk labels classify proximity by hop distance; they are not a domain-specific risk assessment.
 
 ## Schema, Cypher, and Architecture
-
-Inspect the actual graph before writing Cypher:
 
 ```sh
 codebase-memory-mcp cli get_graph_schema --project my-project
@@ -114,17 +123,14 @@ codebase-memory-mcp cli query_graph \
   --query "MATCH (n:Function) WHERE n.name = 'OrderHandler' RETURN n.name, n.qualified_name, n.file_path LIMIT 20" \
   --max-rows 20
 
-codebase-memory-mcp cli get_architecture \
-  --project my-project \
-  --aspects overview
-
-codebase-memory-mcp cli get_architecture \
-  --project my-project \
-  --path packages/orders \
-  --aspects all
+printf '%s\n' '{
+  "project": "my-project",
+  "path": "packages/orders",
+  "aspects": ["overview"]
+}' | codebase-memory-mcp cli get_architecture
 ```
 
-`query_graph` has no offset pagination; constrain Cypher and `--max-rows`. `search_graph` is the better choice for paginated browsing.
+Build Cypher only from labels, properties, and edge types returned by `get_graph_schema`. `query_graph` supports a read-only openCypher subset, has no CLI offset, and defaults up to a 100,000-row ceiling; include Cypher `LIMIT` and `--max-rows`. Prefer `search_graph` for paginated browsing. Scope architecture by path and request only needed aspects to control output size.
 
 ## Literal Search and Change Impact
 
@@ -133,6 +139,7 @@ codebase-memory-mcp cli search_code \
   --project my-project \
   --pattern 'ORDER_NOT_FOUND' \
   --file-pattern '*.ts' \
+  --path-filter '^src/' \
   --mode compact \
   --context 2 \
   --limit 20
@@ -148,8 +155,8 @@ codebase-memory-mcp cli detect_changes \
   --depth 2
 ```
 
-`search_code` modes are `compact`, `full`, and `files`. It reports grep and enriched-result totals but has no offset; narrow the path or file pattern, or raise the limit.
+`search_code` searches indexed files only. Modes are `compact`, `full`, and `files`; results report grep and enriched totals but provide no offset, so narrow `file_pattern`/`path_filter` or raise the limit. In v0.9.0, `detect_changes --scope all` maps current changes, while `--since <ref>` compares `<ref>...HEAD`. Deduplicate repeated `changed_files`, and verify the paths directly before treating `changed_count` or impacted symbols as complete.
 
-## Non-Discovery Tools
+## Stateful or Sensitive Tools
 
-The CLI also exposes `delete_project`, `manage_adr`, and `ingest_traces`. These mutate stored state or may ingest sensitive runtime data. Do not use them during ordinary discovery. If explicitly requested, inspect the installed tool help, confirm the exact project and payload, execute only the approved operation, and verify the resulting state.
+`delete_project` removes cached graph data. `manage_adr` mutates stored architectural decisions. `ingest_traces` mutates graph state and can expose sensitive runtime metadata. Inspect installed help and verify the exact project and payload before an explicitly scoped use. During ordinary discovery, use none of them except `delete_project` to remove a uniquely named index created in the same task.


### PR DESCRIPTION
## Summary

- make `codebase-memory-mcp cli <tool>` the always-preferred path over grep, glob, or file search for code discovery
- define the `search_graph` → `trace_path` → `get_code_snippet` → `query_graph` → `get_architecture` priority and narrow fallback conditions
- sharpen index identity, freshness, coverage, persistence, installation, mutation, cross-repository, and cleanup boundaries
- update the v0.9.0 command reference with help-verified input shapes and behavior observed against a real TypeScript codebase

## Affected paths

- `README.md`
- `skills/workflow-repository/using-codebase-memory-cli/SKILL.md`
- `skills/workflow-repository/using-codebase-memory-cli/references/commands.md`
- `docs/plans/archived/2026-08-06_refine-codebase-memory-cli-skill-plan.md`

## Verification

- `quick_validate.py skills/workflow-repository/using-codebase-memory-cli` — passed
- representative `codebase-memory-mcp 0.9.0` index/search/trace/snippet/Cypher/architecture/change-impact checks against `~/workspace/pi` — passed
- task-scoped repository index cleanup and `list_projects` absence check — passed
- relative Markdown link validation — passed
- `prek run -a` — passed
- `git diff --check` — passed

No automated repository tests were added or run; this repository documents that it has no automated test suite.
