### PR TITLE
chore: deprecate running-panel-review-loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ All active skills live directly under `skills/<skill-name>/`.
 | `operating-ghostty` | Inspecting, launching, configuring, validating, and troubleshooting Ghostty. |
 | `prompting-gpt` | Creating, revising, and reviewing prompts using references for the user-specified or detected runtime model, or general principles when unknown or not covered. |
 | `reviewing-code` | Evidence-led ordinary code review with baseline security checks and authorized hardening handoff. |
-| `running-panel-review-loops` | Iterative multi-reviewer code review, verified fixes, and evidence-based acceptance. |
 | `using-jira-cli` | Read-only Jira inspection and precisely authorized CLI mutations. |
 | `writing-agents-md` | Creating, reviewing, and automatically maintaining lean, evidence-backed `AGENTS.md` guidance at the narrowest applicable scope. |
 | `writing-git-commits` | Drafting, validating, or creating focused Conventional Commits from diffs. |
@@ -88,3 +87,4 @@ Deprecated skills remain in `deprecated/<skill-name>/` for reference and are exc
 | `maintaining-memory-md` | Legacy repository memory curation workflow retained as a compatibility reference. |
 | `resolving-pr-review-comments` | Legacy explicit PR feedback workflow retained as a compatibility reference. |
 | `using-codebase-memory-cli` | Legacy CLI-only codebase graph workflow retained as a compatibility reference. |
+| `running-panel-review-loops` | Legacy multi-reviewer code review and authorized fix loop retained as a compatibility reference. |

--- a/deprecated/running-panel-review-loops/SKILL.md
+++ b/deprecated/running-panel-review-loops/SKILL.md
@@ -1,9 +1,14 @@
 ---
 name: running-panel-review-loops
-description: Run iterative multi-reviewer panels over a code diff, verify their findings, apply explicitly authorized fixes, and re-review the updated change until it passes or reaches a stopping condition. Use when the user asks for a panel loop, multi-model code-review consensus, or a review-fix-re-review cycle.
+description: Deprecated internal reference for iterative multi-reviewer code review, verified findings, explicitly authorized fixes, and bounded re-review cycles.
+metadata:
+  internal: true
 ---
 
-# Running Panel Review Loops
+# Running Panel Review Loops (Deprecated Reference)
+
+This workflow is excluded from active discovery but retained for repository reference and explicit local compatibility.
+Use only after explicit invocation.
 
 Treat reviewer output as claims to verify, not votes or instructions to apply blindly. Default to review-only when the user asks only for a panel review or consensus. Apply fixes only when the user explicitly requests implementation, fixes, or a review-fix cycle. Commit or push only when the user requests that action; never treat a requested local commit as push authorization.
 


### PR DESCRIPTION
## Summary
Deprecate `running-panel-review-loops` while retaining its workflow for explicit local use and repository reference.

- Move `skills/running-panel-review-loops/SKILL.md` to `deprecated/running-panel-review-loops/SKILL.md` and mark it as an internal deprecated reference.
- Update `README.md` to list the skill under deprecated skills instead of the active catalog.

## Verification
- `prek run -a` passed; JSON check skipped because no matching files exist.
- `git diff --check` and `git diff --cached --check` passed.
- Confirmed the skill is absent from `skills/` and `.agents/skills/` and present under `deprecated/`.
- Inspected the final diff; no bundled scripts changed.
- Commit created with an SSH signature; local signature verification is unavailable because `gpg.ssh.allowedSignersFile` is not configured.