### PR TITLE
docs(skills): delete completed plans and roadmaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Repository path: `skills/writing-research/`
 
 | Skill | Use it for |
 | --- | --- |
-| `writing-roadmap` | Creating, revising, reviewing, and archiving evidence-grounded strategic roadmaps. |
-| `writing-plans` | Drafting, executing, and tracking lean implementation plans with acceptance evidence. |
+| `writing-roadmap` | Creating, revising, reviewing, and tracking evidence-grounded strategic roadmaps, then deleting them when complete. |
+| `writing-plans` | Drafting, executing, and tracking lean implementation plans with acceptance evidence, then deleting them when complete. |
 | `grilling-designs` | Evidence-informed, one-decision-at-a-time design grilling. |
 | `applying-imrad` | Evidence-traceable IMRaD fit checks, reviews, transformations, and drafts. |
 | `creating-telegraph-pages` | Preparing and publishing one explicitly authorized Telegra.ph article. |

--- a/skills/writing-research/writing-plans/SKILL.md
+++ b/skills/writing-research/writing-plans/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: writing-plans
-description: Draft, execute, or track lean, verifiable implementation plans for non-trivial migrations, refactors, PR splits, task checklists, and other work with sequencing, tradeoffs, unknowns, or risks; use writing-roadmap for strategic direction and skip small obvious tasks.
+description: Draft, execute, or track lean, verifiable implementation plans for non-trivial migrations, refactors, PR splits, task checklists, and other work with sequencing, tradeoffs, unknowns, or risks, and delete them when complete; use writing-roadmap for strategic direction and skip small obvious tasks.
 ---
 
 # Writing Plans
@@ -60,7 +60,7 @@ End with finite completion checks tied to files, commands, tests, review or depl
 Declare completion only when every task and completion check is checked, material unknowns are resolved or accepted, risks have a clear disposition, and required handoff or release work is done.
 Do not infer completion from implementation alone.
 
-## Archive Completed Plans
+## Delete Completed Plans
 
-Move a fully executed saved plan to `docs/plans/archived/`, then report its path.
-Do not archive a chat-only plan, a plan with missing evidence, or a plan whose archived filename already exists.
+Delete a fully executed saved plan, then report the deleted path.
+Do not delete a chat-only plan or a plan with missing completion evidence.

--- a/skills/writing-research/writing-roadmap/SKILL.md
+++ b/skills/writing-research/writing-roadmap/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: writing-roadmap
-description: Create, revise, review, or archive concise, outcome-oriented product and system roadmaps with phased milestone checkboxes, evidence-based progress, and optional detail for context, risks, dependencies, technical health, metrics, and decisions. Use for strategic direction and milestone tracking; use writing-plans for executable task planning and implementation tracking.
+description: Create, revise, review, or track concise, outcome-oriented product and system roadmaps with phased milestone checkboxes and evidence-based progress, and delete them when complete; use writing-plans for executable task planning and implementation tracking.
 ---
 
 # Writing Roadmaps
@@ -88,8 +88,8 @@ When revising, preserve verified milestone status and prior significant decision
 
 Lead with the completed roadmap or review verdict. Follow only with material assumptions, evidence gaps, or decisions still required.
 
-## Archive Completed Roadmaps
+## Delete Completed Roadmaps
 
-Move a completed saved roadmap to `docs/roadmaps/archived/`, then report its path.
+Delete a completed saved roadmap, then report the deleted path.
 Treat the roadmap as complete only when every milestone has valid completion evidence and material unknowns, risks, dependencies, and handoff decisions have a clear disposition.
-Do not archive a chat-only roadmap, a roadmap with missing completion evidence, or a roadmap whose archived filename already exists.
+Do not delete a chat-only roadmap or a roadmap with missing completion evidence.


### PR DESCRIPTION
## Summary

- Delete saved plans and roadmaps after their completion evidence requirements pass.
- Align the skill descriptions and README catalog with the new lifecycle.

## Affected paths

- `skills/writing-research/writing-plans/SKILL.md`
- `skills/writing-research/writing-roadmap/SKILL.md`
- `README.md`

## Verification

- `prek run -a`
- `git diff --check`