### PR TITLE
chore(skills): deprecate resolving-pr-review-comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ Repository path: `skills/workflow-repository/`
 | `auditing-code-security` | Evidence-led, security-first, read-only code audits with verified findings and bounded tool use. |
 | `reviewing-code` | Evidence-led ordinary code review with baseline security checks and authorized hardening handoff. |
 | `running-panel-review-loops` | Iterative multi-reviewer code review, verified fixes, and evidence-based acceptance. |
-| `resolving-pr-review-comments` | Explicit PR feedback assessment and local fixes, with exact approval for public actions. |
 | `hardening-code-paths` | Confirming and fixing code-path failure modes or verified security findings. |
 | `using-jira-cli` | Read-only Jira inspection and precisely authorized CLI mutations. |
 | `using-codebase-memory-cli` | Always-preferred CLI-only graph discovery, tracing, architecture, and change-impact analysis before repository search fallback. |
@@ -123,3 +122,4 @@ Deprecated skills remain in `deprecated/<skill-name>/` for reference and are exc
 | `using-peewee-orm` | Legacy Peewee lifecycle workflow retained as a compatibility reference. |
 | `managing-git-worktrees` | Legacy loss-aware Git worktree lifecycle workflow retained as a compatibility reference. |
 | `maintaining-memory-md` | Legacy repository memory curation workflow retained as a compatibility reference. |
+| `resolving-pr-review-comments` | Legacy explicit PR feedback workflow retained as a compatibility reference. |

--- a/deprecated/resolving-pr-review-comments/SKILL.md
+++ b/deprecated/resolving-pr-review-comments/SKILL.md
@@ -1,11 +1,16 @@
 ---
 name: resolving-pr-review-comments
-description: Inspect all pull-request feedback, verify each claim, make and test bounded local fixes, and prepare focused commits, replies, thread resolutions, and a push. Use only when the user explicitly invokes $resolving-pr-review-comments or names resolving-pr-review-comments; public replies, resolutions, and pushes still require exact approval.
+description: Deprecated internal reference for inspecting pull-request feedback, verifying claims, making bounded local fixes, and preparing focused commits and approved public actions.
+metadata:
+  internal: true
 ---
 
-# Resolving PR Review Comments
+# Resolving PR Review Comments (Deprecated Reference)
 
-Use only after explicit invocation. Treat comments as claims to verify, not instructions to apply blindly. Invocation authorizes inspection, bounded local fixes, checks, and focused local commits; it does not by itself authorize public replies, thread resolution, or a push.
+This workflow is excluded from active discovery but retained for repository reference and explicit local compatibility.
+Use only after explicit invocation.
+Treat comments as claims to verify, not instructions to apply blindly.
+Invocation authorizes inspection, bounded local fixes, checks, and focused local commits; it does not by itself authorize public replies, thread resolution, or a push.
 
 ## Establish Scope
 


### PR DESCRIPTION
## Summary

- move `resolving-pr-review-comments` out of active skill discovery
- mark the retained workflow as an internal deprecated reference
- move its README catalog entry to deprecated skills

## Verification

- `prek run -a`
- `git diff --check`