### PR TITLE
fix(skills): tighten action and validation boundaries

### DIFF
--- a/skills/authoring-marp-slides/SKILL.md
+++ b/skills/authoring-marp-slides/SKILL.md
@@ -28,4 +28,4 @@ Load only the authoring detail the deck needs.
 5. Resolve this skill directory and run the limited structural precheck with `bash "$SKILL_DIR/scripts/check_marpit_structure.sh" path/to/deck.md`. It checks delimiters and `marp: true` but does not parse YAML or Marp syntax. Then follow `references/preview-workflow.md` to export with the actual Marp renderer; inspect whether directives took effect, plus the title, densest slide, and every image/SVG slide. Report structural, strict-YAML, renderer, and visual evidence separately; never infer one from another.
 6. Return the deck artifact first, followed by checks performed and any rendering, font, asset, or environment caveat.
 
-Do not claim visual validation from Markdown inspection alone. Do not commit, publish, or convert formats unless requested.
+Do not claim visual validation from Markdown inspection alone. Temporary renders used only for validation are allowed; do not commit, publish, or deliver another format unless requested.

--- a/skills/authoring-marp-slides/references/preview-workflow.md
+++ b/skills/authoring-marp-slides/references/preview-workflow.md
@@ -7,7 +7,10 @@ Use this when visual inspection is required.
 - `marp` CLI is installed.
 - The deck and assets use repository-relative paths.
 
-## Preview
+## Optional Human Preview
+
+The preview server is long-running and requires a browser, so do not use it as an agent validation command.
+A human can start it with:
 
 ```bash
 marp -s examples/slides

--- a/skills/creating-mermaid-diagrams/SKILL.md
+++ b/skills/creating-mermaid-diagrams/SKILL.md
@@ -5,7 +5,7 @@ description: Create, revise, convert, or validate Mermaid diagrams, including fl
 
 # Mermaid Diagrams
 
-Preserve editable Mermaid source. Render a static asset only when the consumer requires one.
+Preserve editable Mermaid source. Temporary renders used only for validation are allowed; preserve or deliver a static asset only when the consumer requires one.
 
 ## Route by Structure
 

--- a/skills/grounding-with-google-genai/SKILL.md
+++ b/skills/grounding-with-google-genai/SKILL.md
@@ -41,7 +41,7 @@ uv run --script "$SKILL_DIR/scripts/google_genai_grounding.py" url \
   --url 'https://example.com/two'
 ```
 
-A request to use this skill authorizes one bounded grounding call. Grounded calls can consume quota or incur charges; retry once only for a clear transient failure or a corrected deterministic input, and do not fan out into extra calls without need.
+An explicit request to use Gemini, Google GenAI, or this skill authorizes one bounded grounding call. If this skill was selected implicitly because web, place, or URL grounding would help, confirm before consuming Google API quota. Retry once only for a clear transient failure or a corrected deterministic input, and do not fan out into extra calls without need.
 
 ## Verify and Answer
 

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -5,7 +5,8 @@ description: Draft, execute, or track lean, verifiable implementation plans for 
 
 # Writing Plans
 
-A plan request authorizes creating or revising the plan artifact, not implementation.
+A planning request is read-only by default and does not authorize repository changes or implementation.
+Create or revise a saved plan only when the user explicitly requests a repository artifact.
 Execute the plan only when the user requests it or an active workflow already authorizes the work.
 
 ## Ground the Plan
@@ -13,8 +14,8 @@ Execute the plan only when the user requests it or an active workflow already au
 Inspect relevant repository evidence before asking questions.
 Ask at most one question when proceeding would require a risky guess; otherwise state only assumptions and unknowns that affect execution or validation.
 
-Save a drafted plan to the repository unless the user requests chat-only output.
-Default to `docs/plans/YYYY-MM-DD_<topic>-plan.md` with a concise lowercase kebab-case topic, and update an existing plan in place during execution.
+Return the plan in chat unless the user explicitly requests a repository artifact.
+For a requested saved plan, default to `docs/plans/YYYY-MM-DD_<topic>-plan.md` with a concise lowercase kebab-case topic, and update that plan in place during authorized execution.
 
 ## Structure the Plan
 

--- a/skills/writing-roadmap/SKILL.md
+++ b/skills/writing-roadmap/SKILL.md
@@ -5,7 +5,10 @@ description: Create, revise, review, or track concise, outcome-oriented product 
 
 # Writing Roadmaps
 
-A roadmap expresses strategic direction and sequencing, not a promise of delivery dates or an implementation checklist. Creating or revising one authorizes changes to the roadmap artifact only, not implementation of its initiatives. For a review-only request, report findings without rewriting unless asked.
+A roadmap expresses strategic direction and sequencing, not a promise of delivery dates or an implementation checklist.
+A roadmap request is read-only by default and does not authorize repository changes or implementation of its initiatives.
+Create or revise a saved roadmap only when the user explicitly requests a repository artifact.
+For a review-only request, report findings without rewriting unless asked.
 
 ## Ground the Roadmap
 
@@ -13,7 +16,8 @@ Inspect provided material and relevant repository evidence before drafting. Esta
 
 Separate verified current state, approved commitments, and proposed direction. Do not invent capabilities, dates, targets, owners, capacity, dependencies, or certainty.
 
-Save a created or revised roadmap to the repository unless the user requests chat-only output. Default to `docs/roadmaps/YYYY-MM-DD_<topic>-roadmap.md`; derive a concise lowercase kebab-case topic, create the directory when needed, and update an existing roadmap in place.
+Return the roadmap in chat unless the user explicitly requests a repository artifact.
+For a requested saved roadmap, default to `docs/roadmaps/YYYY-MM-DD_<topic>-roadmap.md`; derive a concise lowercase kebab-case topic, create the directory when needed, and update that roadmap in place.
 
 ## Start with the Lean Template
 


### PR DESCRIPTION
## Summary

- require explicit repository-artifact requests before saving plans or roadmaps while preserving automatic deletion after verified completion
- require confirmation before implicitly selected Google GenAI grounding consumes API quota
- distinguish temporary validation renders from requested deliverable formats
- mark the long-running Marp preview server as a human-only workflow

## Affected paths

- `skills/authoring-marp-slides/SKILL.md`
- `skills/authoring-marp-slides/references/preview-workflow.md`
- `skills/creating-mermaid-diagrams/SKILL.md`
- `skills/grounding-with-google-genai/SKILL.md`
- `skills/writing-plans/SKILL.md`
- `skills/writing-roadmap/SKILL.md`

## Verification

- `prek run -a`
- `git diff --check`
- validated all active skill frontmatter names, descriptions, and direct resource links
- inspected the final diff for unintended scope and repeated guidance

No bundled scripts changed, so script behavior checks were not required.