### PR TITLE
chore: remove justfile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,16 +26,11 @@ Follow global defaults; this file contains only repository-specific additions an
 - Keep examples repository-relative and executable when practical.
 - For user interfaces, apply Apple-derived design philosophy across platforms while translating platform-specific metrics and controls to target conventions; minimize cognitive load without sacrificing functional completeness, keep critical actions and state visible, and use predictable progressive disclosure for secondary complexity.
 
-## Commands
-
-- Run `just` to list available recipes without mutating repository state.
-
 ## Boundaries
 
 - For answer, explanation, review, diagnosis, or planning requests, inspect the relevant materials and report without making changes.
 - For change, build, or fix requests, make the requested in-scope local changes and run relevant safe checks without asking first.
 - Ask before writing to external systems, taking destructive or costly actions, or materially expanding the scope.
-- Run `just bump-version <major|minor|patch>` only when explicitly requested because it fetches tags and creates a local lightweight tag.
 - Ask before running `scripts/download_human_interface_guidelines.py` because its default mode downloads a large external corpus; when maintaining the archiver, enumerate the DocC navigator and page JSON under `/tutorials/data/` instead of recursively downloading HTML.
 - Treat ignored `build/` content as generated output; do not hand-edit or commit it.
 - Treat `skills/` as the active source of truth; `.agents/skills` is an ignored local discovery symlink, not a second copy to edit.

--- a/examples/slides/assets/skill-lifecycle.svg
+++ b/examples/slides/assets/skill-lifecycle.svg
@@ -34,8 +34,8 @@
       <g>
         <rect x="414" y="144" width="212" height="112" rx="16" fill="#EFF6FF" stroke="#2563EB" stroke-width="3" filter="url(#shadow-sm)"/>
         <text x="520" y="184" text-anchor="middle" font-size="24" font-weight="700">Install</text>
-        <text x="520" y="214" text-anchor="middle" fill="#64748B">just install-all</text>
-        <text x="520" y="239" text-anchor="middle" fill="#64748B">or npx skills add</text>
+        <text x="520" y="214" text-anchor="middle" fill="#64748B">npx skills add</text>
+        <text x="520" y="239" text-anchor="middle" fill="#64748B">narumiruna/skills</text>
       </g>
 
       <g>

--- a/examples/slides/skills-project.md
+++ b/examples/slides/skills-project.md
@@ -158,16 +158,6 @@ Use the hosted collection when you just want the skills:
 npx skills add narumiruna/skills
 ```
 
-Use local copy-based installs while editing this repository:
-
-```shell
-just install-all
-just install managing-python-with-uv
-just clean managing-python-with-uv
-```
-
-`just` by itself is intentionally non-mutating.
-
 ---
 
 <!-- _class: lead -->
@@ -196,10 +186,9 @@ This is especially visible in the slide toolkit: colors, Marp authoring, and SVG
 ## Maintainer loop
 
 1. Author or refine a skill in `skills/<name>/`.
-2. Install locally with `just install <name>` or `just install-all`.
-3. Exercise the behavior through Codex using `/skills` or `$skill-name`.
-4. Validate repository changes with `prek run -a`.
-5. Rebuild slide outputs after changing `examples/slides/`.
+2. Exercise the behavior through Codex using `/skills` or `$skill-name`.
+3. Validate repository changes with `prek run -a`.
+4. Rebuild slide outputs after changing `examples/slides/`.
 
 ---
 
@@ -209,7 +198,6 @@ This is especially visible in the slide toolkit: colors, Marp authoring, and SVG
 |---|---|---|
 | `README.md` | install flows, external positioning, skill discovery | maintainer-only process detail |
 | `AGENTS.md` | contributor workflow and repo editing rules | product messaging |
-| `justfile` | executable install and clean recipes | undocumented side paths |
 | `examples/` | slide decks and visual examples | skill source text |
 
 ---

--- a/justfile
+++ b/justfile
@@ -1,8 +1,0 @@
-# Default behavior: show available recipes instead of mutating state.
-[default]
-list:
-    @just --list
-
-# Create the next semantic version tag from the latest major.minor.patch tag.
-bump-version bump="patch":
-    scripts/bump-version.sh {{ bump }}


### PR DESCRIPTION
## Summary

- remove the root `justfile`
- remove repository guidance and slide content that referenced its recipes
- update the skill lifecycle visual to show the supported `npx skills add narumiruna/skills` flow

## Affected paths

- `justfile`
- `AGENTS.md`
- `examples/slides/skills-project.md`
- `examples/slides/assets/skill-lifecycle.svg`

## Verification

- `prek run -a`
- `git diff --check`
- rendered `examples/slides/skills-project.md` to HTML with `@marp-team/marp-cli`
- validated the SVG with the repository `svglint` hook

## Visual preview

- [Updated skill lifecycle SVG](https://github.com/narumiruna/skills/blob/narumi/chore/remove-justfile/examples/slides/assets/skill-lifecycle.svg)
