### PR TITLE
docs(skills): move AGENTS writing rule

### DIFF
--- a/skills/creating-agent-skills/SKILL.md
+++ b/skills/creating-agent-skills/SKILL.md
@@ -12,7 +12,6 @@ A review or score request is read-only unless the user also asks for changes.
 
 - Keep documents concise and clear.
 - Put one sentence on each line.
-- When writing an `AGENTS.md` file, organize rules under descriptive `##` section headings and write each rule as a one-sentence bullet list item.
 
 ## Choose the Mode
 

--- a/skills/writing-agents-md/SKILL.md
+++ b/skills/writing-agents-md/SKILL.md
@@ -77,7 +77,7 @@ The `[Optional]` marker is a template annotation; remove it from headings includ
 
 ## Writing Rules
 
-- Write `AGENTS.md` in concise plain language, with one enforceable sentence on each line.
+- Organize rules under descriptive `##` section headings and write each rule as a concise, enforceable, one-sentence bullet list item.
 - State the outcome, useful context, hard limits, actions that need approval, and success criteria.
 - Describe a sequence only when its order matters.
 - State each rule once in the smallest scope where it belongs.


### PR DESCRIPTION
## Summary

- remove the misplaced `AGENTS.md` formatting rule from `creating-agent-skills`
- add the rule to `writing-agents-md` while consolidating the existing one-sentence guidance

## Affected paths

- `skills/creating-agent-skills/SKILL.md`
- `skills/writing-agents-md/SKILL.md`

## Verification

- `prek run -a`
- `git diff --check`
