### PR TITLE
docs(creating-agent-skills): define AGENTS section and item structure

### DIFF
--- a/skills/workflow-repository/creating-agent-skills/SKILL.md
+++ b/skills/workflow-repository/creating-agent-skills/SKILL.md
@@ -12,6 +12,7 @@ A review or score request is read-only unless the user also asks for changes.
 
 - Keep documents concise and clear.
 - Put one sentence on each line.
+- When writing an `AGENTS.md` file, keep each list item to exactly one sentence.
 
 ## Choose the Mode
 

--- a/skills/workflow-repository/creating-agent-skills/SKILL.md
+++ b/skills/workflow-repository/creating-agent-skills/SKILL.md
@@ -12,7 +12,7 @@ A review or score request is read-only unless the user also asks for changes.
 
 - Keep documents concise and clear.
 - Put one sentence on each line.
-- When writing an `AGENTS.md` file, keep each list item to exactly one sentence.
+- When writing an `AGENTS.md` file, organize rules under descriptive `##` section headings and write each rule as a one-sentence bullet list item.
 
 ## Choose the Mode
 


### PR DESCRIPTION
## Summary

- Require generated or revised `AGENTS.md` rules to be grouped under descriptive `##` section headings.
- Require every rule to be a one-sentence bullet list item.

## Affected paths

- `skills/workflow-repository/creating-agent-skills/SKILL.md`

## Verification

- `prek run -a`
- `git diff --check`
